### PR TITLE
Set limit size on file for tool history log

### DIFF
--- a/src/utils/toolHistory.ts
+++ b/src/utils/toolHistory.ts
@@ -32,6 +32,7 @@ function formatLocalTimestamp(isoTimestamp: string): string {
 class ToolHistory {
   private history: ToolCallRecord[] = [];
   private readonly MAX_ENTRIES = 1000;
+  private readonly MAX_HISTORY_FILE_SIZE_BYTES = 5 * 1024 * 1024;
   private readonly historyFile: string;
   private writeQueue: ToolCallRecord[] = [];
   private isWriting = false;
@@ -65,6 +66,11 @@ class ToolHistory {
         return;
       }
 
+      if (this.clearHistoryFileIfTooLarge()) {
+        this.history = [];
+        return;
+      }
+
       const content = fs.readFileSync(this.historyFile, 'utf-8');
       const lines = content.trim().split('\n').filter(line => line.trim());
 
@@ -91,6 +97,32 @@ class ToolHistory {
   }
 
   /**
+   * Clear history file when it exceeds the maximum size.
+   */
+  private clearHistoryFileIfTooLarge(): boolean {
+    try {
+      if (!fs.existsSync(this.historyFile)) {
+        return false;
+      }
+
+      const stats = fs.statSync(this.historyFile);
+      if (stats.size <= this.MAX_HISTORY_FILE_SIZE_BYTES) {
+        return false;
+      }
+    } catch (error) {
+      return false;
+    }
+
+    try {
+      fs.writeFileSync(this.historyFile, '', 'utf-8');
+    } catch (error) {
+      // Still treat the file as too large so callers can continue with empty memory.
+    }
+
+    return true;
+  }
+
+  /**
    * Trim history file to prevent it from growing indefinitely
    */
   private trimHistoryFile(): void {
@@ -101,6 +133,10 @@ class ToolHistory {
       // Write them back
       const lines = keepEntries.map(entry => JSON.stringify(entry)).join('\n') + '\n';
       fs.writeFileSync(this.historyFile, lines, 'utf-8');
+
+      if (this.clearHistoryFileIfTooLarge()) {
+        this.history = [];
+      }
     } catch (error) {
       // Silently fail
     }
@@ -131,9 +167,18 @@ class ToolHistory {
     this.writeQueue = [];
     
     try {
+      const clearedLargeFile = this.clearHistoryFileIfTooLarge();
+      if (clearedLargeFile) {
+        this.history = toWrite.slice(-this.MAX_ENTRIES);
+      }
+
       // Append to file (atomic append operation)
       const lines = toWrite.map(entry => JSON.stringify(entry)).join('\n') + '\n';
       fs.appendFileSync(this.historyFile, lines, 'utf-8');
+
+      if (this.clearHistoryFileIfTooLarge()) {
+        this.history = [];
+      }
     } catch (error) {
       // Put back in queue on failure
       this.writeQueue.unshift(...toWrite);

--- a/src/utils/toolHistory.ts
+++ b/src/utils/toolHistory.ts
@@ -33,6 +33,10 @@ class ToolHistory {
   private history: ToolCallRecord[] = [];
   private readonly MAX_ENTRIES = 1000;
   private readonly MAX_HISTORY_FILE_SIZE_BYTES = 5 * 1024 * 1024;
+  // When the file exceeds the cap we trim it down to this target instead of
+  // all the way to zero, so a single overflow doesn't cause every subsequent
+  // flush to re-trim.
+  private readonly HISTORY_FILE_TRIM_TARGET_BYTES = 4 * 1024 * 1024;
   private readonly historyFile: string;
   private writeQueue: ToolCallRecord[] = [];
   private isWriting = false;
@@ -66,10 +70,9 @@ class ToolHistory {
         return;
       }
 
-      if (this.clearHistoryFileIfTooLarge()) {
-        this.history = [];
-        return;
-      }
+      // If the file is over the cap, trim it down before reading so we
+      // load a bounded amount.
+      this.trimHistoryFileIfTooLarge();
 
       const content = fs.readFileSync(this.historyFile, 'utf-8');
       const lines = content.trim().split('\n').filter(line => line.trim());
@@ -97,15 +100,22 @@ class ToolHistory {
   }
 
   /**
-   * Clear history file when it exceeds the maximum size.
+   * Trim the on-disk history file to stay under the size cap by dropping the
+   * oldest entries (lines) until the kept tail fits within the trim target.
+   * Returns true only when the file was actually rewritten with a smaller
+   * tail, so callers can fall through to their normal path on failure or
+   * no-op rather than mutating in-memory state.
+   *
+   * Always keeps at least the most recent entry, even if a single record
+   * exceeds the trim target — there is no useful state below that.
    */
-  private clearHistoryFileIfTooLarge(): boolean {
+  private trimHistoryFileIfTooLarge(): boolean {
+    let stats: fs.Stats;
     try {
       if (!fs.existsSync(this.historyFile)) {
         return false;
       }
-
-      const stats = fs.statSync(this.historyFile);
+      stats = fs.statSync(this.historyFile);
       if (stats.size <= this.MAX_HISTORY_FILE_SIZE_BYTES) {
         return false;
       }
@@ -114,12 +124,33 @@ class ToolHistory {
     }
 
     try {
-      fs.writeFileSync(this.historyFile, '', 'utf-8');
-    } catch (error) {
-      // Still treat the file as too large so callers can continue with empty memory.
-    }
+      const content = fs.readFileSync(this.historyFile, 'utf-8');
+      const lines = content.split('\n').filter(line => line.length > 0);
+      if (lines.length === 0) {
+        return false;
+      }
 
-    return true;
+      // Walk lines from newest to oldest, accumulating bytes (line + '\n'),
+      // and keep as many as fit within the trim target. Always keep at
+      // least the last line.
+      const kept: string[] = [];
+      let bytes = 0;
+      for (let i = lines.length - 1; i >= 0; i--) {
+        const lineBytes = Buffer.byteLength(lines[i], 'utf-8') + 1; // +1 for '\n'
+        if (kept.length > 0 && bytes + lineBytes > this.HISTORY_FILE_TRIM_TARGET_BYTES) {
+          break;
+        }
+        kept.push(lines[i]);
+        bytes += lineBytes;
+      }
+      kept.reverse();
+
+      fs.writeFileSync(this.historyFile, kept.join('\n') + '\n', 'utf-8');
+      return true;
+    } catch (error) {
+      // Trim failed; do not claim the file was changed.
+      return false;
+    }
   }
 
   /**
@@ -133,10 +164,6 @@ class ToolHistory {
       // Write them back
       const lines = keepEntries.map(entry => JSON.stringify(entry)).join('\n') + '\n';
       fs.writeFileSync(this.historyFile, lines, 'utf-8');
-
-      if (this.clearHistoryFileIfTooLarge()) {
-        this.history = [];
-      }
     } catch (error) {
       // Silently fail
     }
@@ -161,24 +188,21 @@ class ToolHistory {
    */
   private async flushToDisk(): Promise<void> {
     if (this.isWriting || this.writeQueue.length === 0) return;
-    
+
     this.isWriting = true;
     const toWrite = [...this.writeQueue];
     this.writeQueue = [];
-    
+
     try {
-      const clearedLargeFile = this.clearHistoryFileIfTooLarge();
-      if (clearedLargeFile) {
-        this.history = toWrite.slice(-this.MAX_ENTRIES);
-      }
+      // If the on-disk file has grown past the cap, trim it down to the
+      // target size (keeping the most recent entries) before appending.
+      // The in-memory cache is unaffected — it is already bounded by
+      // MAX_ENTRIES via addCall.
+      this.trimHistoryFileIfTooLarge();
 
       // Append to file (atomic append operation)
       const lines = toWrite.map(entry => JSON.stringify(entry)).join('\n') + '\n';
       fs.appendFileSync(this.historyFile, lines, 'utf-8');
-
-      if (this.clearHistoryFileIfTooLarge()) {
-        this.history = [];
-      }
     } catch (error) {
       // Put back in queue on failure
       this.writeQueue.unshift(...toWrite);


### PR DESCRIPTION
## **User description**
For tool call log file there are no limit, it can grow huge. 
With this PR there is a limit of 5 MB, if file is bigger than 5 mb it will be cleared and histroy starts from empty file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tool history now enforces a 5 MiB maximum and automatically trims old entries to keep the most recent data (targeting a smaller retained size). Trimming runs at startup and before periodic saves so history stays bounded and storage/performance remain consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Keep recent tool history when the log file exceeds its size limit**

### What Changed
- When the tool history log grows past 5 MB, it now removes the oldest entries and keeps the most recent calls instead of clearing the file
- Recent tool calls remain available after restart and after new calls are saved
- If trimming the log fails, the existing history is left in place instead of being erased

### Impact
`✅ Fewer empty tool history views`
`✅ Less loss of recent tool calls`
`✅ Smaller oversized log files`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=N7RJIhGFLdcMc4x2cUuiqLQtUxA6k8bkMs8AgwG-4F8&org=wonderwhy-er)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
