### PR TITLE
fix: return not-found for missing directories

### DIFF
--- a/src/tools/filesystem.ts
+++ b/src/tools/filesystem.ts
@@ -679,20 +679,17 @@ export async function listDirectory(dirPath: string, depth: number = 2): Promise
     const isAccessDeniedError = (err: NodeJS.ErrnoException) =>
         err.code === 'EPERM' || err.code === 'EACCES' || err.code === 'ETIMEDOUT';
 
-    function addDeniedEntry(displayPath: string, err: NodeJS.ErrnoException): void {
-        // Keep [DENIED] prefix so UI parser regex still matches.
-        // Append a hint for permission/timeout errors so user gets context.
-        if (isAccessDeniedError(err)) {
-            results.push(`[DENIED] ${displayPath} — not accessible (permission denied, cloud-only file, or Full Disk Access not granted)`);
-        } else {
-            results.push(`[DENIED] ${displayPath}`);
-        }
+    const getDisplayPath = (targetPath: string): string => path.basename(targetPath) || targetPath;
+
+    function addDeniedEntry(displayPath: string): void {
+        // Keep the payload path-only so the UI can parse denied entries reliably.
+        results.push(`[DENIED] ${displayPath}`);
     }
 
     try {
         const stats = await fs.stat(validPath);
         if (!stats.isDirectory()) {
-            throw new Error(`Path is not a directory: ${dirPath}`);
+            throw new Error(`Directory not found: ${dirPath}`);
         }
     } catch (error) {
         const err = error as NodeJS.ErrnoException;
@@ -700,7 +697,7 @@ export async function listDirectory(dirPath: string, depth: number = 2): Promise
             throw new Error(`Directory not found: ${dirPath}`);
         }
         if (isAccessDeniedError(err)) {
-            addDeniedEntry(path.basename(validPath), err);
+            addDeniedEntry(getDisplayPath(validPath));
             return results;
         }
         throw error;
@@ -717,8 +714,8 @@ export async function listDirectory(dirPath: string, depth: number = 2): Promise
             if (isTopLevel && (err.code === 'ENOENT' || err.code === 'ENOTDIR')) {
                 throw new Error(`Directory not found: ${dirPath}`);
             }
-            const displayPath = relativePath || path.basename(currentPath);
-            addDeniedEntry(displayPath, err);
+            const displayPath = relativePath || getDisplayPath(currentPath);
+            addDeniedEntry(displayPath);
             return;
         }
 

--- a/src/tools/filesystem.ts
+++ b/src/tools/filesystem.ts
@@ -677,6 +677,19 @@ export async function listDirectory(dirPath: string, depth: number = 2): Promise
 
     const MAX_NESTED_ITEMS = 100; // Maximum items to show per nested directory
 
