### PR TITLE
feat: customizable MCP UI widget rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wonderwhy-er/desktop-commander",
-  "version": "0.2.37",
+  "version": "0.2.38",
   "description": "MCP server for terminal operations and file editing",
   "mcpName": "io.github.wonderwhy-er/desktop-commander",
   "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/wonderwhy-er/DesktopCommanderMCP",
     "source": "github"
   },
-  "version": "0.2.37",
+  "version": "0.2.38",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@wonderwhy-er/desktop-commander",
-      "version": "0.2.37",
+      "version": "0.2.38",
       "transport": {
         "type": "stdio"
       }

--- a/src/config-field-definitions.ts
+++ b/src/config-field-definitions.ts
@@ -41,7 +41,25 @@ export const CONFIG_FIELD_DEFINITIONS = {
   },
   showMcpUI: {
     label: 'Show MCP UI Widgets',
-    description: 'When on, tools like read_file, list_directory, and get_config render an interactive UI widget in supported clients (e.g. Claude Desktop). When off, those tools return plain text only. Individual tool calls can override this default by passing the showUI parameter.',
+    description: 'Global default for whether tools render interactive UI widgets in supported clients (e.g. Claude Desktop). Individual tools below can override this. Per-call showUI parameter overrides everything.',
+    valueType: 'boolean',
+    defaultValue: true,
+  },
+  showReadFileUI: {
+    label: 'Show File Preview Widget',
+    description: 'When on, read_file renders an interactive file preview widget. When off, it returns plain text. Overrides the global Show MCP UI Widgets setting for this tool.',
+    valueType: 'boolean',
+    defaultValue: true,
+  },
+  showListDirectoryUI: {
+    label: 'Show Directory Listing Widget',
+    description: 'When on, list_directory renders an interactive directory tree widget. When off, it returns plain text. Overrides the global Show MCP UI Widgets setting for this tool.',
+    valueType: 'boolean',
+    defaultValue: true,
+  },
+  showGetConfigUI: {
+    label: 'Show Config Editor Widget',
+    description: 'When on, get_config renders an interactive config editor widget. When off, it returns plain text. Overrides the global Show MCP UI Widgets setting for this tool.',
     valueType: 'boolean',
     defaultValue: true,
   },

--- a/src/config-field-definitions.ts
+++ b/src/config-field-definitions.ts
@@ -5,6 +5,7 @@ export type ConfigFieldDefinition = {
   description: string;
   valueType: ConfigFieldValueType;
   defaultValue?: unknown;
+  parentKey?: string; // If set, this field is a child of the named parent field
 };
 
 // Single source of truth for user-editable configuration fields.
@@ -46,22 +47,25 @@ export const CONFIG_FIELD_DEFINITIONS = {
     defaultValue: true,
   },
   showReadFileUI: {
-    label: 'Show File Preview Widget',
-    description: 'When on, read_file renders an interactive file preview widget. When off, it returns plain text. Overrides the global Show MCP UI Widgets setting for this tool.',
+    label: 'File Preview Widget',
+    description: 'When on, read_file renders an interactive file preview widget. When off, it returns plain text.',
     valueType: 'boolean',
     defaultValue: true,
+    parentKey: 'showMcpUI',
   },
   showListDirectoryUI: {
-    label: 'Show Directory Listing Widget',
-    description: 'When on, list_directory renders an interactive directory tree widget. When off, it returns plain text. Overrides the global Show MCP UI Widgets setting for this tool.',
+    label: 'Directory Listing Widget',
+    description: 'When on, list_directory renders an interactive directory tree widget. When off, it returns plain text.',
     valueType: 'boolean',
     defaultValue: true,
+    parentKey: 'showMcpUI',
   },
   showGetConfigUI: {
-    label: 'Show Config Editor Widget',
-    description: 'When on, get_config renders an interactive config editor widget. When off, it returns plain text. Overrides the global Show MCP UI Widgets setting for this tool.',
+    label: 'Config Editor Widget',
+    description: 'When on, get_config renders an interactive config editor widget. When off, it returns plain text.',
     valueType: 'boolean',
     defaultValue: true,
+    parentKey: 'showMcpUI',
   },
 } as const satisfies Record<string, ConfigFieldDefinition>;
 

--- a/src/config-field-definitions.ts
+++ b/src/config-field-definitions.ts
@@ -38,6 +38,11 @@ export const CONFIG_FIELD_DEFINITIONS = {
     description: 'Maximum number of lines that can be written in one edit operation. This helps prevent accidental oversized writes and keeps file changes predictable.',
     valueType: 'number',
   },
