### PR TITLE
fix: add windowsHide and explicit stdio pipes to prevent pwsh.exe stdout loss

### DIFF
--- a/src/terminal-manager.ts
+++ b/src/terminal-manager.ts
@@ -157,12 +157,14 @@ export class TerminalManager {
       // Use shell-specific configuration with login flags where appropriate
       spawnConfig = getShellSpawnArgs(shellToUse, enhancedCommand);
       spawnOptions = {
+        stdio: ['pipe', 'pipe', 'pipe'] as const,
+        windowsHide: true,  // Prevent .NET-based shells (pwsh.exe) from allocating a new console
         env: {
           ...process.env,
           TERM: 'xterm-256color'  // Better terminal compatibility
         }
       };
-      
+
       // Add shell option if needed (for unknown shells)
       if (spawnConfig.useShellOption) {
         spawnOptions.shell = spawnConfig.useShellOption;
@@ -176,6 +178,8 @@ export class TerminalManager {
       };
       spawnOptions = {
         shell: shellToUse,
+        stdio: ['pipe', 'pipe', 'pipe'] as const,
+        windowsHide: true,
         env: {
           ...process.env,
           TERM: 'xterm-256color'


### PR DESCRIPTION
## **User description**
## Summary

- Add `windowsHide: true` to `spawn()` options to prevent .NET 8 runtime (used by pwsh.exe) from allocating a new console via `AllocConsole()`
- Explicitly set `stdio: ['pipe', 'pipe', 'pipe']` to ensure child process output routes through Node.js pipes regardless of shell runtime

## Root cause

When `defaultShell` is `pwsh.exe` (PowerShell 7), the .NET 8 runtime allocates its own console instead of inheriting Node.js stdio pipes. This causes external executables (Python, Git, Node.js) to emit stdout to a visible desktop window rather than back through the captured pipe, resulting in zero output lines for `start_process` and `read_process_output`.

## Test plan

- [ ] Verify `start_process` with `pwsh.exe` as defaultShell captures stdout from `python -c "print('hello')"`
- [ ] Verify `start_process` with `pwsh.exe` captures stdout from `git --version`
- [ ] Verify `start_process` with `powershell.exe` still works as before (regression check)
- [ ] Verify `start_process` with `cmd.exe` still works as before (regression check)
- [ ] Verify interactive REPL sessions still function correctly

Fixes #378

Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Keep command output visible when using PowerShell on Windows**

### What Changed
- Command output is now routed through the app’s normal pipes on Windows, so text from tools like Python, Git, and Node shows up in the terminal again.
- PowerShell sessions no longer open a separate console window that can steal output away from the app.
- This applies when running commands through the default shell and when using a named shell.

### Impact
`✅ Fewer missing command outputs on Windows`
`✅ Clearer terminal logs from external tools`
`✅ No extra console window for PowerShell commands`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal command execution with standardized I/O stream handling across different shell configurations.
  * Enhanced console allocation behavior on Windows for consistent terminal output display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->