### PR TITLE
fix: skip frontmatter when rewriting wiki links

### DIFF
--- a/src/ui/file-preview/src/markdown/linking.ts
+++ b/src/ui/file-preview/src/markdown/linking.ts
@@ -17,6 +17,7 @@ interface ParsedWikiLink {
 
 const WIKI_LINK_PATTERN = /\[\[([^\]|#]*)(?:#([^\]|]+))?(?:\|([^\]]+))?\]\]/g;
 const FENCE_PATTERN = /^(`{3,}|~{3,})/;
+const FRONTMATTER_DELIMITER = '---';
 
 function encodeLinkPath(pathValue: string): string {
     return encodeURI(normalizePathSeparators(pathValue));
@@ -218,8 +219,21 @@ export function restoreWikiLinks(markdown: string): string {
 export function rewriteWikiLinks(source: string): string {
     const lines = source.split('\n');
     let activeFence: string | null = null;
+    let inFrontmatter = lines[0]?.trim() === FRONTMATTER_DELIMITER
+        && lines.slice(1).some((line) => line.trim() === FRONTMATTER_DELIMITER);
 
-    return lines.map((line) => {
+    return lines.map((line, index) => {
+        if (index === 0 && inFrontmatter) {
+            return line;
+        }
+
+        if (inFrontmatter) {
+            if (line.trim() === FRONTMATTER_DELIMITER) {
+                inFrontmatter = false;
+            }
+            return line;
+        }
+
         const trimmedStart = line.trimStart();
         const fenceMatch = trimmedStart.match(FENCE_PATTERN);
         if (fenceMatch) {

--- a/src/ui/file-preview/src/markdown/linking.ts
+++ b/src/ui/file-preview/src/markdown/linking.ts
@@ -17,7 +17,11 @@ interface ParsedWikiLink {
 
 const WIKI_LINK_PATTERN = /\[\[([^\]|#]*)(?:#([^\]|]+))?(?:\|([^\]]+))?\]\]/g;
 const FENCE_PATTERN = /^(`{3,}|~{3,})/;
-const FRONTMATTER_DELIMITER = '---';
+const FRONTMATTER_DELIMITER_PATTERN = /^---\s*$/;
+
+function isFrontmatterDelimiter(line: string | undefined): boolean {
+    return typeof line === 'string' && FRONTMATTER_DELIMITER_PATTERN.test(line);
+}
 
 function encodeLinkPath(pathValue: string): string {
     return encodeURI(normalizePathSeparators(pathValue));
@@ -219,8 +223,8 @@ export function restoreWikiLinks(markdown: string): string {
 export function rewriteWikiLinks(source: string): string {
     const lines = source.split('\n');
     let activeFence: string | null = null;
-    let inFrontmatter = lines[0]?.trim() === FRONTMATTER_DELIMITER
-        && lines.slice(1).some((line) => line.trim() === FRONTMATTER_DELIMITER);
+    let inFrontmatter = isFrontmatterDelimiter(lines[0])
+        && lines.slice(1).some((line) => isFrontmatterDelimiter(line));
 
     return lines.map((line, index) => {
         if (index === 0 && inFrontmatter) {
@@ -228,7 +232,7 @@ export function rewriteWikiLinks(source: string): string {
         }
 
         if (inFrontmatter) {
-            if (line.trim() === FRONTMATTER_DELIMITER) {
+            if (isFrontmatterDelimiter(line)) {
                 inFrontmatter = false;
             }
             return line;

--- a/test/test-markdown-preview.js
+++ b/test/test-markdown-preview.js
@@ -145,6 +145,29 @@ async function testWikiRewriteAndRendering() {
   assert.ok(fencedRewrite.includes('[[Inside Code]]'), 'Long code fences should remain open until a matching-length close fence appears');
   assert.ok(fencedRewrite.includes('[Outside Code](./Outside%20Code.md "mcp-wiki:'), 'Wiki links outside closed fences should still rewrite');
 
+  const frontmatterRewrite = rewriteWikiLinks([
+    '---',
+    'title: My Note',
+    'source_talk: "[[Other Note]]"',
+    'tags: [example]',
+    '---',
+    '',
+    'Body text with a [[Body Link]] for comparison.',
+  ].join('\n'));
+  assert.strictEqual(
+    frontmatterRewrite,
+    [
+      '---',
+      'title: My Note',
+      'source_talk: "[[Other Note]]"',
+      'tags: [example]',
+      '---',
+      '',
+      'Body text with a [Body Link](./Body%20Link.md "mcp-wiki:%5B%5BBody%20Link%5D%5D") for comparison.',
+    ].join('\n'),
+    'YAML frontmatter wikilinks should stay literal while body wikilinks still render',
+  );
+
   const html = renderMarkdown([
     '# Title',
     '## Details',

--- a/test/test-markdown-preview.js
+++ b/test/test-markdown-preview.js
@@ -168,6 +168,31 @@ async function testWikiRewriteAndRendering() {
     'YAML frontmatter wikilinks should stay literal while body wikilinks still render',
   );
 
+  const frontmatterBlockScalarRewrite = rewriteWikiLinks([
+    '---',
+    'title: |',
+    '  intro text',
+    '  ---',
+    'source_talk: "[[Frontmatter Link]]"',
+    '---',
+    '',
+    'Body text with a [[Body Link]] for comparison.',
+  ].join('\n'));
+  assert.strictEqual(
+    frontmatterBlockScalarRewrite,
+    [
+      '---',
+      'title: |',
+      '  intro text',
+      '  ---',
+      'source_talk: "[[Frontmatter Link]]"',
+      '---',
+      '',
+      'Body text with a [Body Link](./Body%20Link.md "mcp-wiki:%5B%5BBody%20Link%5D%5D") for comparison.',
+    ].join('\n'),
+    'Indented --- inside YAML block scalars should not close frontmatter early',
+  );
+
   const html = renderMarkdown([
     '# Title',
     '## Details',


### PR DESCRIPTION
## Summary

- Make `rewriteWikiLinks()` preserve YAML frontmatter when it receives a full markdown document.
- Continue rewriting wikilinks in the markdown body after the closing frontmatter delimiter.
- Add regression coverage for frontmatter wikilinks, body wikilinks, and indented `---` inside YAML block scalars.

## Scope

This is best described as a defensive correctness fix for the markdown rewrite helper.

On current `main`, the editor round-trip path strips YAML frontmatter in `preprocessForEditor()` before handing the body to Tiptap, then re-attaches it during serialization. Because of that, I do not want to claim confirmed current-main on-disk corruption through the normal editor/autosave path.

The issue this PR verifies is narrower: if `rewriteWikiLinks()` / `prepareMarkdownSource()` is called with a complete markdown document that includes YAML frontmatter, wikilinks inside the frontmatter should stay literal metadata rather than being rewritten as body links.

Related to #452.

## Tests

- `node test/test-markdown-preview.js`
- `npm test`
