### PR TITLE
fix: resolve initialization protocol violation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -113,6 +113,17 @@ async function runServer() {
 
 
     console.error("Connecting server...");
+
+    // Set up event-driven initialization completion handler
+    server.oninitialized = () => {
+      // This callback is triggered after the client sends the "initialized" notification
+      // At this point, the MCP protocol handshake is fully complete
+      transport.enableNotifications();
+      process.stderr.write(
+        `[desktop-commander] MCP fully initialized, notifications enabled\n`
+      );
+    };
+
     await server.connect(transport);
     console.error("Server connected successfully");
   } catch (error) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -97,7 +97,8 @@ server.setRequestHandler(InitializeRequestSchema, async (request: InitializeRequ
                 name: clientInfo.name || 'unknown',
                 version: clientInfo.version || 'unknown'
             };
-            console.log(`Client connected: ${currentClient.name} v${currentClient.version}`);
+            // Log to stderr during initialization to avoid protocol violations
+            process.stderr.write(`[desktop-commander] Client connected: ${currentClient.name} v${currentClient.version}\n`);
         }
 
         // Return standard initialization response


### PR DESCRIPTION
Resolves MCP server initialization failures, where clients receive `LoggingMessageNotification` instead of expected initialization response.

### Root Cause
The `FilteredStdioServerTransport` immediately redirected console output to JSON-RPC notifications, causing protocol violations during the initialization phase.

### Solution
- **Added initialization state control**: `isInitialized` flag prevents premature notifications
- **Conditional console redirection**: Output goes to stderr during initialization, JSON-RPC after
- **Proper timing control**: `enableNotifications()` method called after MCP connection established

### Files Modified
- `src/custom-stdio.ts`: Added state control and conditional redirection
- `src/index.ts`: Proper timing for enabling notifications  
- `src/server.ts`: Fixed initialization handler logging

close #188 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved notification control during initialization to prevent protocol violations. Notifications are now only enabled after the system is fully initialized.

* **Bug Fixes**
  * Console and standard output messages during initialization are now correctly redirected to standard error, ensuring protocol compliance.

* **Chores**
  * Enhanced logging to provide clearer status updates during the initialization phase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->