### PR TITLE
fix: pass Supabase session tokens via env to avoid argv disclosure (CWE-200)

### DIFF
--- a/src/remote-device/remote-channel.ts
+++ b/src/remote-device/remote-channel.ts
@@ -415,6 +415,16 @@ export class RemoteChannel {
                 return;
             }
 
+            if (!sessionData.session.refresh_token) {
+                // The subprocess requires both tokens to call setSession(); without a
+                // refresh token it would exit with code 1 and the device row would
+                // silently remain marked as online. Bail out explicitly so the failure
+                // is visible in logs rather than masked behind a generic exit code.
+                console.error('❌ No refresh token available for offline update; skipping subprocess');
+                console.debug('[DEBUG] sessionData.session.refresh_token is null/undefined');
+                return;
+            }
+
             // Get Supabase config from client
             const supabaseUrl = (this.client as any).supabaseUrl;
             const supabaseKey = (this.client as any).supabaseKey;
@@ -450,7 +460,7 @@ export class RemoteChannel {
                 env: {
                     ...process.env,
                     SUPABASE_ACCESS_TOKEN: sessionData.session.access_token,
-                    SUPABASE_REFRESH_TOKEN: sessionData.session.refresh_token || ''
+                    SUPABASE_REFRESH_TOKEN: sessionData.session.refresh_token
                 }
             });
 

--- a/src/remote-device/remote-channel.ts
+++ b/src/remote-device/remote-channel.ts
@@ -442,13 +442,16 @@ export class RemoteChannel {
                 scriptPath,
                 deviceId,
                 supabaseUrl,
-                supabaseKey,
-                sessionData.session.access_token,
-                sessionData.session.refresh_token || ''
+                supabaseKey
             ], {
                 timeout: 3000,
                 stdio: 'pipe', // Capture output to prevent blocking
-                encoding: 'utf-8'
+                encoding: 'utf-8',
+                env: {
+                    ...process.env,
+                    SUPABASE_ACCESS_TOKEN: sessionData.session.access_token,
+                    SUPABASE_REFRESH_TOKEN: sessionData.session.refresh_token || ''
+                }
             });
 
             console.debug('[DEBUG] spawnSync completed, exit code:', result.status, 'signal:', result.signal);

--- a/src/remote-device/scripts/blocking-offline-update.js
+++ b/src/remote-device/scripts/blocking-offline-update.js
@@ -4,17 +4,24 @@
  * Blocking script to update device status to offline
  * Runs synchronously during shutdown to ensure DB update completes
  * 
- * Usage: node blocking-offline-update.js <deviceId> <supabaseUrl> <supabaseKey> <accessToken> <refreshToken>
+ * Usage: SUPABASE_ACCESS_TOKEN=<token> SUPABASE_REFRESH_TOKEN=<token> node blocking-offline-update.js <deviceId> <supabaseUrl> <supabaseKey>
+ * 
+ * Note: Tokens are passed via environment variables (not command-line args)
+ * to prevent exposure in process listings (ps aux, /proc/PID/cmdline).
  */
 
 import { createClient } from '@supabase/supabase-js';
 
-// Parse command line arguments
-const [deviceId, supabaseUrl, supabaseKey, accessToken, refreshToken] = process.argv.slice(2);
+// Parse command line arguments (non-sensitive only)
+const [deviceId, supabaseUrl, supabaseKey] = process.argv.slice(2);
+
+// Read sensitive tokens from environment variables
+const accessToken = process.env.SUPABASE_ACCESS_TOKEN;
+const refreshToken = process.env.SUPABASE_REFRESH_TOKEN;
 
 if (!deviceId || !supabaseUrl || !supabaseKey || !accessToken || !refreshToken) {
     console.error('❌ Missing required arguments');
-    console.error('Usage: node blocking-offline-update.js <deviceId> <supabaseUrl> <supabaseKey> <accessToken> <refreshToken>');
+    console.error('Usage: SUPABASE_ACCESS_TOKEN=<token> SUPABASE_REFRESH_TOKEN=<token> node blocking-offline-update.js <deviceId> <supabaseUrl> <supabaseKey>');
     process.exit(1);
 }
 

