### PR TITLE
Add tool call history

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,7 @@ The server provides a comprehensive set of tools organized into several categori
 | | `get_file_info` | Retrieve detailed metadata about a file or directory |
 | **Text Editing** | `edit_block` | Apply targeted text replacements with enhanced prompting for smaller edits (includes character-level diff feedback) |
 | **Analytics** | `get_usage_stats` | Get usage statistics for your own insight |
+| | `get_recent_tool_calls` | Get recent tool call history with arguments and outputs for debugging and context recovery |
 | | `give_feedback_to_desktop_commander` | Open feedback form in browser to provide feedback to Desktop Commander Team |
 
 ### Quick Examples

--- a/manifest.template.json
+++ b/manifest.template.json
@@ -123,6 +123,10 @@
       "description": "Get usage statistics for debugging and analysis including tool usage and performance metrics."
     },
     {
+      "name": "get_recent_tool_calls",
+      "description": "Get recent tool call history with their arguments and outputs. Returns chronological list of tool calls made during this session for debugging, context recovery, and onboarding new chats."
+    },
+    {
       "name": "give_feedback_to_desktop_commander",
       "description": "Open feedback form in browser to provide feedback about Desktop Commander."
     },

--- a/src/handlers/history-handlers.ts
+++ b/src/handlers/history-handlers.ts
@@ -1,0 +1,40 @@
+import { toolHistory } from '../utils/toolHistory.js';
+import { GetRecentToolCallsArgsSchema } from '../tools/schemas.js';
+import { ServerResult } from '../types.js';
+
+/**
+ * Handle get_recent_tool_calls command
+ */
+export async function handleGetRecentToolCalls(args: unknown): Promise<ServerResult> {
+  try {
+    const parsed = GetRecentToolCallsArgsSchema.parse(args);
+    
+    // Use formatted version with local timezone
+    const calls = toolHistory.getRecentCallsFormatted({
+      maxResults: parsed.maxResults,
+      toolName: parsed.toolName,
+      since: parsed.since
+    });
+    
+    const stats = toolHistory.getStats();
+    
+    // Format the response (excluding file path per user request)
+    const summary = `Tool Call History (${calls.length} results, ${stats.totalEntries} total in memory)`;
+    const historyJson = JSON.stringify(calls, null, 2);
+    
+    return {
+      content: [{
+        type: "text",
+        text: `${summary}\n\n${historyJson}`
+      }]
+    };
+  } catch (error) {
+    return {
+      content: [{
+        type: "text",
+        text: `Error getting tool history: ${error instanceof Error ? error.message : String(error)}`
+      }],
+      isError: true
+    };
+  }
+}

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -4,3 +4,4 @@ export * from './terminal-handlers.js';
 export * from './process-handlers.js';
 export * from './edit-search-handlers.js';
 export * from './search-handlers.js';
+export * from './history-handlers.js';