+    try {
+        const stats = await fs.stat(validPath);
+        if (!stats.isDirectory()) {
+            throw new Error(`Path is not a directory: ${dirPath}`);
+        }
+    } catch (error) {
+        const err = error as NodeJS.ErrnoException;
+        if (err.code === 'ENOENT' || err.code === 'ENOTDIR') {
+            throw new Error(`Directory not found: ${dirPath}`);
+        }
+        throw error;
+    }
+
     async function listRecursive(currentPath: string, currentDepth: number, relativePath: string = '', isTopLevel: boolean = true): Promise<void> {
         if (currentDepth <= 0) return;
 
@@ -685,6 +698,9 @@ export async function listDirectory(dirPath: string, depth: number = 2): Promise
             entries = await fs.readdir(currentPath, { withFileTypes: true });
         } catch (error) {
             const err = error as NodeJS.ErrnoException;
+            if (isTopLevel && (err.code === 'ENOENT' || err.code === 'ENOTDIR')) {
+                throw new Error(`Directory not found: ${dirPath}`);
+            }
             const displayPath = relativePath || path.basename(currentPath);
             // Keep [DENIED] prefix so UI parser regex still matches.
             // Append a hint for permission/timeout errors so user gets context.

--- a/src/tools/filesystem.ts
+++ b/src/tools/filesystem.ts
@@ -676,6 +676,18 @@ export async function listDirectory(dirPath: string, depth: number = 2): Promise
     const results: string[] = [];
 
     const MAX_NESTED_ITEMS = 100; // Maximum items to show per nested directory
+    const isAccessDeniedError = (err: NodeJS.ErrnoException) =>
+        err.code === 'EPERM' || err.code === 'EACCES' || err.code === 'ETIMEDOUT';
+
+    function addDeniedEntry(displayPath: string, err: NodeJS.ErrnoException): void {
+        // Keep [DENIED] prefix so UI parser regex still matches.
+        // Append a hint for permission/timeout errors so user gets context.
+        if (isAccessDeniedError(err)) {
+            results.push(`[DENIED] ${displayPath} — not accessible (permission denied, cloud-only file, or Full Disk Access not granted)`);
+        } else {
+            results.push(`[DENIED] ${displayPath}`);
+        }
+    }
 
     try {
         const stats = await fs.stat(validPath);
@@ -686,6 +698,10 @@ export async function listDirectory(dirPath: string, depth: number = 2): Promise
         const err = error as NodeJS.ErrnoException;
         if (err.code === 'ENOENT' || err.code === 'ENOTDIR') {
             throw new Error(`Directory not found: ${dirPath}`);
+        }
+        if (isAccessDeniedError(err)) {
+            addDeniedEntry(path.basename(validPath), err);
+            return results;
         }
         throw error;
     }
@@ -702,13 +718,7 @@ export async function listDirectory(dirPath: string, depth: number = 2): Promise
                 throw new Error(`Directory not found: ${dirPath}`);
             }
             const displayPath = relativePath || path.basename(currentPath);
-            // Keep [DENIED] prefix so UI parser regex still matches.
-            // Append a hint for permission/timeout errors so user gets context.
-            if (err.code === 'EPERM' || err.code === 'EACCES' || err.code === 'ETIMEDOUT') {
-                results.push(`[DENIED] ${displayPath} — not accessible (permission denied, cloud-only file, or Full Disk Access not granted)`);
-            } else {
-                results.push(`[DENIED] ${displayPath}`);
-            }
+            addDeniedEntry(displayPath, err);
             return;
         }
 

