### PR TITLE
Improve write_file warning message for better UX

### DIFF
--- a/src/handlers/filesystem-handlers.ts
+++ b/src/handlers/filesystem-handlers.ts
@@ -162,16 +162,13 @@ export async function handleWriteFile(args: unknown): Promise<ServerResult> {
         const config = await configManager.getConfig();
         const MAX_LINES = config.fileWriteLineLimit ?? 50; // Default to 50 if not set
         
-        // Strictly enforce line count limit
+        // Check line count and provide helpful guidance for large files
         const lines = parsed.content.split('\n');
         const lineCount = lines.length;
-        let errorMessage = "";
+        let noteMessage = "";
         if (lineCount > MAX_LINES) {
-            errorMessage = `File was written with warning: Line count limit exceeded: ${lineCount} lines (maximum: ${MAX_LINES}).
-            
-SOLUTION: Split your content into smaller chunks:
-1. First chunk: write_file(path, firstChunk, {mode: 'rewrite'})
-2. Additional chunks: write_file(path, nextChunk, {mode: 'append'})`;
+            noteMessage = `
+Note: Large file detected (${lineCount} > ${MAX_LINES} lines). For improved reliability and easier debugging, consider splitting large files into smaller chunks using the append mode for future edits.`;
         }
 
         // Pass the mode parameter to writeFile
@@ -183,7 +180,7 @@ SOLUTION: Split your content into smaller chunks:
         return {
             content: [{ 
                 type: "text", 
-                text: `Successfully ${modeMessage} ${parsed.path} (${lineCount} lines) ${errorMessage}`
+                text: `Successfully ${modeMessage} ${parsed.path} (${lineCount} lines)${noteMessage}`
             }],
         };
     } catch (error) {


### PR DESCRIPTION
## Summary
Improves the confusing warning message when write_file exceeds 50 lines.

## Problem
Current message: `Successfully wrote... File was written with warning: Line count limit exceeded...`
This mixed success/warning format confuses AI assistants and users.

## Solution  
New message: `Successfully wrote... Note: Large file detected (...) For improved reliability...`

## Benefits
- Clear success message first
- Educational tone instead of error-like warning  
- Better AI assistant compatibility
- Same helpful guidance, friendlier delivery

## Technical Details
- File: `src/handlers/filesystem-handlers.ts`
- No functional changes, only message formatting
- Maintains existing configuration options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Success messages for large file writes now include a brief advisory note suggesting splitting files into smaller chunks for better reliability and debugging.

- **Style**
  - Replaced detailed warning messages with a concise informational note for large file operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->