### PR TITLE
Capture exception when file not found for file edit

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -295,11 +295,17 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
       case "edit_block": {
         const parsed = EditBlockArgsSchema.parse(args);
         const { filePath, searchReplace } = await parseEditBlock(parsed.blockContent);
-        await performSearchReplace(filePath, searchReplace);
-        capture('server_edit_block');
-        return {
-          content: [{ type: "text", text: `Successfully applied edit to ${filePath}` }],
-        };
+        try {
+            await performSearchReplace(filePath, searchReplace);
+            return {
+                content: [{ type: "text", text: `Successfully applied edit to ${filePath}` }],
+            };
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            return {
+                content: [{ type: "text", text: errorMessage }],
+            }; 
+        }
       }
       case "read_file": {
         const parsed = ReadFileArgsSchema.parse(args);


### PR DESCRIPTION
When performSearchReplace throw exception we need to capture it and return file not found to the model instead of creating system error