### PR TITLE
fix(security): resolve symlinks before path validation to prevent directory traversal

### DIFF
--- a/src/tools/filesystem.ts
+++ b/src/tools/filesystem.ts
@@ -244,6 +244,36 @@ export async function validatePath(requestedPath: string): Promise<string> {
                 });
                 throw new Error(`Failed to resolve symlink for path: ${absoluteOriginal}. Error: ${err.message}`);
             }
+
+            // SECURITY FIX: When the full path doesn't exist (e.g., writing a new file),
+            // resolve the parent directory to detect symlinks in the path chain.
+            // Without this, an attacker could create a symlink inside an allowed directory
+            // pointing to a restricted location, then write to a non-existent file through
+            // that symlink — bypassing the directory restriction check.
+            try {
+                const parentDir = path.dirname(absoluteOriginal);
+                const resolvedParent = await fs.realpath(parentDir, { encoding: 'utf8' });
+                const basename = path.basename(absoluteOriginal);
+                resolvedRealPath = path.join(resolvedParent, basename);
+            } catch {
+                // Parent also doesn't exist — walk up the tree to find
+                // the deepest existing ancestor and resolve it
+                let current = absoluteOriginal;
+                let remaining: string[] = [];
+                while (true) {
+                    const parent = path.dirname(current);
+                    if (parent === current) break; // reached filesystem root
+                    remaining.unshift(path.basename(current));
+                    current = parent;
+                    try {
+                        const resolvedAncestor = await fs.realpath(current, { encoding: 'utf8' });
+                        resolvedRealPath = path.join(resolvedAncestor, ...remaining);
+                        break;
+                    } catch {
+                        // keep walking up
+                    }
+                }
+            }
         }
 
         const pathForNextCheck = resolvedRealPath ?? absoluteOriginal;

--- a/src/tools/filesystem.ts
+++ b/src/tools/filesystem.ts
@@ -288,25 +288,25 @@ export async function validatePath(requestedPath: string): Promise<string> {
             throw new Error(`Path not allowed: ${requestedPath}. Must be within one of these directories: ${(await getAllowedDirs()).join(', ')}`);
         }
 
+        // SECURITY: Always return the resolved path (with symlinks resolved) so that
+        // all subsequent file operations (read, write, mkdir, etc.) operate on the
+        // canonical target, not on a symlink that could point outside allowed directories.
+        // pathForNextCheck already holds resolvedRealPath ?? absoluteOriginal from above.
+
         // Check if path exists
         try {
             // fs.stat() will automatically follow symlinks, so we get existence info
-            const stats = await fs.stat(absoluteOriginal);
-            // If path exists, resolve any symlinks
-            if (resolvedRealPath) {
-                return resolvedRealPath;
-            }
-
-            return absoluteOriginal;
+            await fs.stat(pathForNextCheck);
+            return pathForNextCheck;
         } catch (error) {
             // Path doesn't exist - validate parent directories
-            if (await validateParentDirectories(absoluteOriginal)) {
-                // Return the path if a valid parent exists
+            if (await validateParentDirectories(pathForNextCheck)) {
+                // Return the resolved path if a valid parent exists
                 // This will be used for folder creation and many other file operations
-                return absoluteOriginal;
+                return pathForNextCheck;
             }
-            // If no valid parent found, return the absolute path anyway
-            return absoluteOriginal;
+            // If no valid parent found, return the resolved path anyway
+            return pathForNextCheck;
         }
     };
 


### PR DESCRIPTION
## **User description**
## Summary

This fixes a directory traversal vulnerability via symlink bypass in `isPathAllowed()` / `validatePath()` — reported in #219 (open for ~7 months now).

The attack is straightforward: create a symlink inside an allowed directory that points to a restricted location, then read/write a file through that symlink. Because the target file doesn't exist yet, `fs.realpath()` fails with ENOENT and the code falls back to the raw (unresolved) path for the allowlist check. The path *looks* like it's inside the allowed directory, but the symlink redirects the actual I/O to somewhere else entirely.

**Example:**
- Allowed directory: `/home/user/projects`
- Attacker creates: `/home/user/projects/evil` -> `/etc/` (symlink)
- Attacker writes to: `/home/user/projects/evil/crontab`
- Old behavior: path passes the allowlist check (starts with `/home/user/projects/`), file gets written to `/etc/crontab`
- New behavior: parent `/home/user/projects/evil` is resolved to `/etc/`, reconstructed path `/etc/crontab` fails the allowlist check

## What changed

In `validatePath()` in `src/tools/filesystem.ts`: when `fs.realpath()` fails with ENOENT (path doesn't exist), the fix now resolves the parent directory to follow any symlinks in the path chain. If the parent also doesn't exist (nested new directories), it walks up to the deepest existing ancestor and resolves from there. The resolved path is then used for the allowlist check instead of the raw path.

This is a minimal, targeted fix — about 30 lines added, no API changes, no breaking changes. Existing tests (allowed-directories, directory-creation) all pass. The existing `test-symlink-security.js` test suite already covers this exact attack scenario and expects the fix.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `test-allowed-directories.js` — all 6 tests pass
- [x] `test-directory-creation.js` — all tests pass (write-to-nonexistent-path still works)
- [x] `test-symlink-security.js` — covers the exact attack vector (requires symlink privileges to run; passes on Linux/macOS)

Closes #219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filesystem path validation and symlink handling when canonical resolution fails. Adds robust fallback that resolves symlink targets or locates the nearest existing parent/ancestor, standardizes which resolved path is used for allowlist checks and subsequent operations, and consistently returns that chosen path—making behavior more reliable for broken symlinks and non-existent targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Block symlink-based writes outside allowed folders**

### What Changed
- File paths are now checked using their real destination, so a symlink inside an allowed folder can no longer point writes or folder creation at a restricted location.
- When a new file or nested folder does not exist yet, the path check now follows the nearest existing parent so hidden symlinks in the path are still caught.
- File operations now use the resolved path after validation, preventing writes from following a misleading symlink target.

### Impact
`✅ Prevented writes outside allowed directories`
`✅ Safer file creation in symlinked folders`
`✅ Fewer directory traversal security bypasses`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
