### PR TITLE
fix: Use SDK protocol version negotiation instead of hardcoded value

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,8 @@ import {
     ListResourceTemplatesRequestSchema,
     ListPromptsRequestSchema,
     InitializeRequestSchema,
+    LATEST_PROTOCOL_VERSION,
+    SUPPORTED_PROTOCOL_VERSIONS,
     type CallToolRequest,
     type InitializeRequest,
 } from "@modelcontextprotocol/sdk/types.js";
@@ -154,9 +156,15 @@ server.setRequestHandler(InitializeRequestSchema, async (request: InitializeRequ
 
         capture('run_server_mcp_initialized');
 
+        // Negotiate protocol version with client
+        const requestedVersion = request.params?.protocolVersion;
+        const protocolVersion = (requestedVersion && SUPPORTED_PROTOCOL_VERSIONS.includes(requestedVersion))
+            ? requestedVersion
+            : LATEST_PROTOCOL_VERSION;
+
         // Return standard initialization response
         return {
-            protocolVersion: "2024-11-05",
+            protocolVersion,
             capabilities: {
                 tools: {},
                 resources: {},


### PR DESCRIPTION
## **User description**
## Problem

Desktop Commander was hardcoding `protocolVersion: "2024-11-05"` in the initialization response, causing compatibility issues with newer Claude Desktop versions that expect protocol `2025-06-18`.

**Symptoms:**
- "No result received from client-side tool execution" errors
- Server disconnects and timeouts
- Intermittent tool call failures

**Affected versions:** Claude Desktop 1.1.1520+

## Root Cause

The MCP SDK exports `LATEST_PROTOCOL_VERSION` and `SUPPORTED_PROTOCOL_VERSIONS` for proper version negotiation, but Desktop Commander wasn't using them.

## Solution

- Import `LATEST_PROTOCOL_VERSION` and `SUPPORTED_PROTOCOL_VERSIONS` from the SDK
- Implement proper protocol negotiation: respond with the client's requested version if it's in the supported list, otherwise use the latest
- Remove the hardcoded `"2024-11-05"` value

## Testing

Build succeeds. The fix allows DC to respond with whatever protocol version the client requests (if supported), making it forward-compatible with future Claude Desktop updates.

Closes #325, #326, #327


___

## **CodeAnt-AI Description**
Fix protocol negotiation to avoid client disconnects and tool failures

### What Changed
- Server no longer returns a hardcoded protocol version; it responds with the client's requested version when that version is supported, otherwise it uses the SDK's latest supported version
- Initialization now uses the SDK's supported/latest protocol info so newer Claude Desktop clients (e.g., 1.1.1520+) can connect without errors

### Impact
`✅ Fewer "No result received from client-side tool execution" errors`
`✅ Fewer client disconnects and timeouts with newer Claude Desktop versions`
`✅ Supports Claude Desktop 1.1.1520+ and future protocol versions`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced server protocol version negotiation: the server now dynamically selects the appropriate protocol version based on client requests, falling back to the default when needed. This improves compatibility and flexibility during the initialization process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->