### PR TITLE
fix: Use cmd /c wrapper for npx on Windows

### DIFF
--- a/setup-claude-server.js
+++ b/setup-claude-server.js
@@ -757,8 +757,9 @@ export default async function setup() {
                     // Debug with npx
                     logToFile('Setting up debug configuration with npx. The process will pause on start until a debugger connects.');
                     // Add environment variables to help with debugging
+                    // Inspector flag must be in NODE_OPTIONS, not passed as npx argument
                     const debugEnv = {
-                        "NODE_OPTIONS": "--trace-warnings --trace-exit",
+                        "NODE_OPTIONS": "--inspect-brk=9229 --trace-warnings --trace-exit",
                         "DEBUG": "*"
                     };
 
@@ -771,7 +772,6 @@ export default async function setup() {
                             "args": [
                                 "/c",
                                 "npx",
-                                "--inspect-brk=9229",
                                 packageSpec
                             ],
                             "env": debugEnv
@@ -780,7 +780,6 @@ export default async function setup() {
                         serverConfig = {
                             "command": "npx",
                             "args": [
-                                "--inspect-brk=9229",
                                 packageSpec
                             ],
                             "env": debugEnv


### PR DESCRIPTION
## **User description**
## Problem

On Windows, using `npx.cmd` or just `npx` directly in MCP server configurations has been failing with errors like:
- `Cannot read properties of undefined (reading 'cmd')`
- Connection failures when Claude Desktop tries to start the server

## Root Cause

Windows requires a `cmd /c` wrapper to properly execute npx commands because:
- Node.js has difficulties spawning batch files like `npx.cmd` without setting the shell option
- npx is a script, not a traditional binary executable
- This is the officially recommended approach by Anthropic

## Solution

Updated `setup-claude-server.js` to use the `cmd /c` wrapper pattern for Windows npx installations:

**Before:**
```json
{
  "command": "npx.cmd",
  "args": ["@wonderwhy-er/desktop-commander"]
}
```

**After:**
```json
{
  "command": "cmd",
  "args": ["/c", "npx", "-y", "@wonderwhy-er/desktop-commander"]
}
```

## Changes

- ✅ Updated debug npx configuration to use `cmd /c` wrapper
- ✅ Updated standard npx configuration to use `cmd /c` wrapper  
- ✅ Added `-y` flag to auto-accept npx prompts in standard mode
- ✅ Maintains compatibility with macOS/Linux (unchanged)

## References

- [Anthropic MCP Windows Documentation](https://docs.anthropic.com/en/docs/claude-code/mcp#configure-mcp-servers)
- [GitHub Issue: Windows npx wrapper requirement](https://github.com/anthropics/claude-code/issues/9594)
- Example from Smithery MCP servers using this pattern

## Testing

Tested on Windows 11 with:
- Claude Desktop latest version
- Node.js v22.17.1
- Both npx and local installation modes


___

## **CodeAnt-AI Description**
Wrap Windows npx server launches with cmd /c

### What Changed
- Windows debug mode now starts via `cmd /c npx --inspect-brk=9229` so the debugger-targeted process launches instead of failing to spawn npx directly
- Windows standard mode now runs `cmd /c npx -y`, aligning with the existing Linux/macOS flow and preventing npx from hanging on prompts

### Impact
`✅ Fewer Windows startup failures`
`✅ Reliable debugger attachment on Windows`
`✅ No manual prompts when launching npx on Windows`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows handling for starting the server, ensuring debug/instrumentation flags work reliably.
  * Uniform application of environment settings across platforms.

* **Refactor**
  * Standardized invocation paths so installation/start commands behave consistently on Windows and non-Windows.
  * Added automatic confirmation for command-line installs and clarified debug vs. normal start flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->