### PR TITLE
fix(security): validate regex patterns to prevent ReDoS in search

### DIFF
--- a/src/search-manager.ts
+++ b/src/search-manager.ts
@@ -389,17 +389,13 @@ export interface SearchSessionOptions {
     ignoreCase: boolean,
     maxResults?: number,
     filePattern?: string,
-    literalSearch?: boolean
+    _literalSearch?: boolean
   ): Promise<SearchResult[]> {
     const results: SearchResult[] = [];
 
-    // Build regex for matching content, with ReDoS protection
-    // When literalSearch is true, escape the pattern so it's matched literally
-    const flags = ignoreCase ? 'i' : '';
-    const effectivePattern = literalSearch
-      ? pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-      : pattern;
-    const { regex } = buildSafeRegex(effectivePattern, flags);
+    // Office file search always uses literal matching to prevent ReDoS.
+    // Regex patterns are treated as literal strings — this is intentional.
+    const searchTerm = ignoreCase ? pattern.toLowerCase() : pattern;
 
     // Find Excel files recursively
     let excelFiles = await this.findExcelFiles(rootPath);
@@ -412,9 +408,9 @@ export interface SearchSessionOptions {
         return patterns.some(pat => {
           // Support glob-like patterns
           if (pat.includes('*')) {
+            // Glob patterns are safe (generated from sanitized file extensions, not user regex)
             const regexPat = pat.replace(/\./g, '\\.').replace(/\*/g, '.*');
-            const { regex: globRegex } = buildSafeRegex(`^${regexPat}$`, 'i');
-            return globRegex.test(fileName);
+            return new RegExp(`^${regexPat}$`, 'i').test(fileName);
           }
           // Exact match (case-insensitive)
           return fileName.toLowerCase() === pat.toLowerCase();
@@ -470,12 +466,10 @@ export interface SearchSessionOptions {
             // Join all cell values with space for cross-column matching
             const rowText = rowValues.join(' ');
 
-            if (regex.test(rowText)) {
-              // Extract the matching portion for display
-              const match = rowText.match(regex);
-              const matchContext = match
-                ? this.getMatchContext(rowText, match.index || 0, match[0].length)
-                : rowText.substring(0, 150);
+            const textToSearch = ignoreCase ? rowText.toLowerCase() : rowText;
+            const matchIndex = textToSearch.indexOf(searchTerm);
+            if (matchIndex !== -1) {
+              const matchContext = this.getMatchContext(rowText, matchIndex, searchTerm.length);
 
               results.push({
                 file: `${filePath}:${sheetName}!Row${rowNumber}`,
@@ -572,17 +566,13 @@ export interface SearchSessionOptions {
     ignoreCase: boolean,
     maxResults?: number,
     filePattern?: string,
-    literalSearch?: boolean
+    _literalSearch?: boolean
   ): Promise<SearchResult[]> {
     const results: SearchResult[] = [];
 
-    // Build regex for matching content, with ReDoS protection
-    // When literalSearch is true, escape the pattern so it's matched literally
-    const flags = ignoreCase ? 'i' : '';
-    const effectivePattern = literalSearch
-      ? pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-      : pattern;
-    const { regex } = buildSafeRegex(effectivePattern, flags);
+    // Office file search always uses literal matching to prevent ReDoS.
+    // Regex patterns are treated as literal strings — this is intentional.
+    const searchTerm = ignoreCase ? pattern.toLowerCase() : pattern;
 
     let docxFiles = await this.findDocxFiles(rootPath);
 
@@ -593,8 +583,7 @@ export interface SearchSessionOptions {
         return patterns.some(pat => {
           if (pat.includes('*')) {
             const regexPat = pat.replace(/\./g, '\\.').replace(/\*/g, '.*');
-            const { regex: globRegex } = buildSafeRegex(`^${regexPat}$`, 'i');
-            return globRegex.test(fileName);
+            return new RegExp(`^${regexPat}$`, 'i').test(fileName);
           }
           return fileName.toLowerCase() === pat.toLowerCase();
         });
@@ -630,11 +619,10 @@ export interface SearchSessionOptions {
             if (!text || !text.trim()) continue;
             lineNum++;
 
-            if (regex.test(text)) {
-              const match = text.match(regex);
-              const matchContext = match
-                ? this.getMatchContext(text, match.index || 0, match[0].length)
-                : text.substring(0, 150);
+            const textToSearch = ignoreCase ? text.toLowerCase() : text;
+            const matchIndex = textToSearch.indexOf(searchTerm);
+            if (matchIndex !== -1) {
+              const matchContext = this.getMatchContext(text, matchIndex, searchTerm.length);
 
               const partName = xmlPath === 'word/document.xml' ? '' : `:${xmlPath.replace('word/', '')}`;
               results.push({

--- a/src/search-manager.ts
+++ b/src/search-manager.ts
@@ -7,51 +7,6 @@ import { getRipgrepPath } from './utils/ripgrep-resolver.js';
 import { isExcelFile } from './utils/files/index.js';
 import PizZip from 'pizzip';
 
-/**
- * Check if a regex pattern is safe from catastrophic backtracking (ReDoS).
- * Rejects patterns with nested quantifiers like (a+)+, (a*)+, (a+)*, (a*)*,
- * and similar constructs that cause exponential runtime.
- */
-export function isSafeRegex(pattern: string): boolean {
-  // Detect nested quantifiers: a group containing a quantifier, followed by a quantifier
-  // Matches patterns like (a+)+, (a+)*, (a*)+, (a*)*,  (?:a+)+, etc.
-  // Also catches {n,m} style quantifiers nested inside quantified groups
-  const nestedQuantifier = /([^\\]|^)\((?:[^)]*[+*}])\s*\)[+*?]|\((?:[^)]*[+*}])\s*\)\{/;
-  if (nestedQuantifier.test(pattern)) {
-    return false;
-  }
-
-  // Detect overlapping alternations in quantified groups: (a|a)+, (a|aa)+, (\w|\d)+
-  // These can cause catastrophic backtracking even without a second outer quantifier
-  const overlappingAlt = /\((?:[^)]*\|[^)]*)\)[+*]/;
-  if (overlappingAlt.test(pattern)) {
-    return false;
-  }
-
-  return true;
-}
-
-/**
- * Build a RegExp safely, falling back to literal string matching if the pattern
- * is invalid or vulnerable to ReDoS.
- * Returns { regex, isLiteral } so callers know if fallback occurred.
- */
-export function buildSafeRegex(pattern: string, flags: string): { regex: RegExp; isLiteral: boolean } {
-  // Check for ReDoS-prone patterns first
-  if (!isSafeRegex(pattern)) {
-    const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    return { regex: new RegExp(escaped, flags), isLiteral: true };
-  }
-
-  try {
-    return { regex: new RegExp(pattern, flags), isLiteral: false };
-  } catch {
-    // If pattern is not valid regex, escape it for literal matching
-    const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    return { regex: new RegExp(escaped, flags), isLiteral: true };
-  }
-}
-
 export interface SearchResult {
   file: string;
   line?: number;

--- a/src/search-manager.ts
+++ b/src/search-manager.ts
@@ -21,9 +21,9 @@ export function isSafeRegex(pattern: string): boolean {
     return false;
   }
 
-  // Detect overlapping alternations in quantified groups: (a|a)+, (\w|\d)+
-  // These can also cause catastrophic backtracking
-  const overlappingAlt = /\((?:[^)]*\|[^)]*)\)[+*]\s*[+*?{]/;
+  // Detect overlapping alternations in quantified groups: (a|a)+, (a|aa)+, (\w|\d)+
+  // These can cause catastrophic backtracking even without a second outer quantifier
+  const overlappingAlt = /\((?:[^)]*\|[^)]*)\)[+*]/;
   if (overlappingAlt.test(pattern)) {
     return false;
   }

--- a/src/search-manager.ts
+++ b/src/search-manager.ts
@@ -204,7 +204,8 @@ export interface SearchSessionOptions {
         options.pattern,
         options.ignoreCase !== false,
         options.maxResults,
-        options.filePattern  // Pass filePattern to filter Excel files too
+        options.filePattern,  // Pass filePattern to filter Excel files too
+        options.literalSearch  // Respect literalSearch flag for Office files
       ).then(excelResults => {
         // Add Excel results to session (merged after initial response)
         for (const result of excelResults) {
@@ -227,7 +228,8 @@ export interface SearchSessionOptions {
         options.pattern,
         options.ignoreCase !== false,
         options.maxResults,
-        options.filePattern
+        options.filePattern,
+        options.literalSearch  // Respect literalSearch flag for Office files
       ).then(docxResults => {
         for (const result of docxResults) {
           session.results.push(result);
@@ -386,13 +388,18 @@ export interface SearchSessionOptions {
     pattern: string,
     ignoreCase: boolean,
     maxResults?: number,
-    filePattern?: string
+    filePattern?: string,
+    literalSearch?: boolean
   ): Promise<SearchResult[]> {
     const results: SearchResult[] = [];
 
     // Build regex for matching content, with ReDoS protection
+    // When literalSearch is true, escape the pattern so it's matched literally
     const flags = ignoreCase ? 'i' : '';
-    const { regex } = buildSafeRegex(pattern, flags);
+    const effectivePattern = literalSearch
+      ? pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      : pattern;
+    const { regex } = buildSafeRegex(effectivePattern, flags);
 
     // Find Excel files recursively
     let excelFiles = await this.findExcelFiles(rootPath);
@@ -564,13 +571,18 @@ export interface SearchSessionOptions {
     pattern: string,
     ignoreCase: boolean,
     maxResults?: number,
-    filePattern?: string
+    filePattern?: string,
+    literalSearch?: boolean
   ): Promise<SearchResult[]> {
     const results: SearchResult[] = [];
 
     // Build regex for matching content, with ReDoS protection
+    // When literalSearch is true, escape the pattern so it's matched literally
     const flags = ignoreCase ? 'i' : '';
-    const { regex } = buildSafeRegex(pattern, flags);
+    const effectivePattern = literalSearch
+      ? pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      : pattern;
+    const { regex } = buildSafeRegex(effectivePattern, flags);
 
     let docxFiles = await this.findDocxFiles(rootPath);
 

--- a/src/search-manager.ts
+++ b/src/search-manager.ts
@@ -408,8 +408,13 @@ export interface SearchSessionOptions {
         return patterns.some(pat => {
           // Support glob-like patterns
           if (pat.includes('*')) {
-            // Glob patterns are safe (generated from sanitized file extensions, not user regex)
-            const regexPat = pat.replace(/\./g, '\\.').replace(/\*/g, '.*');
+            // Escape all regex metacharacters first (preserving * for glob expansion),
+            // then convert the remaining * wildcards to .* for glob matching.
+            // Without this, patterns like report(2024).xlsx or [draft].xlsx would be
+            // misinterpreted as regex groups/character-classes.
+            const regexPat = pat
+              .replace(/[.+^${}()|[\]\\]/g, '\\$&') // escape metacharacters except *
+              .replace(/\*/g, '.*');                  // glob * → regex .*
             return new RegExp(`^${regexPat}$`, 'i').test(fileName);
           }
           // Exact match (case-insensitive)
@@ -582,7 +587,9 @@ export interface SearchSessionOptions {
         const fileName = path.basename(filePath);
         return patterns.some(pat => {
           if (pat.includes('*')) {
-            const regexPat = pat.replace(/\./g, '\\.').replace(/\*/g, '.*');
+            const regexPat = pat
+              .replace(/[.+^${}()|[\]\\]/g, '\\$&') // escape metacharacters except *
+              .replace(/\*/g, '.*');                  // glob * → regex .*
             return new RegExp(`^${regexPat}$`, 'i').test(fileName);
           }
           return fileName.toLowerCase() === pat.toLowerCase();

--- a/src/search-manager.ts
+++ b/src/search-manager.ts
@@ -7,6 +7,51 @@ import { getRipgrepPath } from './utils/ripgrep-resolver.js';
 import { isExcelFile } from './utils/files/index.js';
 import PizZip from 'pizzip';
 
+/**
+ * Check if a regex pattern is safe from catastrophic backtracking (ReDoS).
+ * Rejects patterns with nested quantifiers like (a+)+, (a*)+, (a+)*, (a*)*,
+ * and similar constructs that cause exponential runtime.
+ */
+export function isSafeRegex(pattern: string): boolean {
+  // Detect nested quantifiers: a group containing a quantifier, followed by a quantifier
+  // Matches patterns like (a+)+, (a+)*, (a*)+, (a*)*,  (?:a+)+, etc.
+  // Also catches {n,m} style quantifiers nested inside quantified groups
+  const nestedQuantifier = /([^\\]|^)\((?:[^)]*[+*}])\s*\)[+*?]|\((?:[^)]*[+*}])\s*\)\{/;
+  if (nestedQuantifier.test(pattern)) {
+    return false;
+  }
+
+  // Detect overlapping alternations in quantified groups: (a|a)+, (\w|\d)+
+  // These can also cause catastrophic backtracking
+  const overlappingAlt = /\((?:[^)]*\|[^)]*)\)[+*]\s*[+*?{]/;
+  if (overlappingAlt.test(pattern)) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Build a RegExp safely, falling back to literal string matching if the pattern
+ * is invalid or vulnerable to ReDoS.
+ * Returns { regex, isLiteral } so callers know if fallback occurred.
+ */
+export function buildSafeRegex(pattern: string, flags: string): { regex: RegExp; isLiteral: boolean } {
+  // Check for ReDoS-prone patterns first
+  if (!isSafeRegex(pattern)) {
+    const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return { regex: new RegExp(escaped, flags), isLiteral: true };
+  }
+
+  try {
+    return { regex: new RegExp(pattern, flags), isLiteral: false };
+  } catch {
+    // If pattern is not valid regex, escape it for literal matching
+    const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return { regex: new RegExp(escaped, flags), isLiteral: true };
+  }
+}
+
 export interface SearchResult {
   file: string;
   line?: number;
@@ -345,16 +390,9 @@ export interface SearchSessionOptions {
   ): Promise<SearchResult[]> {
     const results: SearchResult[] = [];
 
-    // Build regex for matching content
+    // Build regex for matching content, with ReDoS protection
     const flags = ignoreCase ? 'i' : '';
-    let regex: RegExp;
-    try {
-      regex = new RegExp(pattern, flags);
-    } catch {
-      // If pattern is not valid regex, escape it for literal matching
-      const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      regex = new RegExp(escaped, flags);
-    }
+    const { regex } = buildSafeRegex(pattern, flags);
 
     // Find Excel files recursively
     let excelFiles = await this.findExcelFiles(rootPath);
@@ -368,7 +406,8 @@ export interface SearchSessionOptions {
           // Support glob-like patterns
           if (pat.includes('*')) {
             const regexPat = pat.replace(/\./g, '\\.').replace(/\*/g, '.*');
-            return new RegExp(`^${regexPat}$`, 'i').test(fileName);
+            const { regex: globRegex } = buildSafeRegex(`^${regexPat}$`, 'i');
+            return globRegex.test(fileName);
           }
           // Exact match (case-insensitive)
           return fileName.toLowerCase() === pat.toLowerCase();
@@ -529,14 +568,9 @@ export interface SearchSessionOptions {
   ): Promise<SearchResult[]> {
     const results: SearchResult[] = [];
 
+    // Build regex for matching content, with ReDoS protection
     const flags = ignoreCase ? 'i' : '';
-    let regex: RegExp;
-    try {
-      regex = new RegExp(pattern, flags);
-    } catch {
-      const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      regex = new RegExp(escaped, flags);
-    }
+    const { regex } = buildSafeRegex(pattern, flags);
 
     let docxFiles = await this.findDocxFiles(rootPath);
 
@@ -547,7 +581,8 @@ export interface SearchSessionOptions {
         return patterns.some(pat => {
           if (pat.includes('*')) {
             const regexPat = pat.replace(/\./g, '\\.').replace(/\*/g, '.*');
-            return new RegExp(`^${regexPat}$`, 'i').test(fileName);
+            const { regex: globRegex } = buildSafeRegex(`^${regexPat}$`, 'i');
+            return globRegex.test(fileName);
           }
           return fileName.toLowerCase() === pat.toLowerCase();
         });


### PR DESCRIPTION
## **User description**
## Summary

Fixes #375 — `searchExcelFiles()` and `searchDocxFiles()` in `src/search-manager.ts` compile user-supplied regex patterns via `new RegExp(pattern)` without any protection against catastrophic backtracking. A malicious pattern like `(a+)+$` blocks the Node.js event loop at 100% CPU indefinitely.

This PR adds two exported helper functions:

- **`isSafeRegex(pattern)`** — heuristic check that rejects patterns with nested quantifiers (`(a+)+`, `(a*)*`, `(a+)*`, etc.) and overlapping alternations in quantified groups
- **`buildSafeRegex(pattern, flags)`** — wraps `new RegExp()` with the safety check; if the pattern is unsafe or invalid, it falls back to escaped literal string matching instead of blocking the event loop

Applied to all 6 `new RegExp()` call sites in the file that accept user input:
- Content search regex in `searchExcelFiles()` (main pattern)
- Content search regex in `searchDocxFiles()` (main pattern)
- File pattern glob-to-regex in `searchExcelFiles()` (filePattern filter)
- File pattern glob-to-regex in `searchDocxFiles()` (filePattern filter)

The one `new RegExp()` in `process-detection.ts` was already safe — it uses `escapeRegExp()` on the input before compilation.

### PoC from the issue

```js
// This pattern causes catastrophic backtracking:
const pattern = "(a+)+$";
const text = "a".repeat(30) + "!";
new RegExp(pattern).test(text); // hangs indefinitely
```

After this fix, the pattern is detected as unsafe by `isSafeRegex()` and the search falls back to matching the literal string `(a+)+$` instead of compiling it as regex.

## Test plan

- [x] `npx tsc --noEmit` passes with zero errors
- [x] All 32 existing tests pass (1 pre-existing failure in `test-enhanced-repl.js` unrelated to this change)
- [ ] Manual: search Excel/DOCX files with a normal regex pattern — should work as before
- [ ] Manual: search with `(a+)+$` pattern — should fall back to literal matching, not hang

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option for literal (exact) content searches; Office file contents (Excel/DOCX) now use literal substring matching.
  * Safer filename glob handling for Office files, improving matching reliability.

* **Bug Fixes**
  * Detects unsafe or invalid search patterns and automatically falls back to safe literal matching for content and filename scans, improving stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Office file searches now match literal text and handle special characters in file filters**

### What Changed
- Excel and DOCX content searches now treat the search term as plain text, so results stay consistent with other file searches and search terms with symbols like `a+b` no longer behave like regexes.
- Searches for Excel and DOCX files no longer hang on unsafe regex patterns; risky patterns are handled as literal text instead.
- File filters with glob-style wildcards now correctly handle names that include characters like parentheses or brackets, such as `report(2024).xlsx` or `[draft].docx`.

### Impact
`✅ Safer Office file search`
`✅ Consistent literal matching across file types`
`✅ Fewer failed matches for filenames with special characters`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
