### PR TITLE
Add recursive depth dir listing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wonderwhy-er/desktop-commander",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wonderwhy-er/desktop-commander",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/handlers/filesystem-handlers.ts
+++ b/src/handlers/filesystem-handlers.ts
@@ -209,10 +209,15 @@ export async function handleCreateDirectory(args: unknown): Promise<ServerResult
  */
 export async function handleListDirectory(args: unknown): Promise<ServerResult> {
     try {
+        const startTime = Date.now();
         const parsed = ListDirectoryArgsSchema.parse(args);
-        const entries = await listDirectory(parsed.path);
+        const entries = await listDirectory(parsed.path, parsed.depth);
+        const duration = Date.now() - startTime;
+
+        const resultText = entries.join('\n');
+
         return {
-            content: [{ type: "text", text: entries.join('\n') }],
+            content: [{ type: "text", text: resultText }],
         };
     } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);

--- a/src/server.ts
+++ b/src/server.ts
@@ -324,6 +324,20 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                         
                         Use this instead of 'execute_command' with ls/dir commands.
                         Results distinguish between files and directories with [FILE] and [DIR] prefixes.
+                        
+                        Supports recursive listing with the 'depth' parameter (default: 2):
+                        - depth=1: Only direct contents of the directory
+                        - depth=2: Contents plus one level of subdirectories
+                        - depth=3+: Multiple levels deep
+                        
+                        Results show full relative paths from the root directory being listed.
+                        Example output with depth=2:
+                        [DIR] src
+                        [FILE] src/index.ts
+                        [DIR] src/tools
+                        [FILE] src/tools/filesystem.ts
+                        
+                        If a directory cannot be accessed, it will show [DENIED] instead.
                         Only works within allowed directories.
                         
                         ${PATH_GUIDANCE}

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -63,6 +63,7 @@ export const CreateDirectoryArgsSchema = z.object({
 
 export const ListDirectoryArgsSchema = z.object({
   path: z.string(),
+  depth: z.number().optional().default(2),
 });
 
 export const MoveFileArgsSchema = z.object({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Directory listing now supports depth-controlled recursion (default: 2), allowing inclusion of subdirectories up to the specified level.
  - Outputs show full relative paths for files and folders.
  - Inaccessible directories are clearly labeled as [DENIED] for improved clarity.
- Documentation
  - Updated tool description to explain the depth parameter, examples of depth levels, output format, and [DENIED] behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->