### PR TITLE
[llm-auto-fix] fixed code search where filePattern includes multiple values

### DIFF
--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -58,7 +58,10 @@ export async function searchCode(options: {
   }
   
   if (filePattern) {
-    const patterns = filePattern.split('|');
+    const patterns = filePattern
+      .split('|')
+      .map(p => p.trim())      // remove surrounding spaces
+      .filter(Boolean);        // drop empty tokens
     patterns.forEach(p => args.push('-g', p));
   }
   
@@ -117,6 +120,9 @@ export async function searchCode(options: {
               });
             }
           } catch (error) {
+
+
+
 
 
 

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -58,7 +58,8 @@ export async function searchCode(options: {
   }
   
   if (filePattern) {
-    args.push('-g', filePattern);
+    const patterns = filePattern.split('|');
+    patterns.forEach(p => args.push('-g', p));
   }
   
   // Add pattern and path
@@ -116,6 +117,9 @@ export async function searchCode(options: {
               });
             }
           } catch (error) {
+
+
+
             const errorMessage = error instanceof Error ? error.message : String(error);
             capture('server_request_error', {error: `Error parsing ripgrep output: ${errorMessage}`});
             console.error(`Error parsing ripgrep output: ${errorMessage}`);    

--- a/test/test-search-code-edge-cases.js
+++ b/test/test-search-code-edge-cases.js
@@ -448,7 +448,8 @@ export async function testSearchCodeEdgeCases() {
     await testLargeContextLines();
     await testPathTraversalSecurity();
     await testManySmallFiles();
-    
+    await testFilePatternWithMultipleValues();
+
     console.log(`${colors.green}✅ All handleSearchCode edge case tests passed!${colors.reset}`);
     return true;
     


### PR DESCRIPTION
Search code with a single filePattern extension works: `*.js`.
However when LLM specifies multiple (e.g.: `*.ts|*.js|*.py|*.java|*.go`) search breaks.

This is LLM-auto-fix that fixed that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved support for specifying multiple file patterns in code search, allowing more flexible and accurate search results.
- **Tests**
	- Added tests to verify handling of multiple, whitespace-padded, and empty file pattern inputs in code search.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->