### PR TITLE
Remove verbose console logging from ToolHistory

### DIFF
--- a/src/utils/toolHistory.ts
+++ b/src/utils/toolHistory.ts
@@ -62,33 +62,31 @@ class ToolHistory {
   private loadFromDisk(): void {
     try {
       if (!fs.existsSync(this.historyFile)) {
-        console.error('[ToolHistory] No history file found, starting fresh');
         return;
       }
 
       const content = fs.readFileSync(this.historyFile, 'utf-8');
       const lines = content.trim().split('\n').filter(line => line.trim());
-      
+
       // Parse each line as JSON
       const records: ToolCallRecord[] = [];
       for (const line of lines) {
         try {
           records.push(JSON.parse(line));
         } catch (e) {
-          console.error('[ToolHistory] Failed to parse line:', line);
+          // Silently skip invalid lines
         }
       }
-      
+
       // Keep only last 1000 entries
       this.history = records.slice(-this.MAX_ENTRIES);
-      console.error(`[ToolHistory] Loaded ${this.history.length} entries from disk`);
-      
+
       // If file is getting too large, trim it
       if (lines.length > this.MAX_ENTRIES * 2) {
         this.trimHistoryFile();
       }
     } catch (error) {
-      console.error('[ToolHistory] Failed to load history:', error);
+      // Silently fail
     }
   }
 
@@ -97,18 +95,14 @@ class ToolHistory {
    */
   private trimHistoryFile(): void {
     try {
-      console.error('[ToolHistory] Trimming history file...');
-      
       // Keep last 1000 entries in memory
       const keepEntries = this.history.slice(-this.MAX_ENTRIES);
-      
+
       // Write them back
       const lines = keepEntries.map(entry => JSON.stringify(entry)).join('\n') + '\n';
       fs.writeFileSync(this.historyFile, lines, 'utf-8');
-      
-      console.error(`[ToolHistory] Trimmed to ${keepEntries.length} entries`);
     } catch (error) {
-      console.error('[ToolHistory] Failed to trim history file:', error);
+      // Silently fail
     }
   }
 
@@ -141,7 +135,6 @@ class ToolHistory {
       const lines = toWrite.map(entry => JSON.stringify(entry)).join('\n') + '\n';
       fs.appendFileSync(this.historyFile, lines, 'utf-8');
     } catch (error) {
-      console.error('[ToolHistory] Failed to write to disk:', error);
       // Put back in queue on failure
       this.writeQueue.unshift(...toWrite);
     } finally {


### PR DESCRIPTION
## Summary
- Removed all `console.error` statements from the ToolHistory class that were printing diagnostic messages to stderr
- These messages were mixing with agent output during normal operation

## Issue
Users reported that messages like `[ToolHistory]: Loaded XXX entries from disk` were appearing in their console and interfering with their agent's output.

## Changes
- Removed logging from `loadFromDisk()` method
- Removed logging from `trimHistoryFile()` method  
- Removed logging from `flushToDisk()` method
- ToolHistory now operates silently with all diagnostics suppressed

## Test plan
- [ ] Build the project and verify no compilation errors
- [ ] Run the MCP server and verify no ToolHistory messages appear in console
- [ ] Verify tool history functionality still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced noisy error messages during history processing.
  * Silently skips invalid history entries instead of logging parsing failures.
  * Trimming and write failures no longer surface logs; failed writes are retried automatically.
  * Improves resilience of background processing while keeping history limits and batching unchanged.
  * Results in a quieter, less distracting log experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->