### PR TITLE
fix: Resolve Windows ESM path issues in MCP server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wonderwhy-er/desktop-commander",
-  "version": "0.1.16",
+  "version": "0.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wonderwhy-er/desktop-commander",
-      "version": "0.1.16",
+      "version": "0.1.19",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.0.1",
@@ -19,7 +19,7 @@
         "setup": "dist/setup-claude-server.js"
       },
       "devDependencies": {
-        "@types/node": "^20.11.0",
+        "@types/node": "^20.17.24",
         "nodemon": "^3.0.2",
         "shx": "^0.3.4",
         "typescript": "^5.3.3"
@@ -64,11 +64,10 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.17.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.10.tgz",
-      "integrity": "sha512-/jrvh5h6NXhEauFFexRin69nA0uHJ5gwk4iDivp/DeoEua3uwCUto6PC86IpRITBOs4+6i2I56K5x5b6WYGXHA==",
+      "version": "20.17.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.24.tgz",
+      "integrity": "sha512-d7fGCyB96w9BnWQrOsJtpyiSaBcAYYr75bnK6ZRjDbql2cGLj/3GsL5OYmLPNq76l7Gf2q4Rv9J2o6h5CrD9sA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
       }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "homepage": "https://github.com/wonderwhy-er/ClaudeComputerCommander",
   "bugs": "https://github.com/wonderwhy-er/ClaudeComputerCommander/issues",
   "type": "module",
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "bin": {
     "desktop-commander": "dist/index.js",
     "setup": "dist/setup-claude-server.js"
@@ -22,7 +25,7 @@
     "build": "tsc && shx cp setup-claude-server.js dist/ && shx chmod +x dist/*.js",
     "watch": "tsc --watch",
     "start": "node dist/index.js",
-    "setup": "npm install && npm run build && node --experimental-network-imports setup-claude-server.js",
+    "setup": "npm install && npm run build && node setup-claude-server.js",
     "prepare": "npm run build",
     "test": "node test/test.js",
     "test:watch": "nodemon test/test.js",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build": "tsc && shx cp setup-claude-server.js dist/ && shx chmod +x dist/*.js",
     "watch": "tsc --watch",
     "start": "node dist/index.js",
-    "setup": "npm install && npm run build && node setup-claude-server.js",
+    "setup": "npm install && npm run build && node --experimental-network-imports setup-claude-server.js",
     "prepare": "npm run build",
     "test": "node test/test.js",
     "test:watch": "nodemon test/test.js",
@@ -59,7 +59,7 @@
     "zod-to-json-schema": "^3.23.5"
   },
   "devDependencies": {
-    "@types/node": "^20.11.0",
+    "@types/node": "^20.17.24",
     "nodemon": "^3.0.2",
     "shx": "^0.3.4",
     "typescript": "^5.3.3"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     "skipLibCheck": true,
     "diagnostics": true,
     "extendedDiagnostics": true,
-    "listEmittedFiles": true
+    "listEmittedFiles": true,
+    "types": ["node"]
   },
   "include": [
     "src/**/*.ts"


### PR DESCRIPTION
This commit fixes the "Invalid path protocol 'c:'" error when running the MCP server on Windows systems. The error occurred because Node.js ESM imports require proper URL formatting with file:// protocol, which was not being handled correctly for Windows paths.

Changes:
- Added a createFileURL() helper function to properly convert Windows paths to valid file:// URLs
- Fixed import path handling in index.ts for setup script loading
- Updated setup-claude-server.js to use proper URL detection for direct execution
- Added proper TypeScript Node.js type definitions
- Updated tsconfig.json to explicitly include Node types
- Ensured Windows backslashes are properly escaped in JSON config

These changes ensure the MCP server installs and runs correctly on Windows systems while maintaining compatibility with other platforms.

Closes #8