### PR TITLE
security: restrict set_config_value to known configuration keys

### DIFF
--- a/src/tools/config.ts
+++ b/src/tools/config.ts
@@ -55,6 +55,18 @@ export async function getConfig() {
   }
 }
 
+// Keys that can be set via the set_config_value MCP tool.
+// Internal keys (clientId, usageStats, abTest_*, onboardingState, etc.)
+// are managed by the server itself and should not be settable by clients.
+const ALLOWED_CONFIG_KEYS = new Set([
+  'blockedCommands',
+  'allowedDirectories',
+  'defaultShell',
+  'telemetryEnabled',
+  'fileReadLineLimit',
+  'fileWriteLineLimit',
+]);
+
 /**
  * Set a specific config value
  */
@@ -68,6 +80,16 @@ export async function setConfigValue(args: unknown) {
         content: [{
           type: "text",
           text: `Invalid arguments: ${parsed.error}`
+        }],
+        isError: true
+      };
+    }
+
+    if (!ALLOWED_CONFIG_KEYS.has(parsed.data.key)) {
+      return {
+        content: [{
+          type: "text",
+          text: `Key "${parsed.data.key}" is not configurable via this tool. Allowed keys: ${[...ALLOWED_CONFIG_KEYS].join(', ')}`
         }],
         isError: true
       };


### PR DESCRIPTION
## **User description**
## Summary

The `set_config_value` MCP tool accepts any key, allowing a connected AI client to overwrite internal server state — including `blockedCommands` (disabling the command blocklist), `clientId`, A/B test flags, and onboarding state.

This adds an allowlist of keys that can be set via the MCP tool. Internal keys remain writable by server code through `configManager.setValue()` directly.

## What changed

- `src/tools/config.ts`: Added `ALLOWED_CONFIG_KEYS` set and a validation check at the top of `setConfigValue`

### Allowed keys

```
blockedCommands, allowedDirectories, defaultShell,
telemetryEnabled, fileReadLineLimit, fileWriteLineLimit
```

### Why these keys

These are the configuration values that users/clients legitimately need to control. Internal keys like `clientId`, `usageStats`, `abTest_*`, `pendingWelcomeOnboarding`, and `currentClient` are managed by server internals and should not be externally settable.

## Why this matters

Without an allowlist, a connected client can:
- Set `blockedCommands` to `[]`, disabling all command filtering
- Overwrite `clientId`, corrupting analytics
- Modify A/B test assignments and onboarding flags

The `configManager.setValue()` method (used internally by the server) is unchanged — only the MCP-exposed tool is gated.

## Risk

**Low.** All legitimate client use cases are covered by the allowed keys. Internal server code that sets `clientId`, `abTest_*`, etc. calls `configManager.setValue()` directly, not the MCP tool, so it's unaffected.

## Test plan

- [x] Verify allowed keys cover all user-facing config
- [x] Verify internal `configManager.setValue()` calls don't go through the MCP tool
- [ ] Confirm setting an allowed key works as before
- [ ] Confirm setting a disallowed key returns an error


___

## **CodeAnt-AI Description**
Prevent MCP tool from changing internal server configuration keys

### What Changed
- The set_config_value tool now rejects any key not on an explicit allowlist and returns an error message listing allowed keys.
- Only these keys can be set via the tool: blockedCommands, allowedDirectories, defaultShell, telemetryEnabled, fileReadLineLimit, fileWriteLineLimit.
- Attempts to set internal keys (for example clientId, usage stats, A/B test flags, onboarding state) are blocked when coming through the MCP tool; server code can still change them internally.

### Impact
`✅ Prevents external tampering of clientId, analytics, and A/B test flags`
`✅ Clearer error when a user or client attempts to change a disallowed config key`
`✅ Reduced risk of disabling command filtering via remote tool`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration key validation has been enhanced to enforce a whitelist of allowed settings, preventing invalid keys from being set and providing helpful error messages with available options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->