### PR TITLE
Handle offset overflow message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@wonderwhy-er/desktop-commander",
-      "version": "0.1.39",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.8.0",

--- a/src/tools/filesystem.ts
+++ b/src/tools/filesystem.ts
@@ -319,15 +319,25 @@ export async function readFileFromDisk(filePath: string, offset: number = 0, len
                 const totalLines = lines.length;
                 
                 // Apply line-based offset and length
-                const startLine = Math.min(offset, totalLines);
+                let startLine = offset;
+                let offsetBeyondFile = false;
+                if (offset >= totalLines) {
+                    // If offset goes beyond file end, show last lines
+                    offsetBeyondFile = true;
+                    startLine = Math.max(totalLines - length, 0);
+                }
                 const endLine = Math.min(startLine + length, totalLines);
                 const selectedLines = lines.slice(startLine, endLine);
                 const truncatedContent = selectedLines.join('\n');
-                
+
                 // Add an informational message if truncated
                 let content = truncatedContent;
                 if (offset > 0 || endLine < totalLines) {
-                    content = `[Reading ${endLine - startLine} lines from line ${offset} of ${totalLines} total lines]\n\n${truncatedContent}`;
+                    let info = `[Reading ${endLine - startLine} lines from line ${offset} of ${totalLines} total lines]`;
+                    if (offsetBeyondFile) {
+                        info += `\n[Offset beyond file, showing last ${endLine - startLine} lines]`;
+                    }
+                    content = `${info}\n\n${truncatedContent}`;
                 }
                 
                 return { content, mimeType, isImage };

--- a/test/test-readfile-offset.js
+++ b/test/test-readfile-offset.js
@@ -1,0 +1,46 @@
+import { readFile } from '../dist/tools/filesystem.js';
+import { configManager } from '../dist/config-manager.js';
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const TEST_FILE = path.join(__dirname, 'offset-test.txt');
+const TOTAL_LINES = 800;
+const OFFSET = 1000;
+const LENGTH = 100;
+
+async function setup() {
+  await configManager.setValue('allowedDirectories', [__dirname]);
+  const lines = Array.from({length: TOTAL_LINES}, (_, i) => `line ${i + 1}`).join('\n');
+  await fs.writeFile(TEST_FILE, lines);
+}
+
+async function teardown() {
+  await fs.rm(TEST_FILE, { force: true });
+}
+
+async function testReadFileOffset() {
+  await setup();
+  try {
+    const result = await readFile(TEST_FILE, false, OFFSET, LENGTH);
+    const content = typeof result === 'string' ? result : result.content;
+    const lines = content.split('\n').slice(-LENGTH); // last LENGTH lines of output
+    for (let i = 0; i < LENGTH; i++) {
+      const expected = `line ${TOTAL_LINES - LENGTH + 1 + i}`;
+      if (lines[i].trim() !== expected) {
+        throw new Error(`Expected ${expected} but got ${lines[i]}`);
+      }
+    }
+    if (!content.includes('Offset beyond file')) {
+      throw new Error('Expected offset beyond file message');
+    }
+    return true;
+  } finally {
+    await teardown();
+  }
+}
+
+export default testReadFileOffset;


### PR DESCRIPTION
## **User description**
## Summary
- show an additional message when offset exceeds file size in `readFileFromDisk`
- check for that message in the regression test

## Testing
- `npm test` *(fails: Test directory should be accessible)*


___

## **CodeAnt-AI Description**
- Enhanced the `readFileFromDisk` function to detect when the requested offset is beyond the end of the file and display an informational message indicating that the last lines are being shown.
- Improved the formatting of informational messages for truncated file reads.
- Added a new regression test (`test/test-readfile-offset.js`) to verify that the offset overflow message is displayed and that the correct lines are returned when the offset exceeds the file size.
- Updated the project version in `package-lock.json` from 0.1.39 to 0.2.0.

This PR improves the robustness and user feedback of file reading operations by clearly indicating when an offset is out of bounds and ensuring this behavior is covered by automated tests. The changes help prevent confusion for users and make file reading behavior more predictable.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>filesystem.ts</strong><dd><code>Add offset overflow detection and messaging to file reading logic</code></dd></summary>
<hr>

src/tools/filesystem.ts
<li>Enhanced <code>readFileFromDisk</code> to detect when the offset exceeds the file <br>size.<br> <li> Added a user-facing informational message when the offset is beyond <br>the file, indicating that the last lines are being shown.<br> <li> Improved the informational message formatting for truncated file <br>reads.<br>


</details>


  </td>
  <td><a href="https://github.com/wonderwhy-er/DesktopCommanderMCP/pull/128/files#diff-1a8b3584a0ec298361606d5d8abf099962f6ecbc601c268ba5f0739eb90f4ea1">+13/-3</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test-readfile-offset.js</strong><dd><code>Add regression test for offset overflow file reading behavior</code>&nbsp; &nbsp; </dd></summary>
<hr>

test/test-readfile-offset.js
<li>Added a new regression test to verify file reading behavior when the <br>offset exceeds the file size.<br> <li> Test checks for the presence of the new offset overflow message in the <br>output.<br> <li> Includes setup and teardown logic for test file creation and cleanup.<br>


</details>


  </td>
  <td><a href="https://github.com/wonderwhy-er/DesktopCommanderMCP/pull/128/files#diff-c74a9485a1d172565eedcff015f1ae820ef79a05141c3d1077a3f7097399d23f">+46/-0</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Miscellaneous
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package-lock.json</strong><dd><code>Bump project version in package-lock.json</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package-lock.json
- Updated project version from 0.1.39 to 0.2.0.



</details>


  </td>
  <td><a href="https://github.com/wonderwhy-er/DesktopCommanderMCP/pull/128/files#diff-053150b640a7ce75eff69d1a22cae7f0f94ad64ce9a855db544dda0929316519">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
