### PR TITLE
Add support for reading image files as viewable images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wonderwhy-er/desktop-commander",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wonderwhy-er/desktop-commander",
-      "version": "0.1.28",
+      "version": "0.1.29",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.8.0",

--- a/src/server.ts
+++ b/src/server.ts
@@ -39,6 +39,7 @@ import {
   searchFiles,
   getFileInfo,
   listAllowedDirectories,
+  type FileResult,
 } from './tools/filesystem.js';
 import { parseEditBlock, performSearchReplace } from './tools/edit.js';
 import { searchTextInFiles } from './tools/search.js';
@@ -149,8 +150,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         name: "read_file",
         description:
           "Read the complete contents of a file from the file system. " +
-          "Reads UTF-8 text and provides detailed error messages " +
-          "if the file cannot be read. Only works within allowed directories.",
+          "Handles text files normally and image files are returned as viewable images. " +
+          "Recognized image types: PNG, JPEG, GIF, BMP, SVG, WebP, ICO, TIFF. " +
+          "Only works within allowed directories.",
         inputSchema: zodToJsonSchema(ReadFileArgsSchema),
       },
       {
@@ -158,6 +160,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         description:
           "Read the contents of multiple files simultaneously. " +
           "Each file's content is returned with its path as a reference. " +
+          "Handles text files normally and renders images as viewable content. " +
           "Failed reads for individual files won't stop the entire operation. " +
           "Only works within allowed directories.",
         inputSchema: zodToJsonSchema(ReadMultipleFilesArgsSchema),
@@ -316,10 +319,30 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
         capture('server_read_file');
         try {
             const parsed = ReadFileArgsSchema.parse(args);
-            const content = await readFile(parsed.path);
-            return {
-                content: [{ type: "text", text: content }],
-            };
+            // Explicitly cast the result to FileResult since we're passing true
+            const fileResult = await readFile(parsed.path, true) as FileResult;
+            
+            if (fileResult.isImage) {
+                // For image files, return as an image content type
+                return {
+                    content: [
+                        { 
+                            type: "text", 
+                            text: `Image file: ${parsed.path} (${fileResult.mimeType})\n` 
+                        },
+                        {
+                            type: "image",
+                            data: fileResult.content,
+                            mimeType: fileResult.mimeType
+                        }
+                    ],
+                };
+            } else {
+                // For all other files, return as text
+                return {
+                    content: [{ type: "text", text: fileResult.content }],
+                };
+            }
         } catch (error) {
             const errorMessage = error instanceof Error ? error.message : String(error);
             return {
@@ -331,10 +354,46 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
         capture('server_read_multiple_files');
         try {
             const parsed = ReadMultipleFilesArgsSchema.parse(args);
-            const results = await readMultipleFiles(parsed.paths);
-            return {
-            content: [{ type: "text", text: results.join("\n---\n") }],
-            };
+            const fileResults = await readMultipleFiles(parsed.paths);
+            
+            // Create a text summary of all files
+            const textSummary = fileResults.map(result => {
+                if (result.error) {
+                    return `${result.path}: Error - ${result.error}`;
+                } else if (result.mimeType) {
+                    return `${result.path}: ${result.mimeType} ${result.isImage ? '(image)' : '(text)'}`;
+                } else {
+                    return `${result.path}: Unknown type`;
+                }
+            }).join("\n");
+            
+            // Create content items for each file
+            const contentItems: Array<{type: string, text?: string, data?: string, mimeType?: string}> = [];
+            
+            // Add the text summary
+            contentItems.push({ type: "text", text: textSummary });
+            
+            // Add each file content
+            for (const result of fileResults) {
+                if (!result.error && result.content !== undefined) {
+                    if (result.isImage && result.mimeType) {
+                        // For image files, add an image content item
+                        contentItems.push({
+                            type: "image",
+                            data: result.content,
+                            mimeType: result.mimeType
+                        });
+                    } else {
+                        // For text files, add a text summary
+                        contentItems.push({
+                            type: "text",
+                            text: `\n--- ${result.path} contents: ---\n${result.content}`
+                        });
+                    }
+                }
+            }
+            
+            return { content: contentItems };
         } catch (error) {
             const errorMessage = error instanceof Error ? error.message : String(error);
             return {

--- a/src/server.ts
+++ b/src/server.ts
@@ -151,7 +151,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         description:
           "Read the complete contents of a file from the file system. " +
           "Handles text files normally and image files are returned as viewable images. " +
-          "Recognized image types: PNG, JPEG, GIF, BMP, SVG, WebP, ICO, TIFF. " +
+          "Recognized image types: PNG, JPEG, GIF, WebP. " +
           "Only works within allowed directories.",
         inputSchema: zodToJsonSchema(ReadFileArgsSchema),
       },
@@ -161,6 +161,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           "Read the contents of multiple files simultaneously. " +
           "Each file's content is returned with its path as a reference. " +
           "Handles text files normally and renders images as viewable content. " +
+          "Recognized image types: PNG, JPEG, GIF, WebP. " +
           "Failed reads for individual files won't stop the entire operation. " +
           "Only works within allowed directories.",
         inputSchema: zodToJsonSchema(ReadMultipleFilesArgsSchema),

--- a/src/tools/edit.ts
+++ b/src/tools/edit.ts
@@ -6,19 +6,23 @@ interface SearchReplace {
 }
 
 export async function performSearchReplace(filePath: string, block: SearchReplace): Promise<void> {
+    // Read file as plain string (don't pass true to get just the string)
     const content = await readFile(filePath);
     
+    // Make sure content is a string
+    const contentStr = typeof content === 'string' ? content : content.content;
+    
     // Find first occurrence
-    const searchIndex = content.indexOf(block.search);
+    const searchIndex = contentStr.indexOf(block.search);
     if (searchIndex === -1) {
         throw new Error(`Search content not found in ${filePath}`);
     }
 
     // Replace content
     const newContent = 
-        content.substring(0, searchIndex) + 
+        contentStr.substring(0, searchIndex) + 
         block.replace + 
-        content.substring(searchIndex + block.search.length);
+        contentStr.substring(searchIndex + block.search.length);
 
     await writeFile(filePath, newContent);
 }

--- a/src/tools/mime-types.ts
+++ b/src/tools/mime-types.ts
@@ -1,0 +1,32 @@
+// Simple MIME type detection based on file extension
+export function getMimeType(filePath: string): string {
+  const extension = filePath.toLowerCase().split('.').pop() || '';
+  
+  // Image types
+  const imageTypes: Record<string, string> = {
+    'png': 'image/png',
+    'jpg': 'image/jpeg',
+    'jpeg': 'image/jpeg',
+    'gif': 'image/gif',
+    'bmp': 'image/bmp',
+    'svg': 'image/svg+xml',
+    'webp': 'image/webp',
+    'ico': 'image/x-icon',
+    'tif': 'image/tiff',
+    'tiff': 'image/tiff',
+  };
+  
+  // Text types - consider everything else as text for simplicity
+  
+  // Check if the file is an image
+  if (extension in imageTypes) {
+    return imageTypes[extension];
+  }
+  
+  // Default to text/plain for all other files
+  return 'text/plain';
+}
+
+export function isImageFile(mimeType: string): boolean {
+  return mimeType.startsWith('image/');
+}

--- a/src/tools/mime-types.ts
+++ b/src/tools/mime-types.ts
@@ -2,21 +2,14 @@
 export function getMimeType(filePath: string): string {
   const extension = filePath.toLowerCase().split('.').pop() || '';
   
-  // Image types
+  // Image types - only the formats we can display
   const imageTypes: Record<string, string> = {
     'png': 'image/png',
     'jpg': 'image/jpeg',
     'jpeg': 'image/jpeg',
     'gif': 'image/gif',
-    'bmp': 'image/bmp',
-    'svg': 'image/svg+xml',
-    'webp': 'image/webp',
-    'ico': 'image/x-icon',
-    'tif': 'image/tiff',
-    'tiff': 'image/tiff',
+    'webp': 'image/webp'
   };
-  
-  // Text types - consider everything else as text for simplicity
   
   // Check if the file is an image
   if (extension in imageTypes) {


### PR DESCRIPTION
This PR enhances the file reading capabilities by adding proper image handling to the `read_file` and `read_multiple_files` tools. When reading image files (PNG, JPEG, GIF, BMP, SVG, WebP, ICO, TIFF), the content is now displayed as a viewable image rather than raw binary data.

This allows AI to see what is in the images

## Key changes:
- Added MIME type detection based on file extensions
- Enhanced file reading to handle both text and image files appropriately
- Updated tool descriptions to communicate the new image support
- Return type-appropriate metadata for both individual and multiple file operations

![image](https://github.com/user-attachments/assets/a27d6e56-90b8-4125-80f3-bbcda28d09af)
