### PR TITLE
Fix command injection via newline and quoting/wildcard blocklist bypass

### DIFF
--- a/src/command-manager.ts
+++ b/src/command-manager.ts
@@ -249,6 +249,11 @@ class CommandManager {
             // If there are no commands extracted, fall back to base command
             if (allCommands.length === 0) {
                 const baseCommand = this.getBaseCommand(command);
+                // Reject if the base command contains glob/wildcard characters
+                // to prevent bypass via e.g. /usr/bin/su*o (#421)
+                if (/[*?\[\]]/.test(baseCommand)) {
+                    return false;
+                }
                 return !blockedCommands.includes(baseCommand);
             }
             

--- a/src/command-manager.ts
+++ b/src/command-manager.ts
@@ -138,7 +138,8 @@ class CommandManager {
                         // We found a separator - extract the command before it
                         if (currentCmd.trim()) {
                             const baseCommand = this.extractBaseCommand(currentCmd.trim());
-                            if (baseCommand) commands.push(baseCommand);
+                            // null means glob/invalid — push sentinel so validateCommand fails closed
+                            commands.push(baseCommand !== null ? baseCommand : '__INVALID_COMMAND__');
                         }
 
                         // Move past the separator
@@ -157,7 +158,8 @@ class CommandManager {
             // Don't forget to add the last command
             if (currentCmd.trim()) {
                 const baseCommand = this.extractBaseCommand(currentCmd.trim());
-                if (baseCommand) commands.push(baseCommand);
+                // null means glob/invalid — push sentinel so validateCommand fails closed
+                commands.push(baseCommand !== null ? baseCommand : '__INVALID_COMMAND__');
             }
 
             // Remove duplicates and return
@@ -222,9 +224,9 @@ class CommandManager {
             // "r"m, r"m", 'r''m' are normalized to the actual command name (#421)
             firstToken = firstToken.replace(/["']/g, '');
 
-            // Reject commands containing glob/wildcard characters to prevent
-            // wildcard-based blocklist bypass, e.g. /usr/bin/su*o (#421)
-            if (/[*?\[\]]/.test(firstToken)) {
+            // Reject commands containing glob/wildcard or brace-expansion characters
+            // to prevent blocklist bypass, e.g. /usr/bin/su*o or /usr/bin/s{udo,x} (#421)
+            if (/[*?\[\]{}]/.test(firstToken)) {
                 return null;
             }
 
@@ -249,14 +251,20 @@ class CommandManager {
             // If there are no commands extracted, fall back to base command
             if (allCommands.length === 0) {
                 const baseCommand = this.getBaseCommand(command);
-                // Reject if the base command contains glob/wildcard characters
-                // to prevent bypass via e.g. /usr/bin/su*o (#421)
-                if (/[*?\[\]]/.test(baseCommand)) {
+                // Reject if the base command contains glob/wildcard/brace characters
+                // to prevent bypass via e.g. /usr/bin/su*o or s{udo,x} (#421)
+                if (/[*?\[\]{}]/.test(baseCommand)) {
                     return false;
                 }
                 return !blockedCommands.includes(baseCommand);
             }
-            
+
+            // Fail closed: if any segment failed extraction (e.g. contained a glob),
+            // reject the entire command rather than silently ignoring the bad segment.
+            if (allCommands.includes('__INVALID_COMMAND__')) {
+                return false;
+            }
+
             // Check if any of the extracted commands are in the blocked list
             for (const cmd of allCommands) {
                 if (blockedCommands.includes(cmd)) {

--- a/src/command-manager.ts
+++ b/src/command-manager.ts
@@ -14,7 +14,8 @@ class CommandManager {
             commandString = commandString.trim();
 
             // Define command separators - these are the operators that can chain commands
-            const separators = [';', '&&', '||', '|', '&'];
+            // Include newline variants to prevent newline-based blocklist bypass (#422)
+            const separators = ['\r\n', '\n', '\r', ';', '&&', '||', '|', '&'];
 
             // This will store our extracted commands
             const commands: string[] = [];
@@ -217,6 +218,18 @@ class CommandManager {
                 return null;
             }
 
+            // Strip surrounding quotes so that e.g. "rm" is caught as rm (#421)
+            if ((firstToken.startsWith('"') && firstToken.endsWith('"')) ||
+                (firstToken.startsWith("'") && firstToken.endsWith("'"))) {
+                firstToken = firstToken.slice(1, -1);
+            }
+
+            // Reject commands containing glob/wildcard characters to prevent
+            // wildcard-based blocklist bypass, e.g. /usr/bin/su*o (#421)
+            if (/[*?\[\]]/.test(firstToken)) {
+                return null;
+            }
+
             // strip path prefix so /usr/bin/sudo gets caught as "sudo"
             const baseName = path.basename(firstToken);
             return baseName.toLowerCase();
@@ -231,6 +244,12 @@ class CommandManager {
             // Get blocked commands from config
             const config = await configManager.getConfig();
             const blockedCommands = config.blockedCommands || [];
+
+            // Reject commands containing glob/wildcard characters outright (#421)
+            // These could be used to bypass blocklist matching via shell expansion
+            if (/[*?\[\]]/.test(command)) {
+                return false;
+            }
             
             // Extract all commands from the command string
             const allCommands = this.extractCommands(command);

--- a/src/command-manager.ts
+++ b/src/command-manager.ts
@@ -218,11 +218,9 @@ class CommandManager {
                 return null;
             }
 
-            // Strip surrounding quotes so that e.g. "rm" is caught as rm (#421)
-            if ((firstToken.startsWith('"') && firstToken.endsWith('"')) ||
-                (firstToken.startsWith("'") && firstToken.endsWith("'"))) {
-                firstToken = firstToken.slice(1, -1);
-            }
+            // Strip all quote characters so that concatenated fragments like
+            // "r"m, r"m", 'r''m' are normalized to the actual command name (#421)
+            firstToken = firstToken.replace(/["']/g, '');
 
             // Reject commands containing glob/wildcard characters to prevent
             // wildcard-based blocklist bypass, e.g. /usr/bin/su*o (#421)
@@ -245,12 +243,6 @@ class CommandManager {
             const config = await configManager.getConfig();
             const blockedCommands = config.blockedCommands || [];
 
-            // Reject commands containing glob/wildcard characters outright (#421)
-            // These could be used to bypass blocklist matching via shell expansion
-            if (/[*?\[\]]/.test(command)) {
-                return false;
-            }
-            
             // Extract all commands from the command string
             const allCommands = this.extractCommands(command);
             


### PR DESCRIPTION
## **User description**
## Summary

Fixes two critical command injection vulnerabilities in `src/command-manager.ts` that allow complete bypass of the `blockedCommands` security feature:

- **Newline bypass (#422):** `extractCommands()` did not treat newline characters as command separators. An attacker could inject `echo benign\nrm -rf /` and validation would only check `echo`, while the shell would execute both commands. Fixed by adding `\r\n`, `\n`, `\r` to the separators array.

- **Quoting and wildcard bypass (#421):** `extractBaseCommand()` did not strip quotes from tokens, so `"rm"` would not match the blocked command `rm`. Wildcard paths like `/usr/bin/su*o` would also evade literal blocklist matching but expand at shell execution time. Fixed by stripping surrounding quotes before comparison and rejecting any command containing glob characters (`*`, `?`, `[`, `]`).

## Changes

All changes are in `src/command-manager.ts`:
- Add `\r\n`, `\n`, `\r` to the `separators` array in `extractCommands()`
- Strip surrounding single/double quotes from command tokens in `extractBaseCommand()`
- Reject commands containing glob/wildcard characters in both `extractBaseCommand()` and `validateCommand()`

## Test plan

- [ ] Verify `echo benign\nrm file` is correctly split into two commands and `rm` is blocked
- [ ] Verify `"rm" file` is correctly identified as `rm` and blocked
- [ ] Verify `/usr/bin/su*o` is rejected outright due to glob characters
- [ ] Verify normal commands without quotes, globs, or newlines continue to work
- [ ] Verify existing test suite passes (`npm test`)

Closes #421
Closes #422

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Commands containing wildcard or brace characters are now rejected to prevent unsafe patterns.
  * Line breaks are recognized and treated as separators so each line is validated independently.
  * Command tokens are normalized (quotes removed) for consistent validation.
  * Inputs fail-closed: any invalid segment now causes the whole input to be rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Block command-bypass tricks in command validation

### What Changed
- Commands split across new lines are now checked separately, so a hidden second command is not allowed through
- Quoted command names and mixed quote fragments are now recognized as the real command, so blocked commands cannot slip past by adding quotes
- Commands with wildcard or brace patterns in the command name are now rejected instead of being treated as safe

### Impact
`✅ Fewer command injection bypasses`
`✅ Safer blocked-command enforcement`
`✅ Clearer rejection of unsafe command patterns`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=7qwiQbvZ_ew43VWoGPSXUy9ut17e14z-HZBE_OW3l7A&org=wonderwhy-er)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
