### PR TITLE
feat: add replace_lines tool - token-efficient line-based editing

### DIFF
--- a/src/config-field-definitions.ts
+++ b/src/config-field-definitions.ts
@@ -38,6 +38,11 @@ export const CONFIG_FIELD_DEFINITIONS = {
     description: 'Maximum number of lines that can be written in one edit operation. This helps prevent accidental oversized writes and keeps file changes predictable.',
     valueType: 'number',
   },
+  editMode: {
+    label: 'Edit Mode',
+    description: 'Controls which file editing tools are registered. "string-replace" (default) uses edit_block with fuzzy matching. "line-replace" uses replace_lines with line numbers. "both" registers both tools. Fewer tools means a leaner system prompt.',
+    valueType: 'string',
+  },
 } as const satisfies Record<string, ConfigFieldDefinition>;
 
 export type ConfigFieldKey = keyof typeof CONFIG_FIELD_DEFINITIONS;

--- a/src/config-manager.ts
+++ b/src/config-manager.ts
@@ -45,6 +45,14 @@ export function isTelemetryDisabledValue(value: unknown): boolean {
   return normalizeTelemetryEnabledValue(value) === false;
 }
 
+const VALID_EDIT_MODES = ['string-replace', 'line-replace', 'both'];
+
+function validateEditMode(value: unknown): void {
+  if (value !== undefined && !VALID_EDIT_MODES.includes(value as string)) {
+    throw new Error(`Invalid editMode "${value}". Must be one of: ${VALID_EDIT_MODES.join(', ')}`);
+  }
+}
+
 /**
  * Singleton config manager for the server
  */
@@ -87,6 +95,11 @@ class ConfigManager {
         await this.saveConfig();
       }
       this.config['version'] = VERSION;
