### PR TITLE
Feat: Introduce Tool Modes (`granular`, `grouped`, `YOLO`) to Reduce Permission Prompts

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -22,7 +22,7 @@ This document provides answers to the most commonly asked questions about Claude
   - [How do I install Claude Desktop Commander?](#how-do-i-install-claude-desktop-commander)
   - [How do I update to the latest version?](#how-do-i-update-to-the-latest-version)
   - [Which operating systems does it support?](#which-operating-systems-does-it-support)
-  - [What's the difference between granular, grouped, and unified modes?](#whats-the-difference-between-granular-grouped-and-unified-modes)
+  - [What's the difference between granular, grouped, and YOLO modes?](#whats-the-difference-between-granular-grouped-and-YOLO-modes)
 
 - [Features & Capabilities](#features--capabilities)
   - [What can I do with Claude Desktop Commander?](#what-can-i-do-with-claude-desktop-commander)
@@ -50,7 +50,7 @@ This document provides answers to the most commonly asked questions about Claude
   - [What's the recommended workflow for coding?](#whats-the-recommended-workflow-for-coding)
   - [How can I manage changes to avoid losing work?](#how-can-i-manage-changes-to-avoid-losing-work)
   - [Should I still use a code editor?](#should-i-still-use-a-code-editor)
-  - [Which mode should I use: granular, grouped, or unified?](#which-mode-should-i-use-granular-grouped-or-unified)
+  - [Which mode should I use: granular, grouped, or YOLO?](#which-mode-should-i-use-granular-grouped-or-YOLO)
 
 - [Comparison with Other Tools](#comparison-with-other-tools)
   - [How does this compare to VSCode extensions like Cline?](#how-does-this-compare-to-vscode-extensions-like-cline)
@@ -135,7 +135,7 @@ Add the MCP server to your claude_desktop_config.json (on Mac, found at ~/Librar
       "args": [
         "-y",
         "@wonderwhy-er/desktop-commander",
-        "--mode=granular"  // Set to "granular", "grouped", or "unified"
+        "--mode=granular"  // Set to "granular", "grouped", or "YOLO"
       ]
     }
   }
@@ -166,7 +166,7 @@ Claude Desktop Commander works with:
 
 Work is in progress to improve WSL (Windows Subsystem for Linux) integration and add SSH support for remote servers.
 
-### What's the difference between granular, grouped, and unified modes?
+### What's the difference between granular, grouped, and YOLO modes?
 
 Claude Desktop Commander offers three different modes for how tools are presented to Claude:
 
@@ -180,7 +180,7 @@ Claude Desktop Commander offers three different modes for how tools are presente
 - Claude specifies which operation to perform via a `subtool` parameter
 - Provides a more organized structure while maintaining control
 
-**Unified Mode:**
+**YOLO Mode:**
 - Consolidates all filesystem and terminal operations into a single `command` tool
 - Security-sensitive operations (`change_blocked_commands`) remain separate for safety
 - Simplifies Claude's tool selection process
@@ -391,7 +391,7 @@ Typical workflow:
 
 Some users report reviewing code only after Claude has made it work, focusing on understanding and quality rather than writing from scratch.
 
-### Which mode should I use: granular, grouped, or unified?
+### Which mode should I use: granular, grouped, or YOLO?
 
 Each mode has its own benefits depending on your workflow and preferences:
 
@@ -405,15 +405,15 @@ Each mode has its own benefits depending on your workflow and preferences:
 - You're comfortable with the different categories of operations
 - You find the number of individual tools overwhelming
 
-**Choose Unified Mode if:**
+**Choose YOLO Mode if:**
 - You trust your operating system to keep Claude in line
 - You don't want to have to give Claude execute rights after it spends three minutes reading files
 - You want Claude to have a simplified interface for choosing tools
-- You're comfortable with YOLO mode
+- You only live once
 
-An important consideration is that you'll need to re-authorize Claude's MCP permissions whenever you switch modes. In granular mode, you'll need to authorize each individual command separately. In grouped mode, you'll authorize file_read and file_write commands as separate groups. In unified mode, you'll authorize all operations except changing blocked commands with a single permission. From a user experience perspective, this affects how frequently you need to approve permissions during your workflow.
+An important consideration is that you'll need to re-authorize Claude's MCP permissions whenever you switch modes. In granular mode, you'll need to authorize each individual command separately. In grouped mode, you'll authorize file_read and file_write commands as separate groups. In YOLO mode, you'll authorize all operations except changing blocked commands with a single permission. From a user experience perspective, this affects how frequently you need to approve permissions during your workflow.
 
-Many users start with granular mode to understand the available tools, then switch to unified mode for day-to-day use once they're comfortable with the system.
+Many users start with granular mode to understand the available tools, then switch to YOLO mode for day-to-day use once they're comfortable with the system.
 
 ## Comparison with Other Tools
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -22,6 +22,7 @@ This document provides answers to the most commonly asked questions about Claude
   - [How do I install Claude Desktop Commander?](#how-do-i-install-claude-desktop-commander)
   - [How do I update to the latest version?](#how-do-i-update-to-the-latest-version)
   - [Which operating systems does it support?](#which-operating-systems-does-it-support)
+  - [What's the difference between granular, grouped, and unified modes?](#whats-the-difference-between-granular-grouped-and-unified-modes)
 
 - [Features & Capabilities](#features--capabilities)
   - [What can I do with Claude Desktop Commander?](#what-can-i-do-with-claude-desktop-commander)
@@ -49,6 +50,7 @@ This document provides answers to the most commonly asked questions about Claude
   - [What's the recommended workflow for coding?](#whats-the-recommended-workflow-for-coding)
   - [How can I manage changes to avoid losing work?](#how-can-i-manage-changes-to-avoid-losing-work)
   - [Should I still use a code editor?](#should-i-still-use-a-code-editor)
+  - [Which mode should I use: granular, grouped, or unified?](#which-mode-should-i-use-granular-grouped-or-unified)
 
 - [Comparison with Other Tools](#comparison-with-other-tools)
   - [How does this compare to VSCode extensions like Cline?](#how-does-this-compare-to-vscode-extensions-like-cline)
@@ -132,7 +134,8 @@ Add the MCP server to your claude_desktop_config.json (on Mac, found at ~/Librar
       "command": "npx",
       "args": [
         "-y",
-        "@wonderwhy-er/desktop-commander"
+        "@wonderwhy-er/desktop-commander",
+        "--mode=granular"  // Set to "granular", "grouped", or "unified"
       ]
     }
   }
@@ -162,6 +165,28 @@ Claude Desktop Commander works with:
 - Linux (with ongoing enhancements for various distributions)
 
 Work is in progress to improve WSL (Windows Subsystem for Linux) integration and add SSH support for remote servers.
+
+### What's the difference between granular, grouped, and unified modes?
+
+Claude Desktop Commander offers three different modes for how tools are presented to Claude:
+
+**Granular Mode (Default):**
+- Each individual capability is presented as a separate tool (e.g., `read_file`, `execute_command`)
+- Most detailed and explicit approach
+- Offers the most fine-grained control
+
+**Grouped Mode:**
+- Tools are organized by functional category (`file_read`, `file_write`, `terminal`, `change_blocked_commands`)
+- Claude specifies which operation to perform via a `subtool` parameter
+- Provides a more organized structure while maintaining control
+
+**Unified Mode:**
+- Consolidates all filesystem and terminal operations into a single `command` tool
+- Security-sensitive operations (`change_blocked_commands`) remain separate for safety
+- Simplifies Claude's tool selection process
+- Makes it easier for Claude to choose the right operation
+
+These modes change how the tools are presented to Claude and how often you need to approve them.  The functionality remains the same regardless of which mode you choose.
 
 ## Features & Capabilities
 
@@ -365,6 +390,30 @@ Typical workflow:
 5. Commit changes using your normal workflow
 
 Some users report reviewing code only after Claude has made it work, focusing on understanding and quality rather than writing from scratch.
+
+### Which mode should I use: granular, grouped, or unified?
+
+Each mode has its own benefits depending on your workflow and preferences:
+
+**Choose Granular Mode if:**
+- You're new to Claude Desktop Commander and want to understand each capability individually
+- You prefer explicit control over which tool Claude uses for each task
+- You want maximum transparency in what Claude is doing
+
+**Choose Grouped Mode if:**
+- You want a more organized structure while maintaining explicit control
+- You're comfortable with the different categories of operations
+- You find the number of individual tools overwhelming
+
+**Choose Unified Mode if:**
+- You trust your operating system to keep Claude in line
+- You don't want to have to give Claude execute rights after it spends three minutes reading files
+- You want Claude to have a simplified interface for choosing tools
+- You're comfortable with YOLO mode
+
+An important consideration is that you'll need to re-authorize Claude's MCP permissions whenever you switch modes. In granular mode, you'll need to authorize each individual command separately. In grouped mode, you'll authorize file_read and file_write commands as separate groups. In unified mode, you'll authorize all operations except changing blocked commands with a single permission. From a user experience perspective, this affects how frequently you need to approve permissions during your workflow.
+
+Many users start with granular mode to understand the available tools, then switch to unified mode for day-to-day use once they're comfortable with the system.
 
 ## Comparison with Other Tools
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ Add this entry to your claude_desktop_config.json:
       "command": "npx",
       "args": [
         "-y",
-        "@wonderwhy-er/desktop-commander"
+        "@wonderwhy-er/desktop-commander",
+        "--mode=granular"  // Available modes: granular, grouped, unified
       ]
     }
   }
@@ -103,9 +104,20 @@ The setup command will:
 - Configure Claude's desktop app
 - Add MCP servers to Claude's config if needed
 
+## Configuration Parameters
+
+Configure the server using command-line arguments (in the `args` array of `claude_desktop_config.json`).
+
+*   `--mode=[granular|grouped|unified]` (Default: `granular`)
+    Controls how tools are presented to Claude and **how often you need to grant permissions**:
+    *   **`granular`**: Each capability (e.g., `read_file`, `execute_command`) is a separate tool. You'll authorize each tool individually upon its first use in a chat.
+    *   **`grouped`**: Tools are combined into categories (`file_read`, `file_write`, `terminal`, `change_blocked_commands`). Claude specifies the exact action using a `subtool` argument. You authorize each *category* once, reducing permission prompts compared to `granular`.
+    *   **`unified`**: Consolidates all tools except `change_blocked_commands` a single `command` tool with many `subtool`s usually requiring only one authorization per chat.
+    *   *Note:* This setting affects how often you click "Allow". The underlying server functionality remains the same.
+
 ## Usage
 
-The server provides these tool categories:
+The server provides these capabilities, presented to Claude based on the selected `--mode`:
 
 ### Terminal Tools
 - `execute_command`: Run commands with configurable timeout
@@ -118,7 +130,7 @@ The server provides these tool categories:
 
 ### Filesystem Tools
 - `read_file`/`write_file`: File operations
-- `create_directory`/`list_directory`: Directory management  
+- `create_directory`/`list_directory`: Directory management
 - `move_file`: Move/rename files
 - `search_files`: Pattern-based file search
 - `get_file_info`: File metadata
@@ -169,6 +181,7 @@ This project extends the MCP Filesystem Server to enable:
 Created as part of exploring Claude MCPs: https://youtube.com/live/TlbjFDbl5Us
 
 ## DONE
+- **30-03-2025 Re-enabled Unified Mode** - Implemented secure unified mode that keeps sensitive operations separate
 - **28-03-2025 Fixed "Watching /" JSON error** - Implemented custom stdio transport to handle non-JSON messages and prevent server crashes
 - **25-03-2025 Better code search** ([merged](https://github.com/wonderwhy-er/ClaudeDesktopCommander/pull/17)) - Enhanced code exploration with context-aware results
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Add this entry to your claude_desktop_config.json:
       "args": [
         "-y",
         "@wonderwhy-er/desktop-commander",
-        "--mode=granular"  // Available modes: granular, grouped, unified
+        "--mode=granular"  // Available modes: granular, grouped, YOLO
       ]
     }
   }
@@ -108,11 +108,11 @@ The setup command will:
 
 Configure the server using command-line arguments (in the `args` array of `claude_desktop_config.json`).
 
-*   `--mode=[granular|grouped|unified]` (Default: `granular`)
+*   `--mode=[granular|grouped|YOLO]` (Default: `granular`)
     Controls how tools are presented to Claude and **how often you need to grant permissions**:
     *   **`granular`**: Each capability (e.g., `read_file`, `execute_command`) is a separate tool. You'll authorize each tool individually upon its first use in a chat.
     *   **`grouped`**: Tools are combined into categories (`file_read`, `file_write`, `terminal`, `change_blocked_commands`). Claude specifies the exact action using a `subtool` argument. You authorize each *category* once, reducing permission prompts compared to `granular`.
-    *   **`unified`**: Consolidates all tools except `change_blocked_commands` a single `command` tool with many `subtool`s usually requiring only one authorization per chat.
+    *   **`YOLO`**: Consolidates all tools except `change_blocked_commands` a unified `command` tool with many `subtool`s usually requiring only one authorization per chat.
     *   *Note:* This setting affects how often you click "Allow". The underlying server functionality remains the same.
 
 ## Usage
@@ -181,7 +181,7 @@ This project extends the MCP Filesystem Server to enable:
 Created as part of exploring Claude MCPs: https://youtube.com/live/TlbjFDbl5Us
 
 ## DONE
-- **30-03-2025 Re-enabled Unified Mode** - Implemented secure unified mode that keeps sensitive operations separate
+- **30-03-2025 Added modes such as YOLO and groped which makes it so you don't have to authorize Claude to perform an action as often.
 - **28-03-2025 Fixed "Watching /" JSON error** - Implemented custom stdio transport to handle non-JSON messages and prevent server crashes
 - **25-03-2025 Better code search** ([merged](https://github.com/wonderwhy-er/ClaudeDesktopCommander/pull/17)) - Enhanced code exploration with context-aware results
 

--- a/setup-claude-server.js
+++ b/setup-claude-server.js
@@ -72,7 +72,7 @@ async function execAsync(command) {
 }
 
 async function restartClaude() {
-	try {
+    try {
         const platform = process.platform
         switch (platform) {
             case "win32":
@@ -153,11 +153,16 @@ export default async function setup() {
 
         // Fix Windows path handling for npx execution
         let serverConfig;
+        // Prepare the additional arguments for both configurations
+        const additionalArgs = [];
+        additionalArgs.push("--mode=granular"); // Set default mode
+
         if (isNpx) {
             serverConfig = {
                 "command": isWindows ? "npx.cmd" : "npx",
                 "args": [
-                    "@wonderwhy-er/desktop-commander"
+                    "@wonderwhy-er/desktop-commander",
+                    ...additionalArgs
                 ]
             };
         } else {
@@ -166,7 +171,8 @@ export default async function setup() {
             serverConfig = {
                 "command": "node",
                 "args": [
-                    indexPath.replace(/\\/g, '\\\\') // Double escape backslashes for JSON
+                    indexPath.replace(/\\/g, '\\\\'), // Double escape backslashes for JSON
+                    ...additionalArgs
                 ]
             };
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,9 +18,16 @@ function parseArgs(): { mode: Mode } {
     if (arg.startsWith('--mode=')) {
       const modeValue = arg.split('=')[1].toLowerCase();
 
-      // Accept all three modes
-      if (['granular', 'grouped', 'unified'].includes(modeValue)) {
-        return { mode: modeValue as Mode };
+      // Accept all three modes (case insensitive)
+      if (['granular', 'grouped', 'yolo'].includes(modeValue)) {
+        // Map the lowercase input to the correct Mode type
+        let mappedMode: Mode;
+        if (modeValue === 'granular') mappedMode = 'granular';
+        else if (modeValue === 'grouped') mappedMode = 'grouped';
+        else if (modeValue === 'yolo') mappedMode = 'YOLO';
+        else mappedMode = 'granular'; // Fallback (should never happen)
+        
+        return { mode: mappedMode };
       } else {
         console.error(`Warning: Invalid mode '${modeValue}'. Using default mode 'granular'.`);
       }

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,6 +8,50 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { commandManager } from './command-manager.js';
+import { z } from "zod";
+import { DesktopCommanderArgsSchema } from './tools/schemas.js';
+
+// Define types for Mode
+export type Mode = 'granular' | 'grouped' | 'unified';
+
+// Define a const enum for tool categories
+const enum ToolCategory {
+  FileRead = 'file_read',
+  FileWrite = 'file_write',
+  Terminal = 'terminal',
+  ChangeBlockedCommands = 'change_blocked_commands'
+}
+
+// Define tool categories for 'grouped' mode
+const ToolCategories: Record<string, ToolCategory> = {
+  // Terminal tools
+  "execute_command": ToolCategory.Terminal,
+  "read_output": ToolCategory.Terminal,
+  "force_terminate": ToolCategory.Terminal,
+  "list_sessions": ToolCategory.Terminal,
+  "list_processes": ToolCategory.Terminal,
+  "kill_process": ToolCategory.Terminal,
+  "list_blocked_commands": ToolCategory.Terminal,
+
+  // Command blocking tools
+  "block_command": ToolCategory.ChangeBlockedCommands,
+  "unblock_command": ToolCategory.ChangeBlockedCommands,
+
+  // File read tools
+  "read_file": ToolCategory.FileRead,
+  "read_multiple_files": ToolCategory.FileRead,
+  "list_directory": ToolCategory.FileRead,
+  "search_files": ToolCategory.FileRead,
+  "search_code": ToolCategory.FileRead,
+  "get_file_info": ToolCategory.FileRead,
+  "list_allowed_directories": ToolCategory.FileRead,
+
+  // File write tools
+  "write_file": ToolCategory.FileWrite,
+  "create_directory": ToolCategory.FileWrite,
+  "move_file": ToolCategory.FileWrite,
+  "edit_block": ToolCategory.FileWrite
+};
 import {
   ExecuteCommandArgsSchema,
   ReadOutputArgsSchema,
@@ -45,6 +89,135 @@ import { searchTextInFiles } from './tools/search.js';
 
 import { VERSION } from './version.js';
 
+// Define all tools with their metadata
+const ALL_TOOLS_METADATA: Record<string, { description: string, schema: z.ZodType<any> }> = {
+  // Terminal tools
+  "execute_command": {
+    description:
+      "Execute a terminal command with timeout. Command will continue running in background if it doesn't complete within timeout.",
+    schema: ExecuteCommandArgsSchema
+  },
+  "read_output": {
+    description:
+      "Read new output from a running terminal session.",
+    schema: ReadOutputArgsSchema
+  },
+  "force_terminate": {
+    description:
+      "Force terminate a running terminal session.",
+    schema: ForceTerminateArgsSchema
+  },
+  "list_sessions": {
+    description:
+      "List all active terminal sessions.",
+    schema: ListSessionsArgsSchema
+  },
+  "list_processes": {
+    description:
+      "List all running processes. Returns process information including PID, " +
+      "command name, CPU usage, and memory usage.",
+    schema: z.object({})
+  },
+  "kill_process": {
+    description:
+      "Terminate a running process by PID. Use with caution as this will " +
+      "forcefully terminate the specified process.",
+    schema: KillProcessArgsSchema
+  },
+  "block_command": {
+    description:
+      "Add a command to the blacklist. Once blocked, the command cannot be executed until unblocked.",
+    schema: BlockCommandArgsSchema
+  },
+  "unblock_command": {
+    description:
+      "Remove a command from the blacklist. Once unblocked, the command can be executed normally.",
+    schema: UnblockCommandArgsSchema
+  },
+  "list_blocked_commands": {
+    description:
+      "List all currently blocked commands.",
+    schema: z.object({})
+  },
+
+  // Filesystem tools
+  "read_file": {
+    description:
+      "Read the complete contents of a file from the file system. " +
+      "Handles various text encodings and provides detailed error messages " +
+      "if the file cannot be read. Only works within allowed directories.",
+    schema: ReadFileArgsSchema
+  },
+  "read_multiple_files": {
+    description:
+      "Read the contents of multiple files simultaneously. " +
+      "Each file's content is returned with its path as a reference. " +
+      "Failed reads for individual files won't stop the entire operation. " +
+      "Only works within allowed directories.",
+    schema: ReadMultipleFilesArgsSchema
+  },
+  "write_file": {
+    description:
+      "Completely replace file contents. Best for large changes (>20% of file) or when edit_block fails. " +
+      "Use with caution as it will overwrite existing files. Only works within allowed directories.",
+    schema: WriteFileArgsSchema
+  },
+  "create_directory": {
+    description:
+      "Create a new directory or ensure a directory exists. Can create multiple " +
+      "nested directories in one operation. Only works within allowed directories.",
+    schema: CreateDirectoryArgsSchema
+  },
+  "list_directory": {
+    description:
+      "Get a detailed listing of all files and directories in a specified path. " +
+      "Results distinguish between files and directories with [FILE] and [DIR] prefixes. " +
+      "Only works within allowed directories.",
+    schema: ListDirectoryArgsSchema
+  },
+  "move_file": {
+    description:
+      "Move or rename files and directories. Can move files between directories " +
+      "and rename them in a single operation. Both source and destination must be " +
+      "within allowed directories.",
+    schema: MoveFileArgsSchema
+  },
+  "search_files": {
+    description:
+      "Recursively search for files and directories matching a pattern. " +
+      "Searches through all subdirectories from the starting path. " +
+      "Only searches within allowed directories.",
+    schema: SearchFilesArgsSchema
+  },
+  "search_code": {
+    description:
+      "Search for text/code patterns within file contents using ripgrep. " +
+      "Fast and powerful search similar to VS Code search functionality. " +
+      "Supports regular expressions, file pattern filtering, and context lines. " +
+      "Only searches within allowed directories.",
+    schema: SearchCodeArgsSchema
+  },
+  "get_file_info": {
+    description:
+      "Retrieve detailed metadata about a file or directory including size, " +
+      "creation time, last modified time, permissions, and type. " +
+      "Only works within allowed directories.",
+    schema: GetFileInfoArgsSchema
+  },
+  "list_allowed_directories": {
+    description:
+      "Returns the list of directories that this server is allowed to access.",
+    schema: z.object({})
+  },
+  "edit_block": {
+    description:
+      "Apply surgical text replacements to files. Best for small changes (<20% of file size). " +
+      "Multiple blocks can be used for separate changes. Will verify changes after application. " +
+      "Format: filepath, then <<<<<<< SEARCH, content to find, =======, new content, >>>>>>> REPLACE.",
+    schema: EditBlockArgsSchema
+  }
+};
+
 export const server = new Server(
   {
     name: "desktop-commander",
@@ -76,204 +249,197 @@ server.setRequestHandler(ListPromptsRequestSchema, async () => {
 });
 
 server.setRequestHandler(ListToolsRequestSchema, async () => {
-  return {
-    tools: [
-      // Terminal tools
-      {
-        name: "execute_command",
-        description:
-          "Execute a terminal command with timeout. Command will continue running in background if it doesn't complete within timeout.",
-        inputSchema: zodToJsonSchema(ExecuteCommandArgsSchema),
-      },
-      {
-        name: "read_output",
-        description:
-          "Read new output from a running terminal session.",
-        inputSchema: zodToJsonSchema(ReadOutputArgsSchema),
-      },
-      {
-        name: "force_terminate",
-        description:
-          "Force terminate a running terminal session.",
-        inputSchema: zodToJsonSchema(ForceTerminateArgsSchema),
-      },
-      {
-        name: "list_sessions",
-        description:
-          "List all active terminal sessions.",
-        inputSchema: zodToJsonSchema(ListSessionsArgsSchema),
-      },
-      {
-        name: "list_processes",
-        description:
-          "List all running processes. Returns process information including PID, " +
-          "command name, CPU usage, and memory usage.",
-        inputSchema: {
-          type: "object",
-          properties: {},
-          required: [],
-        },
-      },
-      {
-        name: "kill_process",
-        description:
-          "Terminate a running process by PID. Use with caution as this will " +
-          "forcefully terminate the specified process.",
-        inputSchema: zodToJsonSchema(KillProcessArgsSchema),
-      },
-      {
-        name: "block_command",
-        description:
-          "Add a command to the blacklist. Once blocked, the command cannot be executed until unblocked.",
-        inputSchema: zodToJsonSchema(BlockCommandArgsSchema),
-      },
-      {
-        name: "unblock_command",
-        description:
-          "Remove a command from the blacklist. Once unblocked, the command can be executed normally.",
-        inputSchema: zodToJsonSchema(UnblockCommandArgsSchema),
-      },
-      {
-        name: "list_blocked_commands",
-        description:
-          "List all currently blocked commands.",
-        inputSchema: {
-          type: "object",
-          properties: {},
-          required: [],
-        },
-      },
-      // Filesystem tools
-      {
-        name: "read_file",
-        description:
-          "Read the complete contents of a file from the file system. " +
-          "Handles various text encodings and provides detailed error messages " +
-          "if the file cannot be read. Only works within allowed directories.",
-        inputSchema: zodToJsonSchema(ReadFileArgsSchema),
-      },
-      {
-        name: "read_multiple_files",
-        description:
-          "Read the contents of multiple files simultaneously. " +
-          "Each file's content is returned with its path as a reference. " +
-          "Failed reads for individual files won't stop the entire operation. " +
-          "Only works within allowed directories.",
-        inputSchema: zodToJsonSchema(ReadMultipleFilesArgsSchema),
-      },
-      {
-        name: "write_file",
-        description:
-          "Completely replace file contents. Best for large changes (>20% of file) or when edit_block fails. " +
-          "Use with caution as it will overwrite existing files. Only works within allowed directories.",
-        inputSchema: zodToJsonSchema(WriteFileArgsSchema),
-      },
-      {
-        name: "create_directory",
-        description:
-          "Create a new directory or ensure a directory exists. Can create multiple " +
-          "nested directories in one operation. Only works within allowed directories.",
-        inputSchema: zodToJsonSchema(CreateDirectoryArgsSchema),
-      },
-      {
-        name: "list_directory",
-        description:
-          "Get a detailed listing of all files and directories in a specified path. " +
-          "Results distinguish between files and directories with [FILE] and [DIR] prefixes. " +
-          "Only works within allowed directories.",
-        inputSchema: zodToJsonSchema(ListDirectoryArgsSchema),
-      },
-      {
-        name: "move_file",
-        description:
-          "Move or rename files and directories. Can move files between directories " +
-          "and rename them in a single operation. Both source and destination must be " +
-          "within allowed directories.",
-        inputSchema: zodToJsonSchema(MoveFileArgsSchema),
-      },
-      {
-        name: "search_files",
-        description:
-          "Recursively search for files and directories matching a pattern. " +
-          "Searches through all subdirectories from the starting path. " +
-          "Only searches within allowed directories.",
-        inputSchema: zodToJsonSchema(SearchFilesArgsSchema),
-      },
-      {
-        name: "search_code",
-        description:
-          "Search for text/code patterns within file contents using ripgrep. " +
-          "Fast and powerful search similar to VS Code search functionality. " +
-          "Supports regular expressions, file pattern filtering, and context lines. " +
-          "Only searches within allowed directories.",
-        inputSchema: zodToJsonSchema(SearchCodeArgsSchema),
-      },
-      {
-        name: "get_file_info",
-        description:
-          "Retrieve detailed metadata about a file or directory including size, " +
-          "creation time, last modified time, permissions, and type. " +
-          "Only works within allowed directories.",
-        inputSchema: zodToJsonSchema(GetFileInfoArgsSchema),
-      },
-      {
-        name: "list_allowed_directories",
-        description: 
-          "Returns the list of directories that this server is allowed to access.",
-        inputSchema: {
-          type: "object",
-          properties: {},
-          required: [],
-        },
-      },
-      {
-        name: "edit_block",
-        description:
-            "Apply surgical text replacements to files. Best for small changes (<20% of file size). " +
-            "Multiple blocks can be used for separate changes. Will verify changes after application. " +
-            "Format: filepath, then <<<<<<< SEARCH, content to find, =======, new content, >>>>>>> REPLACE.",
-        inputSchema: zodToJsonSchema(EditBlockArgsSchema),
-      },
-    ],
-  };
+  // Define ToolDefinition interface locally
+  interface ToolDefinition { name: string; description: string; inputSchema: any; [key: string]: unknown; }
+
+  // Access the mode stored on the server instance
+  const mode: Mode = (server as any).currentMode || 'granular'; // Default to granular
+  let tools: ToolDefinition[] = [];
+  const unifiedSchemaJson = zodToJsonSchema(DesktopCommanderArgsSchema);
+  const allowedSubtools = Object.keys(ALL_TOOLS_METADATA); // No auth filtering yet
+
+  switch (mode) {
+    case 'granular':
+      tools = allowedSubtools.map(subtool => ({
+        name: subtool, // Use specific tool name
+        description: ALL_TOOLS_METADATA[subtool].description,
+        inputSchema: zodToJsonSchema(ALL_TOOLS_METADATA[subtool].schema),
+      }));
+      break;
+
+    case 'grouped':
+      // Group tools by category
+      const groupMap: Record<string, string[]> = {
+        [ToolCategory.FileRead]: [],
+        [ToolCategory.FileWrite]: [],
+        [ToolCategory.Terminal]: [],
+        [ToolCategory.ChangeBlockedCommands]: []
+      };
+
+      // Place each subtool in its category group
+      allowedSubtools.forEach(subtool => {
+        const category = ToolCategories[subtool];
+        if (category && groupMap[category]) {
+          groupMap[category].push(subtool);
+        }
+      });
+
+      // Create a tool for each category that has subtools
+      Object.entries(groupMap).forEach(([category, subtoolsInCategory]) => {
+        if (subtoolsInCategory.length > 0) {
+          // Build a description listing the subtools in this group
+          const subtoolDetails = subtoolsInCategory
+            .map((subtool) => `• ${subtool}: ${ALL_TOOLS_METADATA[subtool].description}`)
+            .join('\n');
+
+          tools.push({
+            name: category,
+            description: `Perform ${category.replace('_', ' ')} operations. Use 'subtool' parameter to specify operation.\nAvailable subtools:\n${subtoolDetails}`,
+            inputSchema: unifiedSchemaJson, // Use the unified schema
+          });
+        }
+      });
+      break;
+
+    case 'unified':
+      // This is the modified unified mode implementation - using the simpler negative check approach with enum
+      const unifiedSubtools: string[] = [];
+      const blockedCommandSubtools: string[] = [];
+      
+      // Separate subtools into unified and blocked command categories
+      allowedSubtools.forEach(subtool => {
+        // Simple negative check - everything except change_blocked_commands goes into unified command
+        if (ToolCategories[subtool] !== ToolCategory.ChangeBlockedCommands) {
+          unifiedSubtools.push(subtool);
+        } else {
+          blockedCommandSubtools.push(subtool);
+        }
+      });
+
+      // Add unified command tool if there are subtools for it
+      if (unifiedSubtools.length > 0) {
+        // Build a description listing all available unified subtools
+        const subtoolDescriptions = unifiedSubtools
+          .map((subtool) => `• ${subtool}: ${ALL_TOOLS_METADATA[subtool].description}`)
+          .join('\n');
+
+        tools.push({
+          name: "command", // Main unified tool name
+          description: `Unified desktop command tool for filesystem and terminal operations. Use 'subtool' parameter to specify operation.\nAvailable subtools:\n${subtoolDescriptions}`,
+          inputSchema: unifiedSchemaJson, // Use the unified schema
+        });
+      }
+
+      // Add separate change_blocked_commands tool if there are subtools for it
+      if (blockedCommandSubtools.length > 0) {
+        const blockedCmdDescriptions = blockedCommandSubtools
+          .map((subtool) => `• ${subtool}: ${ALL_TOOLS_METADATA[subtool].description}`)
+          .join('\n');
+
+        tools.push({
+          name: ToolCategory.ChangeBlockedCommands, // Separate security-sensitive tool
+          description: `Perform change blocked_commands operations. Use 'subtool' parameter to specify operation.\nAvailable subtools:\n${blockedCmdDescriptions}`,
+          inputSchema: unifiedSchemaJson, // Use the unified schema
+        });
+      }
+      break;
+  }
+
+  return { tools };
 });
 
 server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest) => {
   try {
-    const { name, arguments: args } = request.params;
+    const { name: toolNameCalled, arguments: args } = request.params;
+    let subtool: string;
+    let finalArgs: any; // This will hold the correctly parsed args for the switch
 
-    switch (name) {
+    // 1. Determine Subtool and Parse Appropriately
+    if (toolNameCalled === ToolCategory.FileRead ||
+        toolNameCalled === ToolCategory.FileWrite ||
+        toolNameCalled === ToolCategory.Terminal ||
+        toolNameCalled === ToolCategory.ChangeBlockedCommands ||
+        toolNameCalled === "command"
+        ) {
+      // Grouped or Unified Mode Call
+      const parsedUnified = DesktopCommanderArgsSchema.safeParse(args);
+      if (!parsedUnified.success) {
+        throw new Error(`Invalid arguments for ${toolNameCalled}: ${parsedUnified.error.message}`);
+      }
+      subtool = parsedUnified.data.subtool;
+      finalArgs = parsedUnified.data; // Use the data from the unified parse
+
+      // Validate subtool belongs to correct category if grouped mode
+      if ([ToolCategory.FileRead, ToolCategory.FileWrite, ToolCategory.Terminal, ToolCategory.ChangeBlockedCommands].includes(toolNameCalled as any)) {
+        const expectedCategory = toolNameCalled;
+        const actualCategory = ToolCategories[subtool];
+        if (!actualCategory) {
+          throw new Error(`Subtool '${subtool}' specified for group '${toolNameCalled}' is unknown or uncategorized.`);
+        }
+        if (actualCategory !== expectedCategory) {
+          throw new Error(`Subtool '${subtool}' cannot be used with the '${toolNameCalled}' group. It belongs to the '${actualCategory}' group.`);
+        }
+      }
+      
+      // For unified "command" tool, validate the subtool is not in the change_blocked_commands category
+      if (toolNameCalled === "command" && ToolCategories[subtool] === ToolCategory.ChangeBlockedCommands) {
+        throw new Error(`Subtool '${subtool}' cannot be used with the 'command' tool. Security-sensitive operations must be called directly.`);
+      }
+      
+      // For change_blocked_commands tool, ensure the subtool belongs to that category
+      if (toolNameCalled === ToolCategory.ChangeBlockedCommands && ToolCategories[subtool] !== ToolCategory.ChangeBlockedCommands) {
+        throw new Error(`Subtool '${subtool}' cannot be used with the 'change_blocked_commands' tool.`);
+      }
+    } else if (ALL_TOOLS_METADATA[toolNameCalled]) {
+      // Granular Mode Call
+      subtool = toolNameCalled;
+      const schema = ALL_TOOLS_METADATA[subtool].schema;
+      const specificParseResult = schema.safeParse(args);
+      if (!specificParseResult.success) {
+        throw new Error(`Invalid arguments for '${subtool}': ${specificParseResult.error.message}`);
+      }
+      finalArgs = specificParseResult.data; // Use the data from the specific parse
+    } else {
+      // Tool name is not recognized in any mode
+      throw new Error(`Unknown tool name: '${toolNameCalled}'`);
+    }
+
+    // 2. Main Dispatch Switch (Simplified Cases)
+    switch (subtool) {
       // Terminal tools
       case "execute_command": {
-        const parsed = ExecuteCommandArgsSchema.parse(args);
-        return executeCommand(parsed);
+        if (finalArgs.command === undefined) throw new Error("Missing 'command' for execute_command");
+        return executeCommand({
+          command: finalArgs.command,
+          timeout_ms: finalArgs.timeout_ms
+        });
       }
       case "read_output": {
-        const parsed = ReadOutputArgsSchema.parse(args);
-        return readOutput(parsed);
+        if (finalArgs.pid === undefined) throw new Error("Missing 'pid' for read_output");
+        return readOutput({ pid: finalArgs.pid });
       }
       case "force_terminate": {
-        const parsed = ForceTerminateArgsSchema.parse(args);
-        return forceTerminate(parsed);
+        if (finalArgs.pid === undefined) throw new Error("Missing 'pid' for force_terminate");
+        return forceTerminate({ pid: finalArgs.pid });
       }
       case "list_sessions":
         return listSessions();
       case "list_processes":
         return listProcesses();
       case "kill_process": {
-        const parsed = KillProcessArgsSchema.parse(args);
-        return killProcess(parsed);
+        if (finalArgs.pid === undefined) throw new Error("Missing 'pid' for kill_process");
+        return killProcess({ pid: finalArgs.pid });
       }
       case "block_command": {
-        const parsed = BlockCommandArgsSchema.parse(args);
-        const blockResult = await commandManager.blockCommand(parsed.command);
+        if (finalArgs.command === undefined) throw new Error("Missing 'command' for block_command");
+        const blockResult = await commandManager.blockCommand(finalArgs.command);
         return {
           content: [{ type: "text", text: blockResult }],
         };
       }
       case "unblock_command": {
-        const parsed = UnblockCommandArgsSchema.parse(args);
-        const unblockResult = await commandManager.unblockCommand(parsed.command);
+        if (finalArgs.command === undefined) throw new Error("Missing 'command' for unblock_command");
+        const unblockResult = await commandManager.unblockCommand(finalArgs.command);
         return {
           content: [{ type: "text", text: unblockResult }],
         };
@@ -287,72 +453,76 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
       
       // Filesystem tools
       case "edit_block": {
-        const parsed = EditBlockArgsSchema.parse(args);
-        const { filePath, searchReplace } = await parseEditBlock(parsed.blockContent);
+        if (finalArgs.blockContent === undefined) throw new Error("Missing 'blockContent' for edit_block");
+        const { filePath, searchReplace } = await parseEditBlock(finalArgs.blockContent);
         await performSearchReplace(filePath, searchReplace);
         return {
           content: [{ type: "text", text: `Successfully applied edit to ${filePath}` }],
         };
       }
       case "read_file": {
-        const parsed = ReadFileArgsSchema.parse(args);
-        const content = await readFile(parsed.path);
+        if (finalArgs.path === undefined) throw new Error("Missing 'path' for read_file");
+        const content = await readFile(finalArgs.path);
         return {
           content: [{ type: "text", text: content }],
         };
       }
       case "read_multiple_files": {
-        const parsed = ReadMultipleFilesArgsSchema.parse(args);
-        const results = await readMultipleFiles(parsed.paths);
+        if (finalArgs.paths === undefined) throw new Error("Missing 'paths' for read_multiple_files");
+        const results = await readMultipleFiles(finalArgs.paths);
         return {
           content: [{ type: "text", text: results.join("\n---\n") }],
         };
       }
       case "write_file": {
-        const parsed = WriteFileArgsSchema.parse(args);
-        await writeFile(parsed.path, parsed.content);
+        if (finalArgs.path === undefined) throw new Error("Missing 'path' for write_file");
+        if (finalArgs.content === undefined) throw new Error("Missing 'content' for write_file");
+        await writeFile(finalArgs.path, finalArgs.content);
         return {
-          content: [{ type: "text", text: `Successfully wrote to ${parsed.path}` }],
+          content: [{ type: "text", text: `Successfully wrote to ${finalArgs.path}` }],
         };
       }
       case "create_directory": {
-        const parsed = CreateDirectoryArgsSchema.parse(args);
-        await createDirectory(parsed.path);
+        if (finalArgs.path === undefined) throw new Error("Missing 'path' for create_directory");
+        await createDirectory(finalArgs.path);
         return {
-          content: [{ type: "text", text: `Successfully created directory ${parsed.path}` }],
+          content: [{ type: "text", text: `Successfully created directory ${finalArgs.path}` }],
         };
       }
       case "list_directory": {
-        const parsed = ListDirectoryArgsSchema.parse(args);
-        const entries = await listDirectory(parsed.path);
+        if (finalArgs.path === undefined) throw new Error("Missing 'path' for list_directory");
+        const entries = await listDirectory(finalArgs.path);
         return {
           content: [{ type: "text", text: entries.join('\n') }],
         };
       }
       case "move_file": {
-        const parsed = MoveFileArgsSchema.parse(args);
-        await moveFile(parsed.source, parsed.destination);
+        if (finalArgs.source === undefined) throw new Error("Missing 'source' for move_file");
+        if (finalArgs.destination === undefined) throw new Error("Missing 'destination' for move_file");
+        await moveFile(finalArgs.source, finalArgs.destination);
         return {
-          content: [{ type: "text", text: `Successfully moved ${parsed.source} to ${parsed.destination}` }],
+          content: [{ type: "text", text: `Successfully moved ${finalArgs.source} to ${finalArgs.destination}` }],
         };
       }
       case "search_files": {
-        const parsed = SearchFilesArgsSchema.parse(args);
-        const results = await searchFiles(parsed.path, parsed.pattern);
+        if (finalArgs.path === undefined) throw new Error("Missing 'path' for search_files");
+        if (finalArgs.pattern === undefined) throw new Error("Missing 'pattern' for search_files");
+        const results = await searchFiles(finalArgs.path, finalArgs.pattern);
         return {
           content: [{ type: "text", text: results.length > 0 ? results.join('\n') : "No matches found" }],
         };
       }
       case "search_code": {
-        const parsed = SearchCodeArgsSchema.parse(args);
+        if (finalArgs.path === undefined) throw new Error("Missing 'path' for search_code");
+        if (finalArgs.pattern === undefined) throw new Error("Missing 'pattern' for search_code");
         const results = await searchTextInFiles({
-          rootPath: parsed.path,
-          pattern: parsed.pattern,
-          filePattern: parsed.filePattern,
-          ignoreCase: parsed.ignoreCase,
-          maxResults: parsed.maxResults,
-          includeHidden: parsed.includeHidden,
-          contextLines: parsed.contextLines,
+          rootPath: finalArgs.path,
+          pattern: finalArgs.pattern,
+          filePattern: finalArgs.filePattern,
+          ignoreCase: finalArgs.ignoreCase,
+          maxResults: finalArgs.maxResults,
+          includeHidden: finalArgs.includeHidden,
+          contextLines: finalArgs.contextLines,
         });
 
         if (results.length === 0) {
@@ -378,8 +548,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
         };
       }
       case "get_file_info": {
-        const parsed = GetFileInfoArgsSchema.parse(args);
-        const info = await getFileInfo(parsed.path);
+        if (finalArgs.path === undefined) throw new Error("Missing 'path' for get_file_info");
+        const info = await getFileInfo(finalArgs.path);
         return {
           content: [{ 
             type: "text", 
@@ -400,10 +570,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
       }
 
       default:
-        throw new Error(`Unknown tool: ${name}`);
+        throw new Error(`Unknown subtool: ${subtool}`);
     }
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
+    // We can't reference subtool here if it might not be defined
+    console.error(`Error processing tool call '${request.params.name}':`, error);
     return {
       content: [{ type: "text", text: `Error: ${errorMessage}` }],
       isError: true,

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -79,3 +79,38 @@ export const SearchCodeArgsSchema = z.object({
 export const EditBlockArgsSchema = z.object({
   blockContent: z.string(),
 });
+
+// Define the unified DesktopCommanderArgs schema
+// This will be used for grouped and unified modes
+export const DesktopCommanderArgsSchema = z.object({
+  // Required subtool field to specify which operation to perform
+  subtool: z.enum([
+    // List ALL original tool names
+    'execute_command', 'read_output', 'force_terminate', 'list_sessions',
+    'list_processes', 'kill_process', 'block_command', 'unblock_command',
+    'list_blocked_commands', 'read_file', 'read_multiple_files',
+    'write_file', 'create_directory', 'list_directory', 'move_file',
+    'search_files', 'search_code', 'get_file_info', 'list_allowed_directories',
+    'edit_block'
+  ]),
+
+  // Add ALL optional parameters from ALL individual schemas above
+  command: z.string().optional(),
+  timeout_ms: z.number().optional(),
+  pid: z.number().optional(),
+  path: z.string().optional(),
+  paths: z.array(z.string()).optional(),
+  content: z.string().optional(),
+  source: z.string().optional(),
+  destination: z.string().optional(),
+  pattern: z.string().optional(),
+  filePattern: z.string().optional(),
+  ignoreCase: z.boolean().optional(),
+  maxResults: z.number().optional(),
+  includeHidden: z.boolean().optional(),
+  contextLines: z.number().optional(),
+  blockContent: z.string().optional()
+});
+
+// Define the type for the unified schema
+export type DesktopCommanderArgs = z.infer<typeof DesktopCommanderArgsSchema>;

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -80,8 +80,8 @@ export const EditBlockArgsSchema = z.object({
   blockContent: z.string(),
 });
 
-// Define the unified DesktopCommanderArgs schema
-// This will be used for grouped and unified modes
+// Define the YOLO DesktopCommanderArgs schema
+// This will be used for grouped and YOLO modes
 export const DesktopCommanderArgsSchema = z.object({
   // Required subtool field to specify which operation to perform
   subtool: z.enum([
@@ -112,5 +112,5 @@ export const DesktopCommanderArgsSchema = z.object({
   blockContent: z.string().optional()
 });
 
-// Define the type for the unified schema
+// Define the type for the YOLO schema
 export type DesktopCommanderArgs = z.infer<typeof DesktopCommanderArgsSchema>;


### PR DESCRIPTION
**Problem:** Frequent permission prompts in Claude Desktop interrupt workflow with multiple tools.

**Solution:** New `--mode` flag with three options:
- `granular` (Default): Current behavior, one permission per tool
- `grouped`: Tools grouped by category (`file_read`, `file_write`, `terminal`, `change_blocked_commands`)
- `YOLO`: Most tools under single `yolo` tool, minimal prompts
- Claude chooses individual tools using a subtool.

**Implementation:**
- Added `--mode` argument parsing
- Refactored handlers for dynamic tool presentation
- Created unified `DesktopCommanderArgsSchema` 
- Maintained original tool descriptions
- Kept `change_blocked_commands` separate even in YOLO mode
- Updated documentation

The original descriptions of each tool have been maintained (eg. edit_block does not use "\n" characters).

The permission problem from my previous commit is mitigated by making the change_blocked_commands its own group even in YOLO mode.  I also realized that blocked commands are more of a guideline for the LLM anyway since it can write a bash script that runs sudo.  (It could run `sudo -u nobody /usr/bin/whoami` from a bash script it wrote when sudo was in the blocked list.)

I'm planning to use my own branch until there's a YOLO mode option.  Separating read/write/execute slows me down too much.