### PR TITLE
fix: handle empty string params in edit_block for clients requiring all parameters

### DIFF
--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -137,8 +137,12 @@ export const EditBlockArgsSchema = z.object({
   content: z.any().optional(),
   options: z.record(z.any()).optional()
 }).refine(
-  data => (data.old_string !== undefined && data.new_string !== undefined) ||
-          (data.range !== undefined && data.content !== undefined),
+  data => {
+    // Helper to check if value is actually provided (not undefined, not empty string)
+    const hasValue = (v: unknown) => v !== undefined && v !== '';
+    return (hasValue(data.old_string) && hasValue(data.new_string)) ||
+           (hasValue(data.range) && hasValue(data.content));
+  },
   { message: "Must provide either (old_string + new_string) or (range + content)" }
 );
 


### PR DESCRIPTION
## Problem

Some AI clients (e.g., OpenAI/ChatGPT) treat optional MCP parameters as required and send empty strings (`""`) instead of omitting them. This caused `edit_block` to incorrectly enter Excel/range mode when editing text files, resulting in:

```
Error: Range-based editing not supported for .../file.md
```

## Root Cause

The mode detection logic only checked `!== undefined`:
```typescript
if (parsed.range !== undefined && parsed.content !== undefined) {
    // Enters Excel mode even when range="" and content=""
}
```

## Solution

- Treat empty strings as "not provided" in mode detection
- Update schema validation to match  
- Use `createErrorResponse()` for proper analytics capture
- Improve error message with guidance for AI models

## Changes

- `src/tools/edit.ts`: Fixed mode detection, added analytics capture, improved error message
- `src/tools/schemas.ts`: Updated refine validation to handle empty strings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Implemented consistent error handling across edit operations for improved error messaging
* Enhanced validation logic to properly distinguish between missing and empty parameters in text replacement and range-based editing
* Strengthened parameter validation to ensure required fields are present before processing edits

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->