### PR TITLE
Fix defaultShell configuration not working on Windows

### DIFF
--- a/src/terminal-manager.ts
+++ b/src/terminal-manager.ts
@@ -22,7 +22,7 @@ export class TerminalManager {
     if (!shellToUse) {
       try {
         const config = await configManager.getConfig();
-        shellToUse = config.shell || true;
+        shellToUse = config.defaultShell || true;
       } catch (error) {
         // If there's an error getting the config, fall back to default
         shellToUse = true;


### PR DESCRIPTION
### Problem
The `defaultShell` configuration setting was not working on Windows environments. Users had to explicitly specify the `shell` parameter in every `execute_command` call, even when `defaultShell` was properly configured.

### Root Cause
The issue was in the `executeCommand` method where the code was referencing `config.shell` instead of `config.defaultShell`. While the configuration was correctly saved as `defaultShell`, the execution logic was looking for a different property name.

**Debug output showing the issue:**
```json
{
  \"defaultShell\": \"pwsh\",     // ✅ Correctly saved
  \"config.shell\": undefined,  // ❌ Code was checking this
  \"config.defaultShell\": \"pwsh\" // ✅ Should check this instead
}
```

### Solution
Changed the property reference from `config.shell` to `config.defaultShell` in the shell resolution logic.

**Before:**
```typescript
shellToUse = config.shell || true;
```

**After:**
```typescript
shellToUse = config.defaultShell || true;
```

### Testing
- ✅ Tested on Windows 11 with PowerShell 7.5.1
- ✅ `defaultShell: \"pwsh\"` now works without explicit shell parameter
- ✅ Existing explicit shell parameter functionality remains unchanged
- ✅ Fallback to system default still works when no configuration is set

### Impact
- Fixes Windows users' workflow where defaultShell setting was ignored
- Maintains backward compatibility
- No breaking changes to existing functionality