### PR TITLE
fix: Windows build compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "testemonials"
   ],
   "scripts": {
-    "postinstall": "node dist/track-installation.js && node dist/npm-scripts/verify-ripgrep.js || true",
+    "postinstall": "node dist/track-installation.js && node dist/npm-scripts/verify-ripgrep.js || node -e \"process.exit(0)\"",
     "open-chat": "open -n /Applications/Claude.app",
     "sync-version": "node scripts/sync-version.js",
     "bump": "node scripts/sync-version.js --bump",
@@ -32,7 +32,7 @@
     "watch": "tsc --watch",
     "start": "node dist/index.js",
     "start:debug": "node --inspect-brk=9229 dist/index.js",
-    "setup": "npm install && npm run build && node setup-claude-server.js",
+    "setup": "npm install --include=dev && npm run build && node setup-claude-server.js",
     "setup:debug": "npm install && npm run build && node setup-claude-server.js --debug",
     "remove": "npm install && npm run build && node uninstall-claude-server.js",
     "prepare": "npm run build",

--- a/src/utils/ripgrep-resolver.ts
+++ b/src/utils/ripgrep-resolver.ts
@@ -33,10 +33,11 @@ export async function getRipgrepPath(): Promise<string> {
     // @vscode/ripgrep import or binary resolution failed, continue to fallbacks
   }
 
-  // Strategy 2: Try system ripgrep using 'which' command
+  // Strategy 2: Try system ripgrep using 'which' (Unix) or 'where' (Windows)
   try {
     const systemRg = process.platform === 'win32' ? 'rg.exe' : 'rg';
-    const result = execSync(`which ${systemRg}`, { encoding: 'utf-8' }).trim();
+    const whichCmd = process.platform === 'win32' ? 'where' : 'which';
+    const result = execSync(`${whichCmd} ${systemRg}`, { encoding: 'utf-8' }).trim().split(/\r?\n/)[0];
     if (result && existsSync(result)) {
       cachedRgPath = result;
       return result;


### PR DESCRIPTION
## **User description**
## Changes

This PR fixes several Windows-specific build issues:

### 1. Use \where\ instead of \which\ on Windows
- \which\ doesn't exist on Windows; \where\ is the equivalent
- Also handles \where\ returning multiple lines by taking the first result

### 2. Replace \|| true\ with cross-platform fallback
- \	rue\ is a Unix command that doesn't exist on Windows cmd.exe
- Changed to \|| node -e "process.exit(0)"\ which works on all platforms

### 3. Add \--include=dev\ to setup script
- If \NODE_ENV=production\ is set (common on Windows), npm skips devDependencies
- \--include=dev\ forces them to install regardless, ensuring TypeScript and other build tools are available

## Testing
Tested on Windows with \NODE_ENV=production\ set globally - \
pm run setup\ now completes successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved cross-platform compatibility for development setup on Windows and Unix systems.
  * Enhanced binary resolution process to handle platform-specific paths more robustly.
  * Refined installation procedure to ensure all development dependencies are properly installed before setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Fix Windows build and installation so setup and ripgrep detection work**

### What Changed
- System ripgrep is correctly detected on Windows; when multiple locations are returned the first valid path is used so features that rely on ripgrep find the binary.
- The postinstall fallback no longer depends on a Unix-only shell construct, preventing postinstall from failing on Windows.
- The setup script now forces devDependencies to be installed even when NODE_ENV=production, ensuring build tools are present so setup completes.

### Impact
`✅ Fewer Windows setup failures`
`✅ Search/ripgrep features work on Windows`
`✅ Setup succeeds with NODE_ENV=production`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