+  showMcpUI: {
+    label: 'Show MCP UI Widgets',
+    description: 'When on, tools like read_file, list_directory, and get_config render an interactive UI widget in supported clients (e.g. Claude Desktop). When off, those tools return plain text only. Individual tool calls can override this default by passing the showUI parameter.',
+    valueType: 'boolean',
+  },
 } as const satisfies Record<string, ConfigFieldDefinition>;
 
 export type ConfigFieldKey = keyof typeof CONFIG_FIELD_DEFINITIONS;

--- a/src/config-field-definitions.ts
+++ b/src/config-field-definitions.ts
@@ -4,6 +4,7 @@ export type ConfigFieldDefinition = {
   label: string;
   description: string;
   valueType: ConfigFieldValueType;
+  defaultValue?: unknown;
 };
 
 // Single source of truth for user-editable configuration fields.
@@ -42,6 +43,7 @@ export const CONFIG_FIELD_DEFINITIONS = {
     label: 'Show MCP UI Widgets',
     description: 'When on, tools like read_file, list_directory, and get_config render an interactive UI widget in supported clients (e.g. Claude Desktop). When off, those tools return plain text only. Individual tool calls can override this default by passing the showUI parameter.',
     valueType: 'boolean',
+    defaultValue: true,
   },
 } as const satisfies Record<string, ConfigFieldDefinition>;
 

--- a/src/config-manager.ts
+++ b/src/config-manager.ts
@@ -13,6 +13,7 @@ export interface ServerConfig {
   telemetryEnabled?: boolean; // New field for telemetry control
   fileWriteLineLimit?: number; // Line limit for file write operations
   fileReadLineLimit?: number; // Default line limit for file read operations (changed from character-based)
+  showMcpUI?: boolean; // Whether to render interactive UI widgets for read_file, list_directory, get_config
   clientId?: string; // Unique client identifier for analytics
   currentClient?: ClientInfo; // Current connected client information
   [key: string]: any; // Allow for arbitrary configuration keys (including abTest_* keys)
@@ -169,6 +170,7 @@ class ConfigManager {
       telemetryEnabled: true, // Default to opt-out approach (telemetry on by default)
       fileWriteLineLimit: 50,  // Default line limit for file write operations (changed from 100)
       fileReadLineLimit: 1000,  // Default line limit for file read operations (changed from character-based)
+      showMcpUI: true,  // Show interactive UI widgets by default
       pendingWelcomeOnboarding: true  // New install flag - triggers A/B test for welcome page
     };
   }