+
+      // Sanitize editMode from disk - invalid values reset to default
+      if (this.config.editMode && !VALID_EDIT_MODES.includes(this.config.editMode)) {
+        delete this.config.editMode;
+      }
 
       this.initialized = true;
     } catch (error) {
@@ -214,10 +227,7 @@ class ConfigManager {
 
     // Validate editMode values
     if (key === 'editMode') {
-      const valid = ['string-replace', 'line-replace', 'both'];
-      if (!valid.includes(value)) {
-        throw new Error(`Invalid editMode "${value}". Must be one of: ${valid.join(', ')}`);
-      }
+      validateEditMode(value);
     }
     
     // Special handling for telemetry opt-out
@@ -250,6 +260,7 @@ class ConfigManager {
    */
   async updateConfig(updates: Partial<ServerConfig>): Promise<ServerConfig> {
     await this.init();
+    if (updates.editMode !== undefined) validateEditMode(updates.editMode);
     this.config = { ...this.config, ...updates };
     await this.saveConfig();
     return { ...this.config };

--- a/src/config-manager.ts
+++ b/src/config-manager.ts
@@ -13,6 +13,7 @@ export interface ServerConfig {
   telemetryEnabled?: boolean; // New field for telemetry control
   fileWriteLineLimit?: number; // Line limit for file write operations
   fileReadLineLimit?: number; // Default line limit for file read operations (changed from character-based)
+  editMode?: 'string-replace' | 'line-replace' | 'both'; // Controls which editing tools are registered
   clientId?: string; // Unique client identifier for analytics
   currentClient?: ClientInfo; // Current connected client information
   [key: string]: any; // Allow for arbitrary configuration keys (including abTest_* keys)
@@ -209,6 +210,14 @@ class ConfigManager {
 
     if (key === 'telemetryEnabled') {
       value = normalizeTelemetryEnabledValue(value);
+    }
+
+    // Validate editMode values
+    if (key === 'editMode') {
+      const valid = ['string-replace', 'line-replace', 'both'];
+      if (!valid.includes(value)) {
+        throw new Error(`Invalid editMode "${value}". Must be one of: ${valid.join(', ')}`);
+      }
     }
     
     // Special handling for telemetry opt-out

--- a/src/handlers/edit-search-handlers.ts
+++ b/src/handlers/edit-search-handlers.ts
@@ -2,7 +2,7 @@ import {
     EditBlockArgsSchema
 } from '../tools/schemas.js';
 
-import { handleEditBlock } from '../tools/edit.js';
+import { handleEditBlock, handleReplaceLines } from '../tools/edit.js';
 
 import { ServerResult } from '../types.js';
 
@@ -10,4 +10,4 @@ import { ServerResult } from '../types.js';
  * Handle edit_block command
  * Uses the enhanced implementation with multiple occurrence support and fuzzy matching
  */
-export { handleEditBlock };
+export { handleEditBlock, handleReplaceLines };

--- a/src/server.ts
+++ b/src/server.ts
@@ -41,6 +41,7 @@ import {
     SetConfigValueArgsSchema,
     ListProcessesArgsSchema,
     EditBlockArgsSchema,
+    ReplaceLinesArgsSchema,
     GetUsageStatsArgsSchema,
     GiveFeedbackArgsSchema,
     StartSearchArgsSchema,
@@ -57,6 +58,7 @@ import { giveFeedbackToDesktopCommander } from './tools/feedback.js';
 import { getPrompts } from './tools/prompts.js';
 import { trackToolCall } from './utils/trackTools.js';
 import { usageTracker } from './utils/usageTracker.js';
+import { configManager } from './config-manager.js';
 import { processDockerPrompt } from './utils/dockerPrompt.js';
 import { toolHistory } from './utils/toolHistory.js';
 import { handleWelcomePageOnboarding } from './utils/welcome-onboarding.js';
@@ -204,16 +206,21 @@ export { currentClient };
 deferLog('info', 'Setting up request handlers...');
 
 /**
- * Check if a tool should be included based on current client
+ * Check if a tool should be included based on current client and config
  */
-function shouldIncludeTool(toolName: string): boolean {
+async function shouldIncludeTool(toolName: string): Promise<boolean> {
     // Exclude give_feedback_to_desktop_commander for desktop-commander client
     if (toolName === 'give_feedback_to_desktop_commander' && currentClient?.name === 'desktop-commander') {
         return false;
     }
 
-    // Add more conditional tool logic here as needed
-    // Example: if (toolName === 'some_tool' && currentClient?.name === 'some_client') return false;
+    // Edit mode controls which editing tools are registered
+    if (toolName === 'edit_block' || toolName === 'replace_lines') {
+        const editMode = (await configManager.getValue('editMode')) || 'string-replace';
+        if (editMode === 'string-replace' && toolName === 'replace_lines') return false;
+        if (editMode === 'line-replace' && toolName === 'edit_block') return false;
+        // 'both' keeps both tools
+    }
 
     return true;
 }
@@ -788,6 +795,48 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                     openWorldHint: false,
                 },
             },
+            {
+                name: "replace_lines",
+                description: `
+                        Replace lines in a text file by line number range.
+
+                        Token-efficient alternative to edit_block when you already know line numbers
+                        from a previous read_file call. No need to send old_string - just specify
+                        which lines to replace.
+
+                        PARAMETERS:
+                        - path: File path
+                        - startLine: First line to replace (1-based, from read_file output)
+                        - endLine: Last line to replace (1-based, inclusive)
+                        - newContent: Replacement text (can be more or fewer lines than removed)
+
+                        EXAMPLES:
+                        - Replace lines 10-15: startLine=10, endLine=15, newContent="new code here"
+                        - Delete lines 5-8: startLine=5, endLine=8, newContent=""
+                        - Insert after line 3: Use edit_block or write_file instead
+
+                        WARNING - LINE NUMBER SHIFTING:
+                        After every replace_lines call where newContent has a different number of
+                        lines than the replaced range, ALL subsequent line numbers shift.
+                        ALWAYS re-read the file before making another replace_lines call on the
+                        same file. The response includes context lines to verify correctness.
+
+                        IMPORTANT: Line numbers must match the read_file output exactly.
+                        If the file has been modified since the last read_file, re-read first.
+
+                        NOTE: This tool is only available when editMode is set to "line-replace" or "both"
+                        in the configuration. Default editMode is "string-replace" (edit_block only).
+
+                        ${PATH_GUIDANCE}
+                        ${CMD_PREFIX_DESCRIPTION}`,
+                inputSchema: zodToJsonSchema(ReplaceLinesArgsSchema),
+                annotations: {
+                    title: "Replace Lines",
+                    readOnlyHint: false,
+                    destructiveHint: true,
+                    openWorldHint: false,
+                },
+            },
 
             // Terminal tools
             {
@@ -1147,8 +1196,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             }
         ];
 
-        // Filter tools based on current client
-        const filteredTools = allTools.filter(tool => shouldIncludeTool(tool.name));
+        // Filter tools based on current client and config
+        const includeResults = await Promise.all(allTools.map(tool => shouldIncludeTool(tool.name)));
+        const filteredTools = allTools.filter((_, i) => includeResults[i]);
 
         // logToStderr('debug', `Returning ${filteredTools.length} tools (filtered from ${allTools.length} total) for client: ${currentClient?.name || 'unknown'}`);
 
@@ -1413,6 +1463,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
 
             case "edit_block":
                 result = await handlers.handleEditBlock(args);
+                break;
+
+            case "replace_lines":
+                result = await handlers.handleReplaceLines(args);
                 break;
 
             default:

--- a/src/tools/edit.ts
+++ b/src/tools/edit.ts
@@ -490,7 +490,7 @@ export async function handleReplaceLines(args: unknown): Promise<ServerResult> {
     const sep = fileLineEnding;
     const newContent = result.join(sep);
 
-    await writeFile(parsed.path, newContent);
+    await writeFile(validPath, newContent);
 
     const removedCount = parsed.endLine - parsed.startLine + 1;
     const insertedCount = newLines.length;
@@ -520,7 +520,8 @@ export async function handleReplaceLines(args: unknown): Promise<ServerResult> {
     let msg = `Replaced lines ${parsed.startLine}-${parsed.endLine} (${removedCount} lines) with ${insertedCount} lines in ${parsed.path}`;
 
     if (lineDelta !== 0) {
-        msg += `\n\nWARNING: Line count changed by ${lineDelta > 0 ? '+' : ''}${lineDelta}. All line numbers after line ${insertEnd} have shifted. Re-read before further edits.`;
+        const shiftAnchor = insertEnd > 0 ? insertEnd : parsed.startLine;
+        msg += `\n\nWARNING: Line count changed by ${lineDelta > 0 ? '+' : ''}${lineDelta}. All line numbers after line ${shiftAnchor} have shifted. Re-read before further edits.`;
     }
 
     msg += `\n\nContext (lines ${ctxStart + 1}-${ctxEnd}, + = new content):\n${contextOutput}`;

--- a/src/tools/edit.ts
+++ b/src/tools/edit.ts
@@ -21,7 +21,7 @@ import { ServerResult } from '../types.js';
 import { recursiveFuzzyIndexOf, getSimilarityRatio } from './fuzzySearch.js';
 import { capture } from '../utils/capture.js';
 import { createErrorResponse } from '../error-handlers.js';
-import { EditBlockArgsSchema } from "./schemas.js";
+import { EditBlockArgsSchema, ReplaceLinesArgsSchema } from "./schemas.js";
 import path from 'path';
 import { detectLineEnding, normalizeLineEndings } from '../utils/lineEndingHandler.js';
 import { configManager } from '../config-manager.js';
@@ -457,4 +457,78 @@ export async function handleEditBlock(args: unknown): Promise<ServerResult> {
         search: parsed.old_string,
         replace: parsed.new_string
     }, parsed.expected_replacements);
+}
+
+/**
+ * Handle replace_lines command - line-based editing
+ * Replaces lines startLine..endLine (1-based, inclusive) with newContent
+ */
+export async function handleReplaceLines(args: unknown): Promise<ServerResult> {
+    const parsed = ReplaceLinesArgsSchema.parse(args);
+    const validPath = await validatePath(parsed.path);
+    const content = await readFileInternal(validPath, 0, Number.MAX_SAFE_INTEGER);
+
+    if (typeof content !== 'string') {
+        return createErrorResponse('Cannot read file as text: ' + parsed.path);
+    }
+
+    const fileLineEnding = detectLineEnding(content);
+    const lines = content.split(/\r\n|\r|\n/);
+    const totalLines = lines.length;
+
+    if (parsed.startLine > totalLines) {
+        return createErrorResponse(`startLine ${parsed.startLine} exceeds file length (${totalLines} lines)`);
+    }
+    if (parsed.endLine > totalLines) {
+        return createErrorResponse(`endLine ${parsed.endLine} exceeds file length (${totalLines} lines)`);
+    }
+
+    const before = lines.slice(0, parsed.startLine - 1);
+    const after = lines.slice(parsed.endLine);
+    const newLines = parsed.newContent === '' ? [] : parsed.newContent.split(/\r\n|\r|\n/);
+    const result = [...before, ...newLines, ...after];
+    const sep = fileLineEnding;
+    const newContent = result.join(sep);
+
+    await writeFile(parsed.path, newContent);
+
+    const removedCount = parsed.endLine - parsed.startLine + 1;
+    const insertedCount = newLines.length;
+    const lineDelta = insertedCount - removedCount;
+
+    capture('server_replace_lines', {
+        fileExtension: path.extname(parsed.path).toLowerCase(),
+        removedLines: removedCount,
+        insertedLines: insertedCount,
+    });
+
+    // Build response with context around the replacement
+    const CONTEXT_LINES = 3;
+    const newTotalLines = result.length;
+    const insertStart = parsed.startLine;
+    const insertEnd = insertedCount > 0 ? parsed.startLine + insertedCount - 1 : parsed.startLine - 1;
+
+    const ctxStart = Math.max(0, parsed.startLine - 1 - CONTEXT_LINES);
+    const ctxEnd = Math.min(newTotalLines, (insertedCount > 0 ? insertEnd : parsed.startLine) + CONTEXT_LINES);
+    const contextSlice = result.slice(ctxStart, ctxEnd);
+    const contextOutput = contextSlice.map((line, i) => {
+        const lineNum = ctxStart + i + 1;
+        const marker = (insertedCount > 0 && lineNum >= insertStart && lineNum <= insertEnd) ? '+' : ' ';
+        return `${marker} ${String(lineNum).padStart(4)}  ${line}`;
+    }).join('\n');
+
+    let msg = `Replaced lines ${parsed.startLine}-${parsed.endLine} (${removedCount} lines) with ${insertedCount} lines in ${parsed.path}`;
+
+    if (lineDelta !== 0) {
+        msg += `\n\nWARNING: Line count changed by ${lineDelta > 0 ? '+' : ''}${lineDelta}. All line numbers after line ${insertEnd} have shifted. Re-read before further edits.`;
+    }
+
+    msg += `\n\nContext (lines ${ctxStart + 1}-${ctxEnd}, + = new content):\n${contextOutput}`;
+
+    return {
+        content: [{
+            type: "text",
+            text: msg
+        }],
+    };
 }

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -204,6 +204,16 @@ export const GetPromptsArgsSchema = z.object({
   // anonymous_user_use_case: z.string().optional(),
 });
 
+// Replace lines tool schema - line-based editing (token-efficient alternative to edit_block)
+export const ReplaceLinesArgsSchema = z.object({
+  path: z.string(),
+  startLine: z.number().int().min(1),
+  endLine: z.number().int().min(1),
+  newContent: z.string(),
+}).refine(data => data.endLine >= data.startLine, {
+  message: "endLine must be >= startLine"
+});
+
 // Tool history schema
 export const GetRecentToolCallsArgsSchema = z.object({
   maxResults: z.number().min(1).max(1000).optional().default(50),


### PR DESCRIPTION
## Summary

Adds a new `replace_lines` tool with configurable `editMode` scaffolding, directly addressing #68 and incorporating @wonderwhy-er's feedback on configurable tool sets.

## Problem

`edit_block` requires sending both `old_string` + `new_string`, which doubles token usage for edits where the position is already known from a previous `read_file` call.

## Solution

### 1. `replace_lines` tool

`replace_lines(path, startLine, endLine, newContent)` - when line numbers are known from `read_file` output, only line numbers + new content are needed. Roughly **50% fewer tokens** per edit.

| Parameter | Type | Description |
|-----------|------|-------------|
| `path` | string | File path |
| `startLine` | number | First line to replace (1-based, from `read_file` output) |
| `endLine` | number | Last line to replace (1-based, inclusive) |
| `newContent` | string | Replacement text (can be more or fewer lines). Empty string = deletion. |

Response includes context and shift warnings:

```
Replaced lines 3-5 (3 lines) with 5 lines in app.ts

WARNING: Line count changed by +2. All line numbers after line 7 have shifted. Re-read before further edits.

Context (lines 1-10, + = new content):
     1  import { foo } from './bar';
     2  
+    3  // New implementation
+    4  export function handler() {
+    5    return processData();
+    6  }
+    7  
     8  export default app;
```

### 2. `editMode` config option

Per @wonderwhy-er's suggestion, a new config value controls which editing tools are registered:

| Value | Tools registered | Description |
|-------|-----------------|-------------|
| `"string-replace"` (default) | `edit_block` only | Current behavior, lean system prompt |
| `"line-replace"` | `replace_lines` only | Line-based editing only |
| `"both"` | Both tools | User opts in to both |

Set via `set_config_value("editMode", "both")`, takes effect after restart. Invalid values are rejected with a clear error message. Naturally extensible for a future `"diff"` mode.

### Design decisions

- **Opt-in by default** - `replace_lines` not registered unless explicitly enabled, keeping the default context lean
- **Complements, not replaces** `edit_block`
- **1-based line numbers** matching `read_file` output
- **Empty newContent = true deletion** (no leftover blank line)
- **Preserves line endings** (handles CRLF, LF, and standalone CR)
- **Context in response** with `+` markers and line-shift warnings
- **Input validation** on editMode values

## Changes

6 files:

- `src/config-field-definitions.ts` - `editMode` field definition for settings panel
- `src/config-manager.ts` - `editMode` in `ServerConfig` interface + input validation
- `src/tools/schemas.ts` - `ReplaceLinesArgsSchema` with Zod validation
- `src/tools/edit.ts` - `handleReplaceLines` implementation with context output
- `src/handlers/edit-search-handlers.ts` - Export new handler
- `src/server.ts` - `shouldIncludeTool` with async editMode check, tool definition, switch case

## Testing

24 test scenarios across 4 categories, all passing:

**Config (A1-A8):** All three editMode values tested with real restarts - correct tools registered/hidden in each mode.

**Functionality (B1-B8):** Equal line count, expansion (+4 shift), shrink (-4 shift), deletion (true removal), boundary cases (first/last line), error handling (out of bounds, invalid range).

**Compatibility (C1):** `edit_block` works correctly in "both" mode.

**Validation (E1-E4):** Invalid editMode values rejected, config persists on disk.

Closes #68

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new line-based file editing tool for replacing specific line ranges in files.
  * Added `editMode` configuration option to control which editing tools are available: `string-replace`, `line-replace`, or `both`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->