### PR TITLE
test(conditional-tools): fix stale client name and cover get_prompts

### DIFF
--- a/test/test-conditional-tools.js
+++ b/test/test-conditional-tools.js
@@ -46,11 +46,11 @@ async function testConditionalTools() {
     // Wait a bit between tests
     await new Promise(resolve => setTimeout(resolve, 1000));
 
-    // Test 2: desktop-commander client (should exclude feedback tool)
-    console.log('\nTest 2: Testing with desktop-commander client (should exclude feedback tool)...');
+    // Test 2: desktop-commander-app client (should exclude feedback tool and get_prompts)
+    console.log('\nTest 2: Testing with desktop-commander-app client (should exclude feedback tool and get_prompts)...');
     const dcClient = new Client(
         {
-            name: "desktop-commander",
+            name: "desktop-commander-app",
             version: "1.0.0"
         },
         {
@@ -67,13 +67,22 @@ async function testConditionalTools() {
     const dcTools = await dcClient.listTools();
 
     const hasFeedbackDC = dcTools.tools.some(t => t.name === 'give_feedback_to_desktop_commander');
+    const hasGetPromptsDC = dcTools.tools.some(t => t.name === 'get_prompts');
     console.log(`   Tools count: ${dcTools.tools.length}`);
     console.log(`   Has give_feedback_to_desktop_commander: ${hasFeedbackDC}`);
+    console.log(`   Has get_prompts: ${hasGetPromptsDC}`);
 
     if (!hasFeedbackDC) {
-        console.log('   ✅ PASS: Feedback tool is excluded for desktop-commander client');
+        console.log('   ✅ PASS: Feedback tool is excluded for desktop-commander-app client');
     } else {
-        console.log('   ❌ FAIL: Feedback tool should be excluded for desktop-commander client');
+        console.log('   ❌ FAIL: Feedback tool should be excluded for desktop-commander-app client');
+        process.exit(1);
+    }
+
+    if (!hasGetPromptsDC) {
+        console.log('   ✅ PASS: get_prompts is excluded for desktop-commander-app client');
+    } else {
+        console.log('   ❌ FAIL: get_prompts should be excluded for desktop-commander-app client');
         process.exit(1);
     }
 


### PR DESCRIPTION
## **User description**
## Problem

`test-conditional-tools.js` has been failing on main. Two issues:

1. **Stale client name.** The server checks `currentClient.name === 'desktop-commander-app'` (see `src/server.ts` `shouldIncludeTool`), but the test was connecting as `"desktop-commander"`, so the hidden-tool assertion in Test 2 always failed.

2. **Incomplete coverage.** PR #409 extended the filter to hide both `give_feedback_to_desktop_commander` **and** `get_prompts` for the DC-as-client case, but the test only asserted on the feedback tool.

## Fix

- Update the test client name to `desktop-commander-app` to match what the server expects.
- Add assertion that `get_prompts` is also hidden for this client.

## Verification

```
Test 2: Testing with desktop-commander-app client (should exclude feedback tool and get_prompts)...
   Tools count: 24
   Has give_feedback_to_desktop_commander: false
   Has get_prompts: false
   ✅ PASS: Feedback tool is excluded for desktop-commander-app client
   ✅ PASS: get_prompts is excluded for desktop-commander-app client
```

Tool count drops from 26 → 24 as expected (both tools hidden).

## Scope

This is an independent fix off main. Does not depend on any in-flight feature branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test suite configurations and validations for client-side tool detection and behavior verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Confirm the desktop-commander-app client hides both conditional tools**

### What Changed
- Uses the correct client name for the desktop-commander-app test case
- Verifies that both `give_feedback_to_desktop_commander` and `get_prompts` are hidden for that client
- Keeps the regular client case unchanged

### Impact
`✅ Accurate conditional tool coverage`
`✅ Fewer false test failures`
`✅ Safer checks for hidden tools`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=BY5q7VqCv5ndZ7dUkhfffrIYxmejXaQ_GJRSBu2MARU&org=wonderwhy-er)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
