### PR TITLE
[llm-auto-fix] fixed build when using MCP via docker setup (STDIO via docker container)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ COPY package*.json ./
 # Install dependencies without triggering any unwanted scripts
 RUN npm install --ignore-scripts
 
+# Run post-install script for @vscode/ripgrep to download the binary
+RUN npm rebuild @vscode/ripgrep
+
 # Copy all source code
 COPY . .
 


### PR DESCRIPTION
basically when using MCP in STDIO mode via `docker run` this is needed, otherwise `ripgrep` cant be found from within a docker container environment.