--- a/src/tools/config.ts
+++ b/src/tools/config.ts
@@ -13,10 +13,24 @@ export async function getConfig() {
     
     // Add system information and current client to the config response
     const systemInfo = getSystemInfo();
+    
+    // Get memory usage
+    const memoryUsage = process.memoryUsage();
+    const memory = {
+      rss: `${(memoryUsage.rss / 1024 / 1024).toFixed(2)} MB`,
+      heapTotal: `${(memoryUsage.heapTotal / 1024 / 1024).toFixed(2)} MB`,
+      heapUsed: `${(memoryUsage.heapUsed / 1024 / 1024).toFixed(2)} MB`,
+      external: `${(memoryUsage.external / 1024 / 1024).toFixed(2)} MB`,
+      arrayBuffers: `${(memoryUsage.arrayBuffers / 1024 / 1024).toFixed(2)} MB`
+    };
+    
     const configWithSystemInfo = {
       ...config,
       currentClient,
-      systemInfo
+      systemInfo: {
+        ...systemInfo,
+        memory
+      }
     };
     
     console.error(`getConfig result: ${JSON.stringify(configWithSystemInfo, null, 2)}`);

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -137,3 +137,10 @@ export const GetPromptsArgsSchema = z.object({
   category: z.string().optional(),
   promptId: z.string().optional(),
 });
+
+// Tool history schema
+export const GetRecentToolCallsArgsSchema = z.object({
+  maxResults: z.number().min(1).max(1000).optional().default(50),
+  toolName: z.string().optional(),
+  since: z.string().datetime().optional(),
+});

--- a/src/utils/toolHistory.ts
+++ b/src/utils/toolHistory.ts
@@ -11,6 +11,10 @@ export interface ToolCallRecord {
   duration?: number;
 }
 
+interface FormattedToolCallRecord extends Omit<ToolCallRecord, 'timestamp'> {
+  timestamp: string; // formatted local time string
+}
+
 // Format timestamp in local timezone for display
 function formatLocalTimestamp(isoTimestamp: string): string {
   const date = new Date(isoTimestamp);
@@ -206,7 +210,7 @@ class ToolHistory {
     maxResults?: number;
     toolName?: string;
     since?: string;
-  }): any[] {
+  }): FormattedToolCallRecord[] {
     const calls = this.getRecentCalls(options);
     
     // Format timestamps to local timezone

--- a/src/utils/toolHistory.ts
+++ b/src/utils/toolHistory.ts
@@ -1,0 +1,229 @@
+import { ServerResult } from '../types.js';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+export interface ToolCallRecord {
+  timestamp: string;
+  toolName: string;
+  arguments: any;
+  output: ServerResult;
+  duration?: number;
+}
+
+// Format timestamp in local timezone for display
+function formatLocalTimestamp(isoTimestamp: string): string {
+  const date = new Date(isoTimestamp);
+  return date.toLocaleString('en-US', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false
+  });
+}
+
+class ToolHistory {
+  private history: ToolCallRecord[] = [];
+  private readonly MAX_ENTRIES = 1000;
+  private readonly historyFile: string;
+  private writeQueue: ToolCallRecord[] = [];
+  private isWriting = false;
+
+  constructor() {
+    // Store history in same directory as config to keep everything together
+    const historyDir = path.join(os.homedir(), '.claude-server-commander');
+    
+    // Ensure directory exists
+    if (!fs.existsSync(historyDir)) {
+      fs.mkdirSync(historyDir, { recursive: true });
+    }
+    
+    // Use append-only JSONL format (JSON Lines)
+    this.historyFile = path.join(historyDir, 'tool-history.jsonl');
+    
+    // Load existing history on startup
+    this.loadFromDisk();
+    
+    // Start async write processor
+    this.startWriteProcessor();
+  }
+
+  /**
+   * Load history from disk (all instances share the same file)
+   */
+  private loadFromDisk(): void {
+    try {
+      if (!fs.existsSync(this.historyFile)) {
+        console.error('[ToolHistory] No history file found, starting fresh');
+        return;
+      }
+
+      const content = fs.readFileSync(this.historyFile, 'utf-8');
+      const lines = content.trim().split('\n').filter(line => line.trim());
+      
+      // Parse each line as JSON
+      const records: ToolCallRecord[] = [];
+      for (const line of lines) {
+        try {
+          records.push(JSON.parse(line));
+        } catch (e) {
+          console.error('[ToolHistory] Failed to parse line:', line);
+        }
+      }
+      
+      // Keep only last 1000 entries
+      this.history = records.slice(-this.MAX_ENTRIES);
+      console.error(`[ToolHistory] Loaded ${this.history.length} entries from disk`);
+      
+      // If file is getting too large, trim it
+      if (lines.length > this.MAX_ENTRIES * 2) {
+        this.trimHistoryFile();
+      }
+    } catch (error) {
+      console.error('[ToolHistory] Failed to load history:', error);
+    }
+  }
+
+  /**
+   * Trim history file to prevent it from growing indefinitely
+   */
+  private trimHistoryFile(): void {
+    try {
+      console.error('[ToolHistory] Trimming history file...');
+      
+      // Keep last 1000 entries in memory
+      const keepEntries = this.history.slice(-this.MAX_ENTRIES);
+      
+      // Write them back
+      const lines = keepEntries.map(entry => JSON.stringify(entry)).join('\n') + '\n';
+      fs.writeFileSync(this.historyFile, lines, 'utf-8');
+      
+      console.error(`[ToolHistory] Trimmed to ${keepEntries.length} entries`);
+    } catch (error) {
+      console.error('[ToolHistory] Failed to trim history file:', error);
+    }
+  }
+
+  /**
+   * Async write processor - batches writes to avoid blocking
+   */
+  private startWriteProcessor(): void {
+    setInterval(() => {
+      if (this.writeQueue.length > 0 && !this.isWriting) {
+        this.flushToDisk();
+      }
+    }, 1000); // Flush every second
+  }
+
+  /**
+   * Flush queued writes to disk
+   */
+  private async flushToDisk(): Promise<void> {
+    if (this.isWriting || this.writeQueue.length === 0) return;
+    
+    this.isWriting = true;
+    const toWrite = [...this.writeQueue];
+    this.writeQueue = [];
+    
+    try {
+      // Append to file (atomic append operation)
+      const lines = toWrite.map(entry => JSON.stringify(entry)).join('\n') + '\n';
+      fs.appendFileSync(this.historyFile, lines, 'utf-8');
+    } catch (error) {
+      console.error('[ToolHistory] Failed to write to disk:', error);
+      // Put back in queue on failure
+      this.writeQueue.unshift(...toWrite);
+    } finally {
+      this.isWriting = false;
+    }
+  }
+
+  /**
+   * Add a tool call to history
+   */
+  addCall(
+    toolName: string, 
+    args: any, 
+    output: ServerResult, 
+    duration?: number
+  ): void {
+    const record: ToolCallRecord = {
+      timestamp: new Date().toISOString(),
+      toolName,
+      arguments: args,
+      output,
+      duration
+    };
+
+    this.history.push(record);
+
+    // Keep only last 1000 in memory
+    if (this.history.length > this.MAX_ENTRIES) {
+      this.history.shift();
+    }
+    
+    // Queue for async write
+    this.writeQueue.push(record);
+  }
+
+  /**
+   * Get recent tool calls with filters
+   */
+  getRecentCalls(options: {
+    maxResults?: number;
+    toolName?: string;
+    since?: string;
+  }): ToolCallRecord[] {
+    let results = [...this.history];
+
+    // Filter by tool name
+    if (options.toolName) {
+      results = results.filter(r => r.toolName === options.toolName);
+    }
+
+    // Filter by timestamp
+    if (options.since) {
+      const sinceDate = new Date(options.since);
+      results = results.filter(r => new Date(r.timestamp) >= sinceDate);
+    }
+
+    // Limit results (default 50, max 1000)
+    const limit = Math.min(options.maxResults || 50, 1000);
+    return results.slice(-limit);
+  }
+
+  /**
+   * Get recent calls formatted with local timezone
+   */
+  getRecentCallsFormatted(options: {
+    maxResults?: number;
+    toolName?: string;
+    since?: string;
+  }): any[] {
+    const calls = this.getRecentCalls(options);
+    
+    // Format timestamps to local timezone
+    return calls.map(call => ({
+      ...call,
+      timestamp: formatLocalTimestamp(call.timestamp)
+    }));
+  }
+
+  /**
+   * Get current stats
+   */
+  getStats() {
+    return {
+      totalEntries: this.history.length,
+      oldestEntry: this.history[0]?.timestamp,
+      newestEntry: this.history[this.history.length - 1]?.timestamp,
+      historyFile: this.historyFile,
+      queuedWrites: this.writeQueue.length
+    };
+  }
+}
+
+export const toolHistory = new ToolHistory();


### PR DESCRIPTION
Add new tool to capture and query recent tool call history, helps to restore lost chats or pass context between chats about work that was done recently

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Get Recent Tool Calls” tool to view recent tool invocations with filters (tool name, since, max results), durations, and basic stats; included in the tools list.
  * Tool usage is now recorded and persisted across sessions with capped history and batched writes.

* **System Info**
  * System info now includes current memory usage details.

* **Documentation**
  * README updated to document the new tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->