--- a/test/test-cwe200-credential-exposure.js
+++ b/test/test-cwe200-credential-exposure.js
@@ -1,0 +1,106 @@
+/**
+ * PoC test for CWE-200: Device credentials exposed via process.argv
+ *
+ * This test verifies that the blocking-offline-update.js script does NOT
+ * receive sensitive tokens (access_token, refresh_token) via command-line
+ * arguments (which are visible to all users via `ps aux`).
+ *
+ * Instead, tokens should be passed via environment variables or stdin.
+ */
+
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import assert from 'assert';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Path to the files under test - go up one level from test/ to get repo root
+const REPO_ROOT = path.resolve(__dirname, '..');
+const SCRIPT_PATH = path.join(REPO_ROOT, 'src/remote-device/scripts/blocking-offline-update.js');
+const CHANNEL_PATH = path.join(REPO_ROOT, 'src/remote-device/remote-channel.ts');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+    try {
+        fn();
+        console.log(`  ✅ ${name}`);
+        passed++;
+    } catch (err) {
+        console.log(`  ❌ ${name}`);
+        console.log(`     ${err.message}`);
+        failed++;
+    }
+}
+
+console.log('Testing CWE-200: Credential exposure via process.argv\n');
+
+// Test 1: blocking-offline-update.js should NOT read tokens from process.argv
+test('blocking-offline-update.js should not read access_token/refresh_token from process.argv', () => {
+    const content = readFileSync(SCRIPT_PATH, 'utf-8');
+    const lines = content.split('\n');
+
+    // Check every line that references process.argv — none should destructure token variables
+    for (const line of lines) {
+        if (line.includes('process.argv')) {
+            assert.ok(
+                !/accessToken|refreshToken|access_token|refresh_token/i.test(line),
+                `Line reads tokens from process.argv: ${line.trim()}`
+            );
+        }
+    }
+});
+
+// Test 2: blocking-offline-update.js should read tokens from environment variables
+test('blocking-offline-update.js should read tokens from environment variables', () => {
+    const content = readFileSync(SCRIPT_PATH, 'utf-8');
+
+    const envAccessToken = /process\.env\.\w*(?:ACCESS_TOKEN|access_token)/i.test(content);
+    const envRefreshToken = /process\.env\.\w*(?:REFRESH_TOKEN|refresh_token)/i.test(content);
+
+    assert.ok(
+        envAccessToken && envRefreshToken,
+        'Script should read access_token and refresh_token from process.env'
+    );
+});
+
+// Test 3: remote-channel.ts should pass tokens via env, not as args
+test('remote-channel.ts should pass tokens via env option in spawnSync, not as args', () => {
+    const content = readFileSync(CHANNEL_PATH, 'utf-8');
+
+    // Find the spawnSync call
+    const spawnSyncIdx = content.indexOf('spawnSync');
+    assert.ok(spawnSyncIdx !== -1, 'spawnSync call not found in remote-channel.ts');
+
+    // Extract the args array between spawnSync('node', [ ... ])
+    const afterSpawn = content.substring(spawnSyncIdx);
+    const argsArrayMatch = afterSpawn.match(/spawnSync\(\s*'node'\s*,\s*\[([\s\S]*?)\]\s*,/);
+    assert.ok(argsArrayMatch, 'Could not parse spawnSync args array');
+
+    const argsContent = argsArrayMatch[1];
+    // The args array should NOT contain access_token or refresh_token
+    assert.ok(
+        !argsContent.includes('access_token') && !argsContent.includes('refresh_token'),
+        `Tokens should not be in command args: ${argsContent.trim()}`
+    );
+
+    // The options object should include env with the tokens
+    const optionsMatch = afterSpawn.match(/spawnSync\(\s*'node'\s*,\s*\[[\s\S]*?\]\s*,\s*\{([\s\S]*?)\}\s*\)/);
+    assert.ok(optionsMatch, 'Could not parse spawnSync options');
+
+    const optionsContent = optionsMatch[1];
+    assert.ok(
+        optionsContent.includes('SUPABASE_ACCESS_TOKEN') || optionsContent.includes('access_token'),
+        'spawnSync options should include env with access token'
+    );
+    assert.ok(
+        optionsContent.includes('SUPABASE_REFRESH_TOKEN') || optionsContent.includes('refresh_token'),
+        'spawnSync options should include env with refresh token'
+    );
+});
+
+console.log(`\nResults: ${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/test/test-cwe200-credential-exposure.js
+++ b/test/test-cwe200-credential-exposure.js
@@ -41,16 +41,25 @@ console.log('Testing CWE-200: Credential exposure via process.argv\n');
 // Test 1: blocking-offline-update.js should NOT read tokens from process.argv
 test('blocking-offline-update.js should not read access_token/refresh_token from process.argv', () => {
     const content = readFileSync(SCRIPT_PATH, 'utf-8');
-    const lines = content.split('\n');
 
-    // Check every line that references process.argv — none should destructure token variables
-    for (const line of lines) {
-        if (line.includes('process.argv')) {
-            assert.ok(
-                !/accessToken|refreshToken|access_token|refresh_token/i.test(line),
-                `Line reads tokens from process.argv: ${line.trim()}`
-            );
-        }
+    // Strip comments so the test isn't fooled by docs that mention argv + token names.
+    const noComments = content
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+    // Split into statements and look at any statement containing `process.argv`.
+    // Statements are conservatively split on `;` and `\n\n`; this captures
+    // multi-line destructures while still bounding the search to the actual
+    // assignment that uses argv.
+    const statements = noComments.split(/;|\n\s*\n/);
+    const tokenRe = /\b(accessToken|refreshToken|access[_-]?token|refresh[_-]?token)\b/i;
+
+    for (const stmt of statements) {
+        if (!/process\.argv\b/.test(stmt)) continue;
+        assert.ok(
+            !tokenRe.test(stmt),
+            `Statement appears to read a token from process.argv: ${stmt.replace(/\s+/g, ' ').trim()}`
+        );
     }
 });
 
@@ -83,8 +92,8 @@ test('remote-channel.ts should pass tokens via env option in spawnSync, not as a
     const argsContent = argsArrayMatch[1];
     // The args array should NOT contain access_token or refresh_token
     assert.ok(
-        !argsContent.includes('access_token') && !argsContent.includes('refresh_token'),
-        `Tokens should not be in command args: ${argsContent.trim()}`
+        !/(accessToken|refreshToken|access_token|refresh_token)/i.test(argsContent),
+        `Tokens should not be in command args (any case/style): ${argsContent.trim()}`
     );
 
     // The options object should include env with the tokens


### PR DESCRIPTION
## **User description**
## Summary

This PR fixes a sensitive information disclosure (CWE-200 / CWE-214) where Supabase session `access_token` and `refresh_token` are passed as command-line arguments to a Node.js subprocess during the device-offline shutdown flow. Process arguments are world-readable on Unix systems (via `ps aux` and `/proc/<pid>/cmdline`), so any local user on the same host can capture these tokens while the subprocess is alive.

## Affected code

- `src/remote-device/remote-channel.ts` — `spawnSync('node', [...args])` call around line 442 placed `sessionData.session.access_token` and `sessionData.session.refresh_token` into the `argv` array.
- `src/remote-device/scripts/blocking-offline-update.js` — read those tokens back from `process.argv`.

The subprocess is launched during the device shutdown handler, so the exposure window is short but deterministic (it occurs every shutdown).

## Vulnerability details

**Data flow**

1. `RemoteChannel.markDeviceOffline()` retrieves a Supabase session containing the user's `access_token` and `refresh_token`.
2. These tokens were appended to the `args` array of `spawnSync('node', [scriptPath, deviceId, supabaseUrl, supabaseKey, accessToken, refreshToken], ...)`.
3. While the child process exists, its full command line (including the tokens) is exposed via:
   - `ps aux` / `ps -ef` on any Unix system
   - `/proc/<pid>/cmdline`, which on default Linux configurations is readable by any local user (mode `0444`)
   - Audit / EDR logs that record `execve` arguments
4. By contrast, `/proc/<pid>/environ` is restricted to the same UID (mode `0400`), so passing the tokens via the `env` option of `spawnSync` is not subject to the same disclosure.

**Impact** — A captured `access_token` allows an attacker to authenticate to the Supabase backend as the affected user; the `refresh_token` extends that access window.

**Preconditions**

- A local unprivileged user on the same host as the running DesktopCommander process (multi-user host, shared CI runner, container with multiple workloads, etc.).
- The subprocess must be alive when the attacker samples `/proc` or `ps`. On a busy system a tight polling loop can reliably catch short-lived processes.

The `deviceId`, `supabaseUrl`, and `supabaseKey` (which is the public anon key) remain in argv — these are not session secrets and are safe to expose.

## Fix

Move the two tokens out of the `argv` array and into the `env` option of `spawnSync`. The script now reads them from `process.env.SUPABASE_ACCESS_TOKEN` and `process.env.SUPABASE_REFRESH_TOKEN`.

```diff
 const result = spawnSync('node', [
     scriptPath,
     deviceId,
     supabaseUrl,
-    supabaseKey,
-    sessionData.session.access_token,
-    sessionData.session.refresh_token || ''
+    supabaseKey
 ], {
     timeout: 3000,
     stdio: 'pipe',
-    encoding: 'utf-8'
+    encoding: 'utf-8',
+    env: {
+        ...process.env,
+        SUPABASE_ACCESS_TOKEN: sessionData.session.access_token,
+        SUPABASE_REFRESH_TOKEN: sessionData.session.refresh_token || ''
+    }
 });
```

This is the canonical remediation for CWE-214 (sensitive information in process arguments) — environment variables are scoped per-process and not visible across UID boundaries on Unix.

## Tests

A regression test was added at `test/test-cwe200-credential-exposure.js` that statically verifies:

1. `blocking-offline-update.js` does not destructure `accessToken`/`refreshToken` from `process.argv`.
2. The script reads both tokens from `process.env`.
3. `remote-channel.ts`'s `spawnSync` argv array contains neither token, and the options object includes them under `env`.

Result locally:

```
Testing CWE-200: Credential exposure via process.argv
  ✅ blocking-offline-update.js should not read access_token/refresh_token from process.argv
  ✅ blocking-offline-update.js should read tokens from environment variables
  ✅ remote-channel.ts should pass tokens via env option in spawnSync, not as args
Results: 3 passed, 0 failed
```

The change is the only call site of this script (verified via `grep`), so no other invocations needed updating. The script's argument-count validation still rejects missing tokens with a clear usage message.

## Adversarial review

Before submitting, we tried to talk ourselves out of this finding. The main counter-arguments we considered: (1) maybe `/proc` hardening (`hidepid=2`) blocks the read — but that's not the default on any major distro, and `ps` from the same user always works regardless; (2) maybe the subprocess is too short-lived to race — but the 3-second `timeout` and synchronous network call to Supabase keep it alive long enough for trivial polling; (3) maybe the tokens aren't sensitive — they are full Supabase session credentials, not the public anon key. None of those mitigations hold, so the disclosure is real for any multi-tenant host running DesktopCommander.

cc @lewiswigmore


___

## **CodeAnt-AI Description**
**Keep sensitive device tokens out of process listings during offline shutdown**

### What Changed
- Device access and refresh tokens are no longer sent as command-line arguments when marking a device offline.
- The shutdown script now reads those tokens from environment variables instead, so they are not exposed through `ps` or `/proc/<pid>/cmdline`.
- Added a test that checks tokens stay out of command-line arguments and are passed through the environment.

### Impact
`✅ Lower risk of token exposure on shared machines`
`✅ Safer offline shutdown flow`
`✅ Clearer credential handling during device updates`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=EiZfd-Wc6r_ekJ08ULwXjJda5OejLtbFE6HAl9v9as4&org=wonderwhy-er)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced validation for session credentials during offline device updates—the offline-update process now explicitly verifies that required authentication is present before initiating, preventing silent failures.
  * Improved error messaging when authentication credentials are unavailable during offline operations.

* **Tests**
  * Added security verification tests to validate credential handling during offline-update operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->