### PR TITLE
fixed bad mkdir call

### DIFF
--- a/setup-claude-server.js
+++ b/setup-claude-server.js
@@ -44,7 +44,7 @@ async function initConfigFile() {
         // Ensure config directory exists
         const configDir = path.dirname(CONFIG_FILE);
         if (!existsSync(configDir)) {
-            await mkdir(configDir, { recursive: true });
+            mkdirSync(configDir, { recursive: true });
         }
 
         // Check if config file exists


### PR DESCRIPTION
Fixed setup error for missing `mkdir` call. Either `mkdirSync` or `fs.mkdir` needs to be called. Used `mkdirSync` since that's what other places in setup file use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improves startup reliability by ensuring the configuration directory is fully created before initialization, reducing intermittent errors on first run or after clearing settings.
* **Refactor**
  * Streamlines configuration setup with a synchronous creation step, providing a more deterministic launch sequence and clearer error handling when filesystem issues occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->