--- a/src/config-manager.ts
+++ b/src/config-manager.ts
@@ -14,6 +14,9 @@ export interface ServerConfig {
   fileWriteLineLimit?: number; // Line limit for file write operations
   fileReadLineLimit?: number; // Default line limit for file read operations (changed from character-based)
   showMcpUI?: boolean; // Whether to render interactive UI widgets for read_file, list_directory, get_config
+  showReadFileUI?: boolean; // Per-tool override for read_file widget
+  showListDirectoryUI?: boolean; // Per-tool override for list_directory widget
+  showGetConfigUI?: boolean; // Per-tool override for get_config widget
   clientId?: string; // Unique client identifier for analytics
   currentClient?: ClientInfo; // Current connected client information
   [key: string]: any; // Allow for arbitrary configuration keys (including abTest_* keys)

--- a/src/server.ts
+++ b/src/server.ts
@@ -74,6 +74,20 @@ import { listUiResources, readUiResource } from './ui/resources.js';
 
 
 
+/**
+ * Resolve whether a tool call should render its UI widget.
+ * Priority: per-tool config key > global showMcpUI > true (default on).
+ * When false, we strip structuredContent from the response so the widget
+ * has no data to render — the _meta stays on the tool definition always
+ * to avoid "no ui/resourceUri" errors from preloading clients.
+ */
+async function shouldShowUI(toolConfigKey: 'showReadFileUI' | 'showListDirectoryUI' | 'showGetConfigUI'): Promise<boolean> {
+  const config = await configManager.getConfig();
+  const globalDefault = config.showMcpUI ?? true;
+  const perTool = config[toolConfigKey];
+  return typeof perTool === 'boolean' ? perTool : globalDefault;
+}
+
 // Store startup messages to send after initialization
 const deferredMessages: Array<{ level: string, message: string }> = [];
 function deferLog(level: string, message: string) {
@@ -227,13 +241,6 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
     try {
         // logToStderr('debug', 'Generating tools list...');
 
-        // Resolve UI visibility config once for tool definition _meta
-        const uiConfig = await configManager.getConfig();
-        const globalUI = uiConfig.showMcpUI ?? true;
-        const showReadFileUIMeta   = typeof uiConfig.showReadFileUI   === 'boolean' ? uiConfig.showReadFileUI   : globalUI;
-        const showListDirUIMeta    = typeof uiConfig.showListDirectoryUI === 'boolean' ? uiConfig.showListDirectoryUI : globalUI;
-        const showGetConfigUIMeta  = typeof uiConfig.showGetConfigUI  === 'boolean' ? uiConfig.showGetConfigUI  : globalUI;
-
         // Build complete tools array
         const allTools = [
             // Configuration tools
@@ -254,7 +261,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                         - systemInfo (operating system and environment details)
                         ${CMD_PREFIX_DESCRIPTION}`,
                 inputSchema: zodToJsonSchema(GetConfigArgsSchema),
-                ...(showGetConfigUIMeta ? { _meta: buildUiToolMeta(CONFIG_EDITOR_RESOURCE_URI, true) } : {}),
+                _meta: buildUiToolMeta(CONFIG_EDITOR_RESOURCE_URI, true),
                 annotations: {
                     title: "Get Configuration",
                     readOnlyHint: true,
@@ -349,7 +356,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                         ${PATH_GUIDANCE}
                         ${CMD_PREFIX_DESCRIPTION}`,
                 inputSchema: zodToJsonSchema(ReadFileArgsSchema),
-                ...(showReadFileUIMeta ? { _meta: buildUiToolMeta(FILE_PREVIEW_RESOURCE_URI, true) } : {}),
+                _meta: buildUiToolMeta(FILE_PREVIEW_RESOURCE_URI, true),
                 annotations: {
                     title: "Read File or URL",
                     readOnlyHint: true,
@@ -535,7 +542,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                         ${PATH_GUIDANCE}
                         ${CMD_PREFIX_DESCRIPTION}`,
                 inputSchema: zodToJsonSchema(ListDirectoryArgsSchema),
-                ...(showListDirUIMeta ? { _meta: buildUiToolMeta(FILE_PREVIEW_RESOURCE_URI, true) } : {}),
+                _meta: buildUiToolMeta(FILE_PREVIEW_RESOURCE_URI, true),
                 annotations: {
                     title: "List Directory Contents",
                     readOnlyHint: true,
@@ -1230,6 +1237,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
             case "get_config":
                 try {
                     result = await getConfig();
+                    if (result && !result.isError && !await shouldShowUI('showGetConfigUI')) {
+                        delete (result as any).structuredContent;
+                    }
                 } catch (error) {
                     capture('server_request_error', { message: `Error in get_config handler: ${error}` });
                     result = {
@@ -1384,6 +1394,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
             // Filesystem tools
             case "read_file":
                 result = await handlers.handleReadFile(args);
+                if (result && !result.isError && !await shouldShowUI('showReadFileUI')) {
+                    delete (result as any).structuredContent;
+                }
                 break;
 
             case "read_multiple_files":
@@ -1404,6 +1417,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
 
             case "list_directory":
                 result = await handlers.handleListDirectory(args);
+                if (result && !result.isError && !await shouldShowUI('showListDirectoryUI')) {
+                    delete (result as any).structuredContent;
+                }
                 break;
 
             case "move_file":

--- a/src/server.ts
+++ b/src/server.ts
@@ -52,6 +52,7 @@ import {
     WritePdfArgsSchema,
 } from './tools/schemas.js';
 import { getConfig, setConfigValue } from './tools/config.js';
+import { configManager } from './config-manager.js';
 import { getUsageStats } from './tools/usage.js';
 import { giveFeedbackToDesktopCommander } from './tools/feedback.js';
 import { getPrompts } from './tools/prompts.js';
@@ -70,6 +71,16 @@ import {
     FILE_PREVIEW_RESOURCE_URI
 } from './ui/contracts.js';
 import { listUiResources, readUiResource } from './ui/resources.js';
+
+/**
+ * Resolve whether a tool call should render an MCP UI widget.
+ * Priority: per-call `showUI` arg > global `showMcpUI` config > true (default on).
+ */
+async function shouldShowUI(args: { showUI?: boolean }): Promise<boolean> {
+  if (args.showUI !== undefined) return args.showUI;
+  const config = await configManager.getConfig();
+  return config.showMcpUI ?? true;
+}
 
 // Store startup messages to send after initialization
 const deferredMessages: Array<{ level: string, message: string }> = [];
@@ -237,10 +248,12 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                         - fileReadLineLimit (max lines for read_file, default 1000)
                         - fileWriteLineLimit (max lines per write_file call, default 50)
                         - telemetryEnabled (boolean for telemetry opt-in/out)
+                        - showMcpUI (boolean, default true — controls whether read_file, list_directory and get_config render interactive UI widgets; use set_config_value to change)
                         - currentClient (information about the currently connected MCP client)
                         - clientHistory (history of all clients that have connected)
                         - version (version of the DesktopCommander)
                         - systemInfo (operating system and environment details)
+                        Pass showUI=false to suppress the UI widget for this call only.
                         ${CMD_PREFIX_DESCRIPTION}`,
                 inputSchema: zodToJsonSchema(GetConfigArgsSchema),
                 _meta: buildUiToolMeta(CONFIG_EDITOR_RESOURCE_URI, true),
@@ -264,6 +277,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                         - fileReadLineLimit (number, max lines for read_file)
                         - fileWriteLineLimit (number, max lines per write_file call)
                         - telemetryEnabled (boolean)
+                        - showMcpUI (boolean, default true — set to false to disable interactive UI widgets globally for read_file, list_directory and get_config)
                         
                         IMPORTANT: Setting allowedDirectories to an empty array ([]) allows full access 
                         to the entire file system, regardless of the operating system.
@@ -334,6 +348,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                           * For BULK changes (translation, mass replacements): use start_process with Python
                             zipfile module to find/replace all <w:t> elements at once.
 
+                        Pass showUI=false to suppress the interactive UI widget for this call only. Global default is controlled by the showMcpUI config setting.
                         ${PATH_GUIDANCE}
                         ${CMD_PREFIX_DESCRIPTION}`,
                 inputSchema: zodToJsonSchema(ReadFileArgsSchema),
@@ -520,7 +535,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                         
                         If a directory cannot be accessed, it will show [DENIED] instead.
                         Only works within allowed directories.
-                        
+                        Pass showUI=false to suppress the interactive UI widget for this call only. Global default is controlled by the showMcpUI config setting.
                         ${PATH_GUIDANCE}
                         ${CMD_PREFIX_DESCRIPTION}`,
                 inputSchema: zodToJsonSchema(ListDirectoryArgsSchema),
@@ -1219,6 +1234,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
             case "get_config":
                 try {
                     result = await getConfig();
+                    if (result && !result.isError && await shouldShowUI(args as { showUI?: boolean })) {
+                        (result as any)._meta = buildUiToolMeta(CONFIG_EDITOR_RESOURCE_URI, true);
+                    }
                 } catch (error) {
                     capture('server_request_error', { message: `Error in get_config handler: ${error}` });
                     result = {
@@ -1368,6 +1386,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
             // Filesystem tools
             case "read_file":
                 result = await handlers.handleReadFile(args);
+                if (result && !result.isError && await shouldShowUI(args as { showUI?: boolean })) {
+                    (result as any)._meta = buildUiToolMeta(FILE_PREVIEW_RESOURCE_URI, true);
+                }
                 break;
 
             case "read_multiple_files":
@@ -1388,6 +1409,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
 
             case "list_directory":
                 result = await handlers.handleListDirectory(args);
+                if (result && !result.isError && await shouldShowUI(args as { showUI?: boolean })) {
+                    (result as any)._meta = buildUiToolMeta(FILE_PREVIEW_RESOURCE_URI, true);
+                }
                 break;
 
             case "move_file":

--- a/src/server.ts
+++ b/src/server.ts
@@ -53,6 +53,7 @@ import {
 } from './tools/schemas.js';
 import { getConfig, setConfigValue } from './tools/config.js';
 import { configManager } from './config-manager.js';
+import type { ServerConfig } from './config-manager.js';
 import { getUsageStats } from './tools/usage.js';
 import { giveFeedbackToDesktopCommander } from './tools/feedback.js';
 import { getPrompts } from './tools/prompts.js';
@@ -74,12 +75,17 @@ import { listUiResources, readUiResource } from './ui/resources.js';
 
 /**
  * Resolve whether a tool call should render an MCP UI widget.
- * Priority: per-call `showUI` arg > global `showMcpUI` config > true (default on).
+ * Priority: per-call `showUI` arg > per-tool config > global `showMcpUI` config > true (default on).
  */
-async function shouldShowUI(args: { showUI?: boolean }): Promise<boolean> {
+async function shouldShowUI(args: { showUI?: boolean }, toolConfigKey?: keyof ServerConfig): Promise<boolean> {
   if (args.showUI !== undefined) return args.showUI;
   const config = await configManager.getConfig();
-  return config.showMcpUI ?? true;
+  const globalDefault = config.showMcpUI ?? true;
+  if (toolConfigKey !== undefined) {
+    const perTool = config[toolConfigKey];
+    if (typeof perTool === 'boolean') return perTool;
+  }
+  return globalDefault;
 }
 
 // Store startup messages to send after initialization
@@ -1234,7 +1240,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
             case "get_config":
                 try {
                     result = await getConfig();
-                    if (result && !result.isError && await shouldShowUI(args as { showUI?: boolean })) {
+                    if (result && !result.isError && await shouldShowUI(args as { showUI?: boolean }, 'showGetConfigUI')) {
                         (result as any)._meta = buildUiToolMeta(CONFIG_EDITOR_RESOURCE_URI, true);
                     }
                 } catch (error) {
@@ -1386,7 +1392,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
             // Filesystem tools
             case "read_file":
                 result = await handlers.handleReadFile(args);
-                if (result && !result.isError && await shouldShowUI(args as { showUI?: boolean })) {
+                if (result && !result.isError && await shouldShowUI(args as { showUI?: boolean }, 'showReadFileUI')) {
                     (result as any)._meta = buildUiToolMeta(FILE_PREVIEW_RESOURCE_URI, true);
                 }
                 break;
@@ -1409,7 +1415,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
 
             case "list_directory":
                 result = await handlers.handleListDirectory(args);
-                if (result && !result.isError && await shouldShowUI(args as { showUI?: boolean })) {
+                if (result && !result.isError && await shouldShowUI(args as { showUI?: boolean }, 'showListDirectoryUI')) {
                     (result as any)._meta = buildUiToolMeta(FILE_PREVIEW_RESOURCE_URI, true);
                 }
                 break;

--- a/src/server.ts
+++ b/src/server.ts
@@ -53,7 +53,6 @@ import {
 } from './tools/schemas.js';
 import { getConfig, setConfigValue } from './tools/config.js';
 import { configManager } from './config-manager.js';
-import type { ServerConfig } from './config-manager.js';
 import { getUsageStats } from './tools/usage.js';
 import { giveFeedbackToDesktopCommander } from './tools/feedback.js';
 import { getPrompts } from './tools/prompts.js';
@@ -73,20 +72,7 @@ import {
 } from './ui/contracts.js';
 import { listUiResources, readUiResource } from './ui/resources.js';
 
-/**
- * Resolve whether a tool call should render an MCP UI widget.
- * Priority: per-call `showUI` arg > per-tool config > global `showMcpUI` config > true (default on).
- */
-async function shouldShowUI(args: { showUI?: boolean }, toolConfigKey?: keyof ServerConfig): Promise<boolean> {
-  if (args.showUI !== undefined) return args.showUI;
-  const config = await configManager.getConfig();
-  const globalDefault = config.showMcpUI ?? true;
-  if (toolConfigKey !== undefined) {
-    const perTool = config[toolConfigKey];
-    if (typeof perTool === 'boolean') return perTool;
-  }
-  return globalDefault;
-}
+
 
 // Store startup messages to send after initialization
 const deferredMessages: Array<{ level: string, message: string }> = [];
@@ -266,7 +252,6 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                         - clientHistory (history of all clients that have connected)
                         - version (version of the DesktopCommander)
                         - systemInfo (operating system and environment details)
-                        Pass showUI=false to suppress the UI widget for this call only.
                         ${CMD_PREFIX_DESCRIPTION}`,
                 inputSchema: zodToJsonSchema(GetConfigArgsSchema),
                 ...(showGetConfigUIMeta ? { _meta: buildUiToolMeta(CONFIG_EDITOR_RESOURCE_URI, true) } : {}),
@@ -361,7 +346,6 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                           * For BULK changes (translation, mass replacements): use start_process with Python
                             zipfile module to find/replace all <w:t> elements at once.
 
-                        Pass showUI=false to suppress the interactive UI widget for this call only. Global default is controlled by the showMcpUI config setting.
                         ${PATH_GUIDANCE}
                         ${CMD_PREFIX_DESCRIPTION}`,
                 inputSchema: zodToJsonSchema(ReadFileArgsSchema),
@@ -548,7 +532,6 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                         
                         If a directory cannot be accessed, it will show [DENIED] instead.
                         Only works within allowed directories.
-                        Pass showUI=false to suppress the interactive UI widget for this call only. Global default is controlled by the showMcpUI config setting.
                         ${PATH_GUIDANCE}
                         ${CMD_PREFIX_DESCRIPTION}`,
                 inputSchema: zodToJsonSchema(ListDirectoryArgsSchema),
@@ -1247,9 +1230,6 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
             case "get_config":
                 try {
                     result = await getConfig();
-                    if (result && !result.isError && await shouldShowUI(args as { showUI?: boolean }, 'showGetConfigUI')) {
-                        (result as any)._meta = buildUiToolMeta(CONFIG_EDITOR_RESOURCE_URI, true);
-                    }
                 } catch (error) {
                     capture('server_request_error', { message: `Error in get_config handler: ${error}` });
                     result = {
@@ -1404,9 +1384,6 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
             // Filesystem tools
             case "read_file":
                 result = await handlers.handleReadFile(args);
-                if (result && !result.isError && await shouldShowUI(args as { showUI?: boolean }, 'showReadFileUI')) {
-                    (result as any)._meta = buildUiToolMeta(FILE_PREVIEW_RESOURCE_URI, true);
-                }
                 break;
 
             case "read_multiple_files":
@@ -1427,9 +1404,6 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
 
             case "list_directory":
                 result = await handlers.handleListDirectory(args);
-                if (result && !result.isError && await shouldShowUI(args as { showUI?: boolean }, 'showListDirectoryUI')) {
-                    (result as any)._meta = buildUiToolMeta(FILE_PREVIEW_RESOURCE_URI, true);
-                }
                 break;
 
             case "move_file":

--- a/src/server.ts
+++ b/src/server.ts
@@ -241,6 +241,13 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
     try {
         // logToStderr('debug', 'Generating tools list...');
 
+        // Resolve UI visibility config once for tool definition _meta
+        const uiConfig = await configManager.getConfig();
+        const globalUI = uiConfig.showMcpUI ?? true;
+        const showReadFileUIMeta   = typeof uiConfig.showReadFileUI   === 'boolean' ? uiConfig.showReadFileUI   : globalUI;
+        const showListDirUIMeta    = typeof uiConfig.showListDirectoryUI === 'boolean' ? uiConfig.showListDirectoryUI : globalUI;
+        const showGetConfigUIMeta  = typeof uiConfig.showGetConfigUI  === 'boolean' ? uiConfig.showGetConfigUI  : globalUI;
+
         // Build complete tools array
         const allTools = [
             // Configuration tools
@@ -262,7 +269,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                         Pass showUI=false to suppress the UI widget for this call only.
                         ${CMD_PREFIX_DESCRIPTION}`,
                 inputSchema: zodToJsonSchema(GetConfigArgsSchema),
-                _meta: buildUiToolMeta(CONFIG_EDITOR_RESOURCE_URI, true),
+                ...(showGetConfigUIMeta ? { _meta: buildUiToolMeta(CONFIG_EDITOR_RESOURCE_URI, true) } : {}),
                 annotations: {
                     title: "Get Configuration",
                     readOnlyHint: true,
@@ -358,7 +365,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                         ${PATH_GUIDANCE}
                         ${CMD_PREFIX_DESCRIPTION}`,
                 inputSchema: zodToJsonSchema(ReadFileArgsSchema),
-                _meta: buildUiToolMeta(FILE_PREVIEW_RESOURCE_URI, true),
+                ...(showReadFileUIMeta ? { _meta: buildUiToolMeta(FILE_PREVIEW_RESOURCE_URI, true) } : {}),
                 annotations: {
                     title: "Read File or URL",
                     readOnlyHint: true,
@@ -545,7 +552,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                         ${PATH_GUIDANCE}
                         ${CMD_PREFIX_DESCRIPTION}`,
                 inputSchema: zodToJsonSchema(ListDirectoryArgsSchema),
-                _meta: buildUiToolMeta(FILE_PREVIEW_RESOURCE_URI, true),
+                ...(showListDirUIMeta ? { _meta: buildUiToolMeta(FILE_PREVIEW_RESOURCE_URI, true) } : {}),
                 annotations: {
                     title: "List Directory Contents",
                     readOnlyHint: true,
@@ -1254,6 +1261,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
             case "set_config_value":
                 try {
                     result = await setConfigValue(args);
+                    // Notify client to re-fetch tools list if a UI visibility setting changed
+                    const UI_CONFIG_KEYS = new Set(['showMcpUI', 'showReadFileUI', 'showListDirectoryUI', 'showGetConfigUI']);
+                    if (!result.isError && args && typeof args === 'object' && UI_CONFIG_KEYS.has((args as any).key)) {
+                        server.sendToolListChanged();
+                    }
                 } catch (error) {
                     capture('server_request_error', { message: `Error in set_config_value handler: ${error}` });
                     result = {

--- a/src/tools/config.ts
+++ b/src/tools/config.ts
@@ -9,6 +9,7 @@ import {
   CONFIG_FIELD_DEFINITIONS,
   CONFIG_FIELD_KEYS,
   isConfigFieldKey,
+  type ConfigFieldDefinition,
 } from '../config-field-definitions.js';
 
 const ALLOWED_CONFIG_KEYS = new Set(CONFIG_FIELD_KEYS);
@@ -129,7 +130,8 @@ export async function getConfig() {
         },
         entries: CONFIG_FIELD_KEYS.map((key) => {
           const definition = CONFIG_FIELD_DEFINITIONS[key];
-          const value = (configWithSystemInfo as Record<string, unknown>)[key];
+          const rawValue = (configWithSystemInfo as Record<string, unknown>)[key];
+          const value = rawValue !== undefined ? rawValue : (definition as ConfigFieldDefinition).defaultValue;
           return {
             key,
             value,

--- a/src/tools/config.ts
+++ b/src/tools/config.ts
@@ -137,6 +137,7 @@ export async function getConfig() {
             value,
             valueType: definition.valueType,
             editable: true,
+            parentKey: (definition as ConfigFieldDefinition).parentKey,
           };
         }),
       },

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -1,9 +1,7 @@
 import { z } from "zod";
 
 // Config tools schemas
-export const GetConfigArgsSchema = z.object({
-  showUI: z.boolean().optional(),
-});
+export const GetConfigArgsSchema = z.object({});
 
 export const SetConfigValueArgsSchema = z.object({
   key: z.string(),
@@ -55,7 +53,6 @@ export const ReadFileArgsSchema = z.object({
   sheet: z.string().optional(),  // String only for MCP client compatibility (Cursor doesn't support union types in JSON Schema)
   range: z.string().optional(),
   options: z.record(z.any()).optional(),
-  showUI: z.boolean().optional(),
 });
 
 export const ReadMultipleFilesArgsSchema = z.object({
@@ -114,7 +111,6 @@ export const CreateDirectoryArgsSchema = z.object({
 export const ListDirectoryArgsSchema = z.object({
   path: z.string(),
   depth: z.number().optional().default(2),
-  showUI: z.boolean().optional(),
 });
 
 export const MoveFileArgsSchema = z.object({

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -1,7 +1,9 @@
 import { z } from "zod";
 
 // Config tools schemas
-export const GetConfigArgsSchema = z.object({});
+export const GetConfigArgsSchema = z.object({
+  showUI: z.boolean().optional(),
+});
 
 export const SetConfigValueArgsSchema = z.object({
   key: z.string(),
@@ -52,7 +54,8 @@ export const ReadFileArgsSchema = z.object({
   length: z.number().optional().default(1000),
   sheet: z.string().optional(),  // String only for MCP client compatibility (Cursor doesn't support union types in JSON Schema)
   range: z.string().optional(),
-  options: z.record(z.any()).optional()
+  options: z.record(z.any()).optional(),
+  showUI: z.boolean().optional(),
 });
 
 export const ReadMultipleFilesArgsSchema = z.object({
@@ -111,6 +114,7 @@ export const CreateDirectoryArgsSchema = z.object({
 export const ListDirectoryArgsSchema = z.object({
   path: z.string(),
   depth: z.number().optional().default(2),
+  showUI: z.boolean().optional(),
 });
 
 export const MoveFileArgsSchema = z.object({

--- a/src/ui/config-editor/src/app.ts
+++ b/src/ui/config-editor/src/app.ts
@@ -16,6 +16,7 @@ export interface ConfigEntry {
     value: unknown;
     valueType: 'string' | 'number' | 'boolean' | 'array' | 'null' | string;
     editable: boolean;
+    parentKey?: string;
 }
 
 export interface ConfigEditorPayload {
@@ -164,6 +165,7 @@ function extractPayload(result: unknown): ConfigEditorPayload | null {
                 value: entry.value,
                 valueType: typeof entry.valueType === 'string' ? entry.valueType : 'string',
                 editable: entry.editable !== false,
+                parentKey: typeof entry.parentKey === 'string' ? entry.parentKey : undefined,
             };
         });
 
@@ -549,6 +551,12 @@ function render(container: HTMLElement, controller: ReturnType<typeof createConf
         const description = entry.description ?? '';
         const summary = getSettingSummary(entry);
 
+        // Determine if this child entry is disabled because its parent is off
+        const isChild = !!entry.parentKey;
+        const parentEntry = entry.parentKey ? entries.find(e => e.key === entry.parentKey) : undefined;
+        const parentIsOff = parentEntry !== undefined && String(parentEntry.value) !== 'true';
+        const childDisabled = isChild && parentIsOff;
+
         let controlHtml: string;
         if (entry.key === 'defaultShell') {
             const currentShell = String(entry.value ?? '');
@@ -568,7 +576,8 @@ function render(container: HTMLElement, controller: ReturnType<typeof createConf
             `;
         } else if (entry.valueType === 'boolean') {
             const checked = String(entry.value) === 'true' ? 'checked' : '';
-            controlHtml = `<label class="setting-switch"><input type="checkbox" data-action="toggle-boolean" data-key-index="${index}" ${checked}/><span class="config-boolean-slider"></span></label>`;
+            const disabledAttr = childDisabled ? 'disabled' : '';
+            controlHtml = `<label class="setting-switch"><input type="checkbox" data-action="toggle-boolean" data-key-index="${index}" ${checked} ${disabledAttr}/><span class="config-boolean-slider"></span></label>`;
         } else if (entry.valueType === 'number') {
             controlHtml = `<input class="setting-inline-input" data-action="edit-number" data-key-index="${index}" type="number" step="any" value="${escapeHtml(String(entry.value ?? ''))}"/>`;
         } else if (entry.valueType === 'array') {
@@ -579,8 +588,10 @@ function render(container: HTMLElement, controller: ReturnType<typeof createConf
             controlHtml = `<input class="setting-inline-input" data-action="edit-string" data-key-index="${index}" type="text" value="${escapeHtml(String(entry.value ?? ''))}"/>`;
         }
 
+        const rowClasses = ['setting-row', isChild ? 'setting-row--child' : '', childDisabled ? 'setting-row--disabled' : ''].filter(Boolean).join(' ');
+
         return `
-          <section class="setting-row">
+          <section class="${rowClasses}">
             <div class="setting-info">
               <h3>${escapeHtml(keyTitle)}</h3>
               ${description ? `<p>${escapeHtml(description)}</p>` : ''}

--- a/src/ui/file-preview/src/app.ts
+++ b/src/ui/file-preview/src/app.ts
@@ -806,7 +806,15 @@ export function renderApp(
     shellController = undefined;
 
     if (!payload) {
-        renderStatusState(container, 'No preview available for this response.');
+        // No structuredContent — widget is suppressed via config (showReadFileUI/showListDirectoryUI).
+        // Render zero-height so autoResize reports height:0 and the host collapses the iframe.
+        container.innerHTML = '';
+        document.documentElement.style.height = '0';
+        document.documentElement.style.overflow = 'hidden';
+        document.body.style.height = '0';
+        document.body.style.margin = '0';
+        document.body.style.padding = '0';
+        document.body.style.overflow = 'hidden';
         onRender?.();
         return;
     }

--- a/src/ui/styles/apps/config-editor.css
+++ b/src/ui/styles/apps/config-editor.css
@@ -76,6 +76,18 @@ body {
   border-top: 1px solid color-mix(in srgb, var(--cfg-border) 40%, transparent);
 }
 
+.setting-row--child {
+  padding-left: 20px;
+  border-left: 2px solid color-mix(in srgb, var(--cfg-border) 60%, transparent);
+  margin-left: 4px;
+  background: color-mix(in srgb, var(--cfg-bg) 60%, transparent);
+}
+
+.setting-row--disabled {
+  opacity: 0.45;
+  pointer-events: none;
+}
+
 .setting-info h3 {
   margin: 0;
   font-size: 14px;

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '0.2.37';
+export const VERSION = '0.2.38';


### PR DESCRIPTION
## What

Adds user control over whether tools render interactive UI widgets in Claude Desktop.

## Config fields added

| Key | Type | Default | Description |
|-----|------|---------|-------------|
| `showMcpUI` | boolean | true | Global default for all three tools |
| `showReadFileUI` | boolean | true | Per-tool override for `read_file` |
| `showListDirectoryUI` | boolean | true | Per-tool override for `list_directory` |
| `showGetConfigUI` | boolean | true | Per-tool override for `get_config` |

## How it works

- Tool definitions in `tools/list` response now conditionally include `_meta` based on config (this is what Claude Desktop actually respects — response-level `_meta` is ignored)
- When a UI config key is changed via `set_config_value`, `server.sendToolListChanged()` is called so the client re-fetches tools immediately without restart
- Per-call `showUI` param on `read_file`, `list_directory`, `get_config` still works as a one-shot override
- Priority chain: `showUI` arg → per-tool config → `showMcpUI` → `true`

## Config editor UI

- All four fields appear as toggle switches in the config editor widget
- Per-tool toggles are visually grouped under the global toggle (indented, left border)
- When global `showMcpUI` is off, child toggles dim (opacity 0.45, pointer-events none)
- `defaultValue` fallback ensures toggles show correctly even before values are persisted to disk

## Key learnings

Claude Desktop reads `_meta` from the **tool definition** (tools/list response), not from individual tool call responses. The fix is to rebuild the tools list dynamically on each `tools/list` request and notify the client when config changes.