### PR TITLE
Clarify MCP description for edit_block, read_file, and how search_files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The server provides these tool categories:
 - `move_file`: Move/rename files
 - `search_files`: Pattern-based file search
 - `get_file_info`: File metadata
-- `code_search`: Recursive ripgrep based text and code search
+- `search_code`: Recursive ripgrep based text and code search
 
 ### Edit Tools
 - `edit_block`: Apply surgical text replacements (best for changes <20% of file size)

--- a/README.md
+++ b/README.md
@@ -132,9 +132,9 @@ Search/Replace Block Format:
 ```
 filepath.ext
 <<<<<<< SEARCH
-existing code to replace
+content to find
 =======
-new code to insert
+new content
 >>>>>>> REPLACE
 ```
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -148,7 +148,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         name: "read_file",
         description:
           "Read the complete contents of a file from the file system. " +
-          "Handles various text encodings and provides detailed error messages " +
+          "Reads UTF-8 text and provides detailed error messages " +
           "if the file cannot be read. Only works within allowed directories.",
         inputSchema: zodToJsonSchema(ReadFileArgsSchema),
       },
@@ -194,7 +194,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       {
         name: "search_files",
         description:
-          "Recursively search for files and directories matching a pattern. " +
+          "Finds files by name using a case-insensitive substring matching. " +
           "Searches through all subdirectories from the starting path. " +
           "Only searches within allowed directories.",
         inputSchema: zodToJsonSchema(SearchFilesArgsSchema),
@@ -230,8 +230,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         name: "edit_block",
         description:
             "Apply surgical text replacements to files. Best for small changes (<20% of file size). " +
-            "Multiple blocks can be used for separate changes. Will verify changes after application. " +
-            "Format: filepath, then <<<<<<< SEARCH, content to find, =======, new content, >>>>>>> REPLACE.",
+            "Call repeatedly to change multiple blocks. Will verify changes after application. " +
+            "Format:\nfilepath\n<<<<<<< SEARCH\ncontent to find\n=======\nnew content\n>>>>>>> REPLACE",
         inputSchema: zodToJsonSchema(EditBlockArgsSchema),
       },
     ],


### PR DESCRIPTION
A simple change.

I found that Claude sometimes didn't realize that the format for edit_block did not have a "," in it but used newline characters.  I added newlines in the description to fix this.  I also once had it search for a file using a wildcard like *.txt but this failed because the code itself uses case insensitive substring matches.  I never had an issue with reading files, but the description is likely more accurate.

The newlines look like normal whitespace in the "Available MCP Tools" list.

The readme still uses the term pattern matching for "search_files" because I presume this in an intended feature.  A substring is a form of pattern until you're an LLM using a tool.  I fixed a typo in the README for search_code instead of code_search