### PR TITLE
fix: default to zsh on macOS when SHELL env var is not set

### DIFF
--- a/src/config-manager.ts
+++ b/src/config-manager.ts
@@ -136,8 +136,11 @@ class ConfigManager {
         if (os.platform() === 'win32') {
           return 'powershell.exe';
         }
-        // Use user's actual shell from environment, or fall back to /bin/sh
-        const userShell = process.env.SHELL || '/bin/sh';
+        // Use user's actual shell from environment
+        // On macOS, default to zsh (default since Catalina) since process.env.SHELL
+        // may not be set when running inside Claude Desktop
+        const fallbackShell = os.platform() === 'darwin' ? '/bin/zsh' : '/bin/sh';
+        const userShell = process.env.SHELL || fallbackShell;
         // Return just the shell path - we'll handle login shell flag elsewhere
         return userShell;
       })(),


### PR DESCRIPTION
## **User description**
## Problem

When running inside Claude Desktop, `process.env.SHELL` may not be set, causing Desktop Commander to fall back to `/bin/sh`. This results in the user's shell profile (`.zprofile`, `.zshrc`) not being sourced properly.

This breaks tools that depend on PATH additions from:
- Homebrew (`brew shellenv`)
- gcloud SDK
- nvm, pyenv, rbenv
- Any custom PATH modifications in shell configs

## Solution

On macOS, default to `/bin/zsh` instead of `/bin/sh` when `process.env.SHELL` is not available.

Since macOS Catalina (10.15), zsh has been the default shell, so this change ensures proper environment sourcing for the vast majority of macOS users.

## Changes

- Modified `getDefaultConfig()` in `config-manager.ts` to use `/bin/zsh` as fallback on darwin platform

## Testing

Verified that after this change, commands like `which gcloud` work correctly when gcloud is installed via Homebrew cask (which creates a symlink in `/opt/homebrew/bin/`).

## Notes

This only affects new installations. Existing users who already have `/bin/sh` in their config can update it via:
```
set_config_value defaultShell /bin/zsh
```


___

## **CodeAnt-AI Description**
Default to zsh on macOS when SHELL is not set, and adjust file I/O and onboarding defaults

### What Changed
- On macOS, when the user's SHELL environment variable is missing, the app now uses /bin/zsh instead of /bin/sh so shell profiles (and PATH changes from Homebrew, gcloud, nvm, etc.) are sourced correctly
- File write operations now use a 50-line default limit (previously 100); file reads use a 1000-line default instead of the prior character-based limit
- New installs will have the welcome onboarding flag enabled to participate in the welcome page A/B test

### Impact
`✅ Fewer missing PATHs on macOS when running inside the desktop app`
`✅ Correct detection of Homebrew/gcloud/nvm tools on macOS`
`✅ New users see the welcome onboarding`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced shell configuration detection to work reliably across all platforms, including systems where environment variables are not set.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->