### PR TITLE
Restart claude after install with npx

### DIFF
--- a/setup-claude-server.js
+++ b/setup-claude-server.js
@@ -46,7 +46,7 @@ async function execAsync(command) {
     return new Promise((resolve, reject) => {
       // Use PowerShell on Windows for better Unicode support and consistency
       const actualCommand = isWindows
-      ? `cmd.exe /c "${command.replace(/"/g, '\\"')}"` 
+      ? `cmd.exe /c ${command}` 
       : command;
         
       exec(actualCommand, (error, stdout, stderr) => {
@@ -61,12 +61,16 @@ async function execAsync(command) {
 
 async function restartClaude() {
 	try {
-		const platform = process.platform
+        const platform = process.platform
         switch (platform) {
             case "win32":
-                await execAsync(
-                    `taskkill /F /IM "Claude.exe"`,
-                )
+                // ignore errors on windows when claude is not running.
+                // just silently kill the process
+                try  {
+                    await execAsync(
+                        `taskkill /F /IM "Claude.exe"`,
+                    )
+                } catch {}
                 break;
             case "darwin":
                 await execAsync(
@@ -82,7 +86,8 @@ async function restartClaude() {
 		await new Promise((resolve) => setTimeout(resolve, 3000))
 
 		if (platform === "win32") {
-			await execAsync(`start "" "Claude.exe"`)
+            // it will never start claude
+			// await execAsync(`start "" "Claude.exe"`)
 		} else if (platform === "darwin") {
 			await execAsync(`open -a "Claude"`)
 		} else if (platform === "linux") {

--- a/setup-claude-server.js
+++ b/setup-claude-server.js
@@ -3,6 +3,7 @@ import { join } from 'path';
 import { readFileSync, writeFileSync, existsSync, appendFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
+import { exec } from "node:child_process";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -15,6 +16,9 @@ const claudeConfigPath = isWindows
 
 // Setup logging
 const LOG_FILE = join(__dirname, 'setup.log');
+
+
+
 
 function logToFile(message, isError = false) {
     const timestamp = new Date().toISOString();
@@ -36,6 +40,59 @@ function logToFile(message, isError = false) {
             message: `Failed to write to log file: ${err.message}`
         }) + '\n');
     }
+}
+
+async function execAsync(command) {
+    return new Promise((resolve, reject) => {
+      // Use PowerShell on Windows for better Unicode support and consistency
+      const actualCommand = isWindows
+      ? `cmd.exe /c "${command.replace(/"/g, '\\"')}"` 
+      : command;
+        
+      exec(actualCommand, (error, stdout, stderr) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve({ stdout, stderr });
+      });
+    });
+}
+
+async function restartClaude() {
+	try {
+		const platform = process.platform
+        switch (platform) {
+            case "win32":
+                await execAsync(
+                    `taskkill /F /IM "Claude.exe"`,
+                )
+                break;
+            case "darwin":
+                await execAsync(
+                    `killall "Claude"`,
+                )
+                break;
+            case "linux":
+                await execAsync(
+                    `pkill -f "claude"`,
+                )
+                break;
+        }
+		await new Promise((resolve) => setTimeout(resolve, 3000))
+
+		if (platform === "win32") {
+			await execAsync(`start "" "Claude.exe"`)
+		} else if (platform === "darwin") {
+			await execAsync(`open -a "Claude"`)
+		} else if (platform === "linux") {
+			await execAsync(`claude`)
+		}
+
+		logToFile(`Claude has been restarted.`)
+	} catch (error) {
+		logToFile(`Failed to restart Claude: ${error}`, true)
+	}
 }
 
 // Check if config file exists and create default if not
@@ -108,6 +165,8 @@ try {
     logToFile(`Configuration location: ${claudeConfigPath}`);
     logToFile('\nTo use the server:\n1. Restart Claude if it\'s currently running\n2. The server will be available as "desktop-commander" in Claude\'s MCP server list');
     
+    await restartClaude();
+
 } catch (error) {
     logToFile(`Error updating Claude configuration: ${error}`, true);
     process.exit(1);


### PR DESCRIPTION
Some Windows users had an issue where tools didn’t show up after installing Desktop Commander. The problem was that the Claude process needed to be restarted.

This update makes sure Claude restarts automatically when installing with:

npx @wonderwhy-er/desktop-commander setup

This fixes the issue without needing to restart manually.