### PR TITLE
fix: Set executable permissions on ripgrep binaries at runtime for MCPB/DXT

### DIFF
--- a/scripts/build-mcpb.cjs
+++ b/scripts/build-mcpb.cjs
@@ -160,7 +160,9 @@ try {
         const src = path.join(ripgrepBinSrc, binary);
         const dest = path.join(ripgrepBinDest, binary);
         fs.copyFileSync(src, dest);
-        // Preserve executable permissions
+        // Set executable permissions (for development/testing)
+        // Note: Zip archives don't preserve permissions reliably, so ripgrep-wrapper.js
+        // also sets permissions at runtime to ensure compatibility after extraction
         if (!binary.endsWith('.exe')) {
             fs.chmodSync(dest, 0o755);
         }

--- a/scripts/ripgrep-wrapper.js
+++ b/scripts/ripgrep-wrapper.js
@@ -34,15 +34,32 @@ const binaryName = isWindows ? `rg-${target}.exe` : `rg-${target}`;
 // __dirname is lib/, so go up one level to reach bin/
 const rgPath = path.join(__dirname, '..', 'bin', binaryName);
 
-// Verify binary exists
+// Verify binary exists and ensure executable permissions
 if (!fs.existsSync(rgPath)) {
   // Try fallback to original rg location
   const fallbackPath = path.join(__dirname, '..', 'bin', isWindows ? 'rg.exe' : 'rg');
   if (fs.existsSync(fallbackPath)) {
+    // Ensure executable permissions on Unix systems
+    if (!isWindows) {
+      try {
+        fs.chmodSync(fallbackPath, 0o755);
+      } catch (err) {
+        // Ignore permission errors - might not have write access
+      }
+    }
     module.exports.rgPath = fallbackPath;
   } else {
     throw new Error(`ripgrep binary not found for platform ${target}: ${rgPath}`);
   }
 } else {
+  // Ensure executable permissions on Unix systems
+  // This fixes issues when extracting from zip archives that don't preserve permissions
+  if (!isWindows) {
+    try {
+      fs.chmodSync(rgPath, 0o755);
+    } catch (err) {
+      // Ignore permission errors - might not have write access
+    }
+  }
   module.exports.rgPath = rgPath;
 }


### PR DESCRIPTION
## **User description**
Zip archives don't reliably preserve Unix file permissions across platforms. This causes EACCES errors when ripgrep binaries are extracted without executable permissions on macOS/Linux.

Solution: ripgrep-wrapper.js now sets 0o755 permissions at runtime when the module is first loaded, ensuring binaries are always executable regardless of how they were extracted.

Fixes: spawn rg-aarch64-apple-darwin EACCES on macOS


___

## **CodeAnt-AI Description**
**Make ripgrep binaries executable at runtime to prevent EACCES on macOS/Linux**

### What Changed
- The ripgrep loader now sets executable permissions for the selected binary and for the fallback binary on macOS/Linux so ripgrep runs instead of failing with EACCES.
- The build script sets executable permissions on copied platform-specific ripgrep binaries so development/test bundles include runnable binaries.
- Permission-setting failures are ignored (won't crash startup), so the app continues even if it can't change file permissions.

### Impact
`✅ No ripgrep EACCES on macOS/Linux`
`✅ Search works after extracting archives that lose execute bits`
`✅ Dev/test bundles include runnable ripgrep binaries`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Executable permissions are now automatically enforced for the ripgrep binary on Unix-based systems across primary and fallback paths.
  * Added error handling for permission operations.

* **Documentation**
  * Updated documentation clarifying executable permission requirements and archive extraction considerations for binary setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->