### PR TITLE
fix: flush process output before completion

### DIFF
--- a/src/terminal-manager.ts
+++ b/src/terminal-manager.ts
@@ -336,9 +336,10 @@ export class TerminalManager {
         });
       }, timeoutMs);
 
-      childProcess.on('exit', (code: any) => {
+      childProcess.on('close', (code: any) => {
         if (childProcess.pid) {
-          // Store completed session before removing active session
+          // Store completed session only after stdio closes, so fast-exiting
+          // processes do not lose stdout/stderr that arrives after exit.
           this.completedSessions.set(childProcess.pid, {
             pid: childProcess.pid,
             outputLines: [...session.outputLines], // Copy line buffer

--- a/test/test-process-output-close.js
+++ b/test/test-process-output-close.js
@@ -2,6 +2,7 @@ import assert from 'assert';
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
+import { pathToFileURL } from 'url';
 
 import { terminalManager } from '../dist/terminal-manager.js';
 
@@ -14,17 +15,22 @@ function quoteForShell(value) {
 async function setup() {
   const testDir = await fs.mkdtemp(TEST_DIR_PREFIX);
   const scriptPath = path.join(testDir, 'fast-stderr.mjs');
-  await fs.writeFile(
-    scriptPath,
-    [
-      "import fs from 'fs';",
-      "fs.writeSync(2, 'FAST_STDERR_START\\n');",
-      "fs.writeSync(2, 'x'.repeat(256 * 1024));",
-      "fs.writeSync(2, '\\nFAST_STDERR_END\\n');",
-      'process.exit(1);',
-    ].join('\n'),
-  );
-  return { testDir, scriptPath };
+  try {
+    await fs.writeFile(
+      scriptPath,
+      [
+        "import fs from 'fs';",
+        "fs.writeSync(2, 'FAST_STDERR_START\\n');",
+        "fs.writeSync(2, 'x'.repeat(256 * 1024));",
+        "fs.writeSync(2, '\\nFAST_STDERR_END\\n');",
+        'process.exit(1);',
+      ].join('\n'),
+    );
+    return { testDir, scriptPath };
+  } catch (error) {
+    await fs.rm(testDir, { recursive: true, force: true });
+    throw error;
+  }
 }
 
 async function teardown(testDir) {
@@ -66,7 +72,7 @@ export default async function runTests() {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   runTests().then((ok) => {
     process.exit(ok ? 0 : 1);
   });

--- a/test/test-process-output-close.js
+++ b/test/test-process-output-close.js
@@ -5,17 +5,17 @@ import path from 'path';
 
 import { terminalManager } from '../dist/terminal-manager.js';
 
-const TEST_DIR = path.join(os.tmpdir(), 'desktop-commander-process-output-close');
-const SCRIPT_PATH = path.join(TEST_DIR, 'fast-stderr.js');
+const TEST_DIR_PREFIX = path.join(os.tmpdir(), 'desktop-commander-process-output-close-');
 
 function quoteForShell(value) {
   return `"${value.replace(/"/g, '\\"')}"`;
 }
 
 async function setup() {
-  await fs.mkdir(TEST_DIR, { recursive: true });
+  const testDir = await fs.mkdtemp(TEST_DIR_PREFIX);
+  const scriptPath = path.join(testDir, 'fast-stderr.mjs');
   await fs.writeFile(
-    SCRIPT_PATH,
+    scriptPath,
     [
       "import fs from 'fs';",
       "fs.writeSync(2, 'FAST_STDERR_START\\n');",
@@ -24,14 +24,15 @@ async function setup() {
       'process.exit(1);',
     ].join('\n'),
   );
+  return { testDir, scriptPath };
 }
 
-async function teardown() {
-  await fs.rm(TEST_DIR, { recursive: true, force: true });
+async function teardown(testDir) {
+  await fs.rm(testDir, { recursive: true, force: true });
 }
 
-async function testFastExitStderrIsFlushed() {
-  const command = `${quoteForShell(process.execPath)} ${quoteForShell(SCRIPT_PATH)}`;
+async function testFastExitStderrIsFlushed(scriptPath) {
+  const command = `${quoteForShell(process.execPath)} ${quoteForShell(scriptPath)}`;
   const result = await terminalManager.executeCommand(command, 2000);
 
   assert.strictEqual(result.isBlocked, false, 'Fast-failing process should be marked complete');
@@ -48,16 +49,20 @@ async function testFastExitStderrIsFlushed() {
 }
 
 export default async function runTests() {
+  let testDir;
   try {
-    await setup();
-    await testFastExitStderrIsFlushed();
+    const fixture = await setup();
+    testDir = fixture.testDir;
+    await testFastExitStderrIsFlushed(fixture.scriptPath);
     console.log('\n✅ process output close tests passed!');
     return true;
   } catch (error) {
     console.error('❌ process output close test failed:', error instanceof Error ? error.message : String(error));
     return false;
   } finally {
-    await teardown();
+    if (testDir) {
+      await teardown(testDir);
+    }
   }
 }
 

--- a/test/test-process-output-close.js
+++ b/test/test-process-output-close.js
@@ -1,0 +1,68 @@
+import assert from 'assert';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+import { terminalManager } from '../dist/terminal-manager.js';
+
+const TEST_DIR = path.join(os.tmpdir(), 'desktop-commander-process-output-close');
+const SCRIPT_PATH = path.join(TEST_DIR, 'fast-stderr.js');
+
+function quoteForShell(value) {
+  return `"${value.replace(/"/g, '\\"')}"`;
+}
+
+async function setup() {
+  await fs.mkdir(TEST_DIR, { recursive: true });
+  await fs.writeFile(
+    SCRIPT_PATH,
+    [
+      "import fs from 'fs';",
+      "fs.writeSync(2, 'FAST_STDERR_START\\n');",
+      "fs.writeSync(2, 'x'.repeat(256 * 1024));",
+      "fs.writeSync(2, '\\nFAST_STDERR_END\\n');",
+      'process.exit(1);',
+    ].join('\n'),
+  );
+}
+
+async function teardown() {
+  await fs.rm(TEST_DIR, { recursive: true, force: true });
+}
+
+async function testFastExitStderrIsFlushed() {
+  const command = `${quoteForShell(process.execPath)} ${quoteForShell(SCRIPT_PATH)}`;
+  const result = await terminalManager.executeCommand(command, 2000);
+
+  assert.strictEqual(result.isBlocked, false, 'Fast-failing process should be marked complete');
+
+  const output = terminalManager.readOutputPaginated(result.pid, 0, 100);
+  assert(output, 'Completed process output should remain readable');
+
+  const text = output.lines.join('\n');
+  assert.strictEqual(output.exitCode, 1, 'Process exit code should be preserved');
+  assert(text.includes('FAST_STDERR_START'), 'stderr start marker should be captured');
+  assert(text.includes('FAST_STDERR_END'), 'stderr end marker should be captured after process exit');
+
+  console.log('✓ fast-exiting process stderr is flushed before completion');
+}
+
+export default async function runTests() {
+  try {
+    await setup();
+    await testFastExitStderrIsFlushed();
+    console.log('\n✅ process output close tests passed!');
+    return true;
+  } catch (error) {
+    console.error('❌ process output close test failed:', error instanceof Error ? error.message : String(error));
+    return false;
+  } finally {
+    await teardown();
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runTests().then((ok) => {
+    process.exit(ok ? 0 : 1);
+  });
+}


### PR DESCRIPTION
## **User description**
## Summary

- finalize completed process sessions on close instead of exit so stdout/stderr have drained
- preserve fast-exiting process stderr in completed session output
- add a regression test for a fast-failing process that writes stderr before exit

Fixes #395

## Test

- npm run build
- node test/test-process-output-close.js


___

## **CodeAnt-AI Description**
**Keep fast-exiting process output until stdio finishes**

### What Changed
- Completed processes are now saved only after their output streams close, so short-lived commands keep late stdout/stderr in the finished result.
- Fast-failing processes still show the correct exit code in completed output.
- Added a regression test for a process that writes a large amount to stderr and exits immediately.

### Impact
`✅ Fewer missing error messages`
`✅ More complete process output`
`✅ Clearer fast-failure results`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=ZOZJZkTdbTchCa_xUt4YrE8x9BUpI2bsfqTQon_XLs0&org=wonderwhy-er)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process output handling so all stdout/stderr (including late-arriving data) is captured; completed sessions are persisted only after streams fully close to prevent lost output and ensure correct exit status.

* **Tests**
  * Added an executable test that simulates a fast-exiting process to verify output is retained, exit codes are preserved, and sessions are not left in a blocked state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->