--- a/test/test-list-directory-errors.js
+++ b/test/test-list-directory-errors.js
@@ -1,0 +1,61 @@
+import assert from 'assert';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+import { configManager } from '../dist/config-manager.js';
+import { listDirectory } from '../dist/tools/filesystem.js';
+
+const TEST_ROOT = path.join(os.tmpdir(), 'desktop-commander-list-directory-errors');
+
+async function setup() {
+  const originalConfig = await configManager.getConfig();
+  await fs.mkdir(TEST_ROOT, { recursive: true });
+  await configManager.setValue('allowedDirectories', [TEST_ROOT]);
+  return originalConfig;
+}
+
+async function teardown(originalConfig) {
+  await configManager.updateConfig(originalConfig);
+  await fs.rm(TEST_ROOT, { recursive: true, force: true });
+}
+
+async function testMissingDirectoryReturnsNotFound() {
+  const missingDir = path.join(TEST_ROOT, 'missing-dir');
+
+  await assert.rejects(
+    listDirectory(missingDir, 1),
+    (error) => {
+      assert(error instanceof Error);
+      assert(error.message.includes(`Directory not found: ${missingDir}`));
+      assert(!error.message.includes('[DENIED]'));
+      return true;
+    },
+    'Missing directories should raise a not-found error instead of returning [DENIED]',
+  );
+
+  console.log('✓ missing directory returns not-found error');
+}
+
+export default async function runTests() {
+  let originalConfig;
+  try {
+    originalConfig = await setup();
+    await testMissingDirectoryReturnsNotFound();
+    console.log('\n✅ list_directory error tests passed!');
+    return true;
+  } catch (error) {
+    console.error('❌ list_directory error test failed:', error instanceof Error ? error.message : String(error));
+    return false;
+  } finally {
+    if (originalConfig) {
+      await teardown(originalConfig);
+    }
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runTests().then((ok) => {
+    process.exit(ok ? 0 : 1);
+  });
+}

--- a/test/test-list-directory-errors.js
+++ b/test/test-list-directory-errors.js
@@ -6,22 +6,22 @@ import path from 'path';
 import { configManager } from '../dist/config-manager.js';
 import { listDirectory } from '../dist/tools/filesystem.js';
 
-const TEST_ROOT = path.join(os.tmpdir(), 'desktop-commander-list-directory-errors');
+const TEST_ROOT_PREFIX = path.join(os.tmpdir(), 'desktop-commander-list-directory-errors-');
 
 async function setup() {
   const originalConfig = await configManager.getConfig();
-  await fs.mkdir(TEST_ROOT, { recursive: true });
-  await configManager.setValue('allowedDirectories', [TEST_ROOT]);
-  return originalConfig;
+  const testRoot = await fs.mkdtemp(TEST_ROOT_PREFIX);
+  await configManager.setValue('allowedDirectories', [testRoot]);
+  return { originalConfig, testRoot };
 }
 
-async function teardown(originalConfig) {
+async function teardown(originalConfig, testRoot) {
   await configManager.updateConfig(originalConfig);
-  await fs.rm(TEST_ROOT, { recursive: true, force: true });
+  await fs.rm(testRoot, { recursive: true, force: true });
 }
 
-async function testMissingDirectoryReturnsNotFound() {
-  const missingDir = path.join(TEST_ROOT, 'missing-dir');
+async function testMissingDirectoryReturnsNotFound(testRoot) {
+  const missingDir = path.join(testRoot, 'missing-dir');
 
   await assert.rejects(
     listDirectory(missingDir, 1),
@@ -39,17 +39,18 @@ async function testMissingDirectoryReturnsNotFound() {
 
 export default async function runTests() {
   let originalConfig;
+  let testRoot;
   try {
-    originalConfig = await setup();
-    await testMissingDirectoryReturnsNotFound();
+    ({ originalConfig, testRoot } = await setup());
+    await testMissingDirectoryReturnsNotFound(testRoot);
     console.log('\n✅ list_directory error tests passed!');
     return true;
   } catch (error) {
     console.error('❌ list_directory error test failed:', error instanceof Error ? error.message : String(error));
     return false;
   } finally {
-    if (originalConfig) {
-      await teardown(originalConfig);
+    if (originalConfig && testRoot) {
+      await teardown(originalConfig, testRoot);
     }
   }
 }

--- a/test/test-list-directory-errors.js
+++ b/test/test-list-directory-errors.js
@@ -2,6 +2,7 @@ import assert from 'assert';
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
+import { pathToFileURL } from 'url';
 
 import { configManager } from '../dist/config-manager.js';
 import { listDirectory } from '../dist/tools/filesystem.js';
@@ -53,13 +54,29 @@ async function testTopLevelStatAccessDeniedReturnsDeniedEntry(testRoot) {
 
   try {
     const entries = await listDirectory(deniedDir, 1);
-    assert.strictEqual(entries.length, 1);
-    assert(entries[0].startsWith('[DENIED] stat-denied'), 'Top-level stat access errors should keep [DENIED] output');
-    assert(entries[0].includes('not accessible'), 'Permission-like stat errors should include the access hint');
+    assert.deepStrictEqual(entries, ['[DENIED] stat-denied']);
     console.log('✓ top-level stat access error returns denied entry');
   } finally {
     fs.stat = originalStat;
   }
+}
+
+async function testFilePathReturnsNotFound(testRoot) {
+  const filePath = path.join(testRoot, 'not-a-directory.txt');
+  await fs.writeFile(filePath, 'not a directory');
+
+  await assert.rejects(
+    listDirectory(filePath, 1),
+    (error) => {
+      assert(error instanceof Error);
+      assert(error.message.includes(`Directory not found: ${filePath}`));
+      assert(!error.message.includes('Path is not a directory'));
+      return true;
+    },
+    'File paths should use the same not-found contract as missing directories',
+  );
+
+  console.log('✓ file path returns not-found error');
 }
 
 export default async function runTests() {
@@ -69,6 +86,7 @@ export default async function runTests() {
     ({ originalConfig, testRoot } = await setup());
     await testMissingDirectoryReturnsNotFound(testRoot);
     await testTopLevelStatAccessDeniedReturnsDeniedEntry(testRoot);
+    await testFilePathReturnsNotFound(testRoot);
     console.log('\n✅ list_directory error tests passed!');
     return true;
   } catch (error) {
@@ -81,7 +99,7 @@ export default async function runTests() {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   runTests().then((ok) => {
     process.exit(ok ? 0 : 1);
   });

--- a/test/test-list-directory-errors.js
+++ b/test/test-list-directory-errors.js
@@ -10,7 +10,7 @@ const TEST_ROOT_PREFIX = path.join(os.tmpdir(), 'desktop-commander-list-director
 
 async function setup() {
   const originalConfig = await configManager.getConfig();
-  const testRoot = await fs.mkdtemp(TEST_ROOT_PREFIX);
+  const testRoot = await fs.realpath(await fs.mkdtemp(TEST_ROOT_PREFIX));
   await configManager.setValue('allowedDirectories', [testRoot]);
   return { originalConfig, testRoot };
 }
@@ -37,12 +37,38 @@ async function testMissingDirectoryReturnsNotFound(testRoot) {
   console.log('✓ missing directory returns not-found error');
 }
 
+async function testTopLevelStatAccessDeniedReturnsDeniedEntry(testRoot) {
+  const deniedDir = path.join(testRoot, 'stat-denied');
+  await fs.mkdir(deniedDir);
+
+  const originalStat = fs.stat;
+  fs.stat = async (target, ...args) => {
+    if (path.resolve(String(target)) === deniedDir) {
+      const error = new Error(`EACCES: permission denied, stat '${deniedDir}'`);
+      error.code = 'EACCES';
+      throw error;
+    }
+    return originalStat.call(fs, target, ...args);
+  };
+
+  try {
+    const entries = await listDirectory(deniedDir, 1);
+    assert.strictEqual(entries.length, 1);
+    assert(entries[0].startsWith('[DENIED] stat-denied'), 'Top-level stat access errors should keep [DENIED] output');
+    assert(entries[0].includes('not accessible'), 'Permission-like stat errors should include the access hint');
+    console.log('✓ top-level stat access error returns denied entry');
+  } finally {
+    fs.stat = originalStat;
+  }
+}
+
 export default async function runTests() {
   let originalConfig;
   let testRoot;
   try {
     ({ originalConfig, testRoot } = await setup());
     await testMissingDirectoryReturnsNotFound(testRoot);
+    await testTopLevelStatAccessDeniedReturnsDeniedEntry(testRoot);
     console.log('\n✅ list_directory error tests passed!');
     return true;
   } catch (error) {


### PR DESCRIPTION
## **User description**
## Summary

- return a clear not-found error when list_directory targets a missing directory
- keep existing [DENIED] output for inaccessible nested directories
- add a regression test for missing top-level directories

Fixes #396

## Test

- npm run build
- node test/test-list-directory-errors.js


___

## **CodeAnt-AI Description**
**Show a not-found error when a directory does not exist**

### What Changed
- Missing directories now return a clear `Directory not found` error instead of being treated like access denied.
- Non-directory paths are also reported as not found when they are requested as folders.
- Added a regression test to confirm missing directories no longer show `[DENIED]`.

### Impact
`✅ Clearer missing-folder errors`
`✅ Fewer false permission-denied messages`
`✅ Safer directory checks`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=GwHsWvZpj_SwocWY7rPCi9t-ydBAMP987o40jPUSnXI&org=wonderwhy-er)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clearer, consistent directory error messages: missing or non-directory paths return "Directory not found" and permission/timeouts surface as standardized "[DENIED]" entries.
  * Early path validation to avoid incorrect recursion.

* **Tests**
  * New tests validating missing-directory, non-directory, and permission-denied behaviors; test module is executable and returns pass/fail status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->