### PR TITLE
Fix MCP stdio protocol violation during startup (Docker/langchain compatibility)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,13 @@ async function runServer() {
     // Set global flag for onboarding control
     (global as any).disableOnboarding = DISABLE_ONBOARDING;
 
+    // Create transport FIRST so all logging gets properly buffered
+    // This must happen before any code that might use logger.*
+    const transport = new FilteredStdioServerTransport();
+    
+    // Export transport for use throughout the application
+    global.mcpTransport = transport;
+
       try {
           deferLog('info', 'Loading configuration...');
           await configManager.loadConfig();
@@ -56,10 +63,6 @@ async function runServer() {
           // Continue anyway - we'll use an in-memory config
       }
 
-    const transport = new FilteredStdioServerTransport();
-    
-    // Export transport for use throughout the application
-    global.mcpTransport = transport;
     // Handle uncaught exceptions
     process.on('uncaughtException', async (error) => {
       const errorMessage = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## **User description**
## Problem

After commit cc89540 (v0.2.19+), Desktop Commander fails to work with certain MCP clients like `langchain-mcp-adapters` and in Docker environments. The client receives `anyio.BrokenResourceError` when trying to fetch tools.

Reported by @ever1022 in GitHub issue comments.

## Root Cause

The MCP stdio protocol requires the **client to send the first message**. Any server output to stdout before the client's initialization request breaks the protocol handshake.

The issue was a timing problem in the initialization sequence:

```
BEFORE (broken):
1. Load config
2. Initialize feature flags  ← logger.* calls write to stdout here!
3. Create transport           ← Too late, damage done
4. Set global.mcpTransport
```

When `featureFlagManager.initialize()` ran, `global.mcpTransport` didn't exist yet, so `logger.ts` fell back to writing JSON-RPC notifications directly to stdout. Additionally, even when the transport existed, `sendLog()` didn't check `isInitialized` before writing.

## Solution

1. **Move transport creation before config loading** - so all logging gets properly buffered from the start

2. **Buffer `sendLog()` messages** - when `isInitialized` is false, store in buffer for replay after MCP handshake

3. **Guard `sendProgress`/`sendCustomNotification`** - silently drop when not initialized

```
AFTER (fixed):
1. Create transport           ← First thing!
2. Set global.mcpTransport    ← All logging now buffered
3. Load config
4. Initialize feature flags   ← Logs buffered, not written to stdout
5. MCP handshake completes
6. Buffered messages replayed
```

## Testing

Created a test script that:
1. Spawns Desktop Commander
2. Waits 3 seconds without sending any message
3. Verifies no stdout output occurred
4. Sends proper MCP initialize request
5. Confirms server responds correctly

**Before fix:** Server wrote JSON-RPC notifications to stdout before client message
**After fix:** No premature stdout output, server responds correctly

## Files Changed

- `src/index.ts` - Move transport creation before config/feature flags init
- `src/custom-stdio.ts` - Add buffering to `sendLog()`, guard `sendProgress`/`sendCustomNotification`


___

## **CodeAnt-AI Description**
Prevent MCP server from writing to stdout before client handshake

### What Changed
- Initialize the MCP transport before loading configuration so all startup logs are buffered instead of written directly to stdout
- Buffer log notifications until the MCP connection is initialized, then replay them without violating the "client sends first message" requirement
- Suppress progress and custom notifications until initialization completes so MCP clients no longer see protocol errors during startup

### Impact
 `✅ Fewer MCP startup failures`
 `✅ Reliable connections with langchain MCP adapters and Docker clients`
 `✅ No stray server logs before MCP client handshake`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented loss and out-of-order delivery of logs, progress updates, and custom notifications during startup by buffering and gating them until the system is ready.

* **Chores**
  * Moved transport initialization earlier so message infrastructure is available from process start.
  * Reduced noisy startup logs and made background refresh timer non-blocking so the process can exit cleanly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->