### PR TITLE
fix: add Promise.race hard timeout to feature flags fetch (#465)

### DIFF
--- a/src/utils/feature-flags.ts
+++ b/src/utils/feature-flags.ts
@@ -119,8 +119,17 @@ class FeatureFlagManager {
    */
   async waitForFreshFlags(): Promise<void> {
     if (this.freshFetchPromise) {
-      const safetyTimeout = new Promise<void>((resolve) => setTimeout(resolve, 5000));
-      await Promise.race([this.freshFetchPromise, safetyTimeout]);
+      let safetyTimeoutHandle: NodeJS.Timeout | undefined;
+      try {
+        const safetyTimeout = new Promise<void>((resolve) => {
+          safetyTimeoutHandle = setTimeout(resolve, 5000);
+        });
+        await Promise.race([this.freshFetchPromise, safetyTimeout]);
+      } finally {
+        if (safetyTimeoutHandle) {
+          clearTimeout(safetyTimeoutHandle);
+        }
+      }
     }
   }
 
@@ -154,13 +163,14 @@ class FeatureFlagManager {
    * Fetch flags from remote URL
    */
   private async fetchFlags(): Promise<void> {
+    const FETCH_TIMEOUT_MS = 3000;
+    const controller = new AbortController();
+    const abortTimeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    let hardTimeoutHandle: NodeJS.Timeout | undefined;
+
     try {
       // Don't log here - runs async and can interfere with MCP clients
-      
-      const FETCH_TIMEOUT_MS = 3000;
-      const controller = new AbortController();
-      const abortTimeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-      
+
       // Use Promise.race as a hard timeout safety net.
       // On some platforms (Windows + Node 24 / undici 7.x), AbortController.abort()
       // fails to interrupt an in-progress TCP connect — the fetch hangs until the
@@ -174,13 +184,14 @@ class FeatureFlagManager {
         }
       });
       const hardTimeout = new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error('Feature flags fetch timed out')), FETCH_TIMEOUT_MS)
+        hardTimeoutHandle = setTimeout(
+          () => reject(new Error('Feature flags fetch timed out')),
+          FETCH_TIMEOUT_MS
+        )
       );
-      
+
       const response = await Promise.race([fetchPromise, hardTimeout]);
-      
-      clearTimeout(abortTimeout);
-      
+
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
       }
@@ -199,6 +210,11 @@ class FeatureFlagManager {
     } catch (error: any) {
       logger.debug('Failed to fetch feature flags:', error.message);
       // Continue with cached values
+    } finally {
+      clearTimeout(abortTimeout);
+      if (hardTimeoutHandle) {
+        clearTimeout(hardTimeoutHandle);
+      }
     }
   }
 

--- a/src/utils/feature-flags.ts
+++ b/src/utils/feature-flags.ts
@@ -113,10 +113,14 @@ class FeatureFlagManager {
    * Wait for fresh flags to be fetched from network.
    * Use this when you need to ensure flags are loaded before making decisions
    * (e.g., A/B test assignments for new users who don't have a cache yet)
+   * 
+   * Has a hard timeout to prevent blocking MCP startup if the fetch hangs.
+   * See: https://github.com/wonderwhy-er/DesktopCommanderMCP/issues/465
    */
   async waitForFreshFlags(): Promise<void> {
     if (this.freshFetchPromise) {
-      await this.freshFetchPromise;
+      const safetyTimeout = new Promise<void>((resolve) => setTimeout(resolve, 5000));
+      await Promise.race([this.freshFetchPromise, safetyTimeout]);
     }
   }
 
@@ -153,17 +157,29 @@ class FeatureFlagManager {
     try {
       // Don't log here - runs async and can interfere with MCP clients
       
+      const FETCH_TIMEOUT_MS = 3000;
       const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), 5000);
+      const abortTimeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
       
-      const response = await fetch(this.flagUrl, {
+      // Use Promise.race as a hard timeout safety net.
+      // On some platforms (Windows + Node 24 / undici 7.x), AbortController.abort()
+      // fails to interrupt an in-progress TCP connect — the fetch hangs until the
+      // OS-level TCP timeout (~30s on Windows). Promise.race guarantees we reject
+      // at the JS level regardless of AbortController behavior.
+      // See: https://github.com/wonderwhy-er/DesktopCommanderMCP/issues/465
+      const fetchPromise = fetch(this.flagUrl, {
         signal: controller.signal,
         headers: {
           'Cache-Control': 'no-cache',
         }
       });
+      const hardTimeout = new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('Feature flags fetch timed out')), FETCH_TIMEOUT_MS)
+      );
       
-      clearTimeout(timeout);
+      const response = await Promise.race([fetchPromise, hardTimeout]);
+      
+      clearTimeout(abortTimeout);
       
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);

--- a/test/test-feature-flags-timeout.js
+++ b/test/test-feature-flags-timeout.js
@@ -1,0 +1,431 @@
+/**
+ * Test: Feature flags fetch must not block startup on slow networks
+ * 
+ * Reproduces GitHub issue #465: ~30 second MCP startup delay caused by
+ * feature flags fetch on high-latency networks where AbortController
+ * doesn't interrupt in-progress TCP connect.
+ *
+ * Strategy: We spin up local TCP servers that simulate different slow-network
+ * scenarios and test that fetch + AbortController actually respects the timeout.
+ * We also replicate the exact fetch pattern used in FeatureFlagManager.fetchFlags()
+ * to confirm whether the current code is safe on this platform.
+ */
+
+import { createServer } from 'net';
+import http from 'http';
+import assert from 'assert';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Create a TCP server that accepts the connection but never sends any HTTP response */
+function createBlackHoleServer() {
+  const sockets = new Set();
+  const server = createServer((socket) => {
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+    // Hold the socket open forever — simulates a server that accepted TCP
+    // but never responds at the HTTP level.
+  });
+  server._testSockets = sockets;
+  return server;
+}
+
+/** Create a TCP server that deliberately delays the HTTP response */
+function createSlowResponseServer(delayMs) {
+  const sockets = new Set();
+  const server = http.createServer((req, res) => {
+    setTimeout(() => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ version: '1', flags: { slow: true } }));
+    }, delayMs);
+  });
+  server.on('connection', (socket) => {
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+  });
+  server._testSockets = sockets;
+  return server;
+}
+
+function listenOnRandomPort(server) {
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      resolve(server.address().port);
+    });
+  });
+}
+
+function closeServer(server) {
+  return new Promise((resolve) => {
+    // Destroy all lingering sockets first
+    if (server._testSockets) {
+      for (const socket of server._testSockets) {
+        socket.destroy();
+      }
+    }
+    server.close(() => resolve());
+  });
+}
+
+const runTest = (name, testFn) => {
+  return testFn()
+    .then(() => {
+      console.log(`✅ Test passed: ${name}`);
+      return true;
+    })
+    .catch((error) => {
+      console.error(`❌ Test failed: ${name}`);
+      console.error(`   ${error.message}`);
+      return false;
+    });
+};
+
+// ---------------------------------------------------------------------------
+// Replicate the EXACT fetch pattern from FeatureFlagManager.fetchFlags()
+// This is the code under test — copied so we can run it against our mock servers.
+// ---------------------------------------------------------------------------
+
+/**
+ * Current implementation (from feature-flags.ts):
+ * Uses AbortController + Promise.race with 3s timeout.
+ */
+const FETCH_TIMEOUT_MS = 3000;
+
+async function currentFetchPattern(url) {
+  const controller = new AbortController();
+  const abortTimeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  const fetchPromise = fetch(url, {
+    signal: controller.signal,
+    headers: { 'Cache-Control': 'no-cache' },
+  });
+  const hardTimeout = new Promise((_, reject) =>
+    setTimeout(() => reject(new Error('Feature flags fetch timed out')), FETCH_TIMEOUT_MS)
+  );
+  try {
+    const response = await Promise.race([fetchPromise, hardTimeout]);
+    clearTimeout(abortTimeout);
+    return response;
+  } catch (err) {
+    clearTimeout(abortTimeout);
+    throw err;
+  }
+}
+
+// (fixedFetchPattern removed — currentFetchPattern already uses Promise.race)
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/**
+ * Test 1: AbortController behavior on this platform
+ * 
+ * Directly tests whether AbortController.abort() can interrupt a fetch
+ * to a black-hole server. If this fails, it confirms the underlying
+ * Node/undici issue from #465.
+ */
+async function testAbortControllerBehavior() {
+  const server = createBlackHoleServer();
+  const port = await listenOnRandomPort(server);
+
+  try {
+    const controller = new AbortController();
+    const abortTimer = setTimeout(() => controller.abort(), 2000);
+
+    const start = Date.now();
+    try {
+      await fetch(`http://127.0.0.1:${port}/test`, {
+        signal: controller.signal,
+      });
+    } catch (err) {
+      // Expected: abort error
+    }
+    clearTimeout(abortTimer);
+
+    const elapsed = Date.now() - start;
+    console.log(`   AbortController interrupted fetch in ${elapsed}ms (expected ~2000ms)`);
+
+    if (elapsed > 5000) {
+      console.log(
+        `   ⚠ WARNING: AbortController took ${elapsed}ms — ` +
+        `this platform may be affected by issue #465.`
+      );
+    }
+
+    // We use a generous 10s limit here. On healthy platforms this is ~2s.
+    // On affected platforms it could be 30s+ (which fails this test and
+    // proves the bug exists on this machine).
+    assert(
+      elapsed < 10000,
+      `AbortController failed to interrupt fetch: ${elapsed}ms. ` +
+      `Node ${process.version}, ${process.platform}. ` +
+      `This confirms the AbortController bug from issue #465.`
+    );
+  } finally {
+    await closeServer(server);
+  }
+}
+
+/**
+ * Test 2: Current fetch pattern (AbortController only) against black-hole
+ * 
+ * This replicates exactly what FeatureFlagManager.fetchFlags() does.
+ * On affected platforms, this should take ~30s (FAIL).
+ * On healthy platforms, this should take ~5s (PASS).
+ */
+async function testCurrentPatternBlackHole() {
+  const server = createBlackHoleServer();
+  const port = await listenOnRandomPort(server);
+  const MAX_ALLOWED = 5000; // 3s timeout + 2s margin
+
+  try {
+    const start = Date.now();
+    try {
+      await currentFetchPattern(`http://127.0.0.1:${port}/flags.json`);
+    } catch (err) {
+      // Expected
+    }
+    const elapsed = Date.now() - start;
+    console.log(`   Current pattern (Promise.race) completed in ${elapsed}ms (limit: ${MAX_ALLOWED}ms)`);
+
+    assert(
+      elapsed < MAX_ALLOWED,
+      `Current fetch pattern (AbortController only) took ${elapsed}ms, exceeding ${MAX_ALLOWED}ms. ` +
+      `This reproduces issue #465 — AbortController is not interrupting the TCP connect.`
+    );
+  } finally {
+    await closeServer(server);
+  }
+}
+
+/**
+ * Test 3: AbortController-only pattern (pre-fix) against black-hole
+ * 
+ * This shows what happens WITHOUT Promise.race — just AbortController.
+ * On macOS this passes, on affected Windows it would hang ~30s.
+ */
+async function testAbortControllerOnlyBlackHole() {
+  const server = createBlackHoleServer();
+  const port = await listenOnRandomPort(server);
+  const MAX_ALLOWED = 7000;
+
+  try {
+    // AbortController-only pattern (the old code before the fix)
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+    const start = Date.now();
+    try {
+      await fetch(`http://127.0.0.1:${port}/flags.json`, {
+        signal: controller.signal,
+        headers: { 'Cache-Control': 'no-cache' },
+      });
+    } catch (err) {
+      // Expected
+    }
+    clearTimeout(timeout);
+    const elapsed = Date.now() - start;
+    console.log(`   AbortController-only pattern completed in ${elapsed}ms (limit: ${MAX_ALLOWED}ms)`);
+
+    assert(
+      elapsed < MAX_ALLOWED,
+      `AbortController-only pattern took ${elapsed}ms — on this platform AbortController works, ` +
+      `but on affected Windows+undici this would be ~30s`
+    );
+  } finally {
+    await closeServer(server);
+  }
+}
+
+/**
+ * Test 4: Current pattern against slow 15s response server
+ */
+async function testCurrentPatternSlowResponse() {
+  const server = createSlowResponseServer(15000);
+  const port = await listenOnRandomPort(server);
+  const MAX_ALLOWED = 5000; // 3s timeout + 2s margin
+
+  try {
+    const start = Date.now();
+    try {
+      await currentFetchPattern(`http://127.0.0.1:${port}/flags.json`);
+    } catch (err) {
+      // Expected: abort
+    }
+    const elapsed = Date.now() - start;
+    console.log(`   Current pattern (slow response) completed in ${elapsed}ms (limit: ${MAX_ALLOWED}ms)`);
+
+    assert(
+      elapsed < MAX_ALLOWED,
+      `Current pattern waited for slow response: ${elapsed}ms (limit: ${MAX_ALLOWED}ms)`
+    );
+  } finally {
+    await closeServer(server);
+  }
+}
+
+/**
+ * Test 5: Simulate the full onboarding path for new users
+ * 
+ * For a new user (no cache), the init handler does:
+ *   await featureFlagManager.waitForFreshFlags()
+ * 
+ * which waits for freshFetchPromise to resolve. With a hanging fetch,
+ * this blocks the MCP initialize response.
+ * 
+ * We simulate this by creating a promise that resolves only when the
+ * fetch completes (like freshFetchPromise), and measure how long it takes.
+ */
+async function testNewUserOnboardingPath() {
+  const server = createBlackHoleServer();
+  const port = await listenOnRandomPort(server);
+  const MAX_ALLOWED = 6000; // 3s fetch timeout + waitForFreshFlags 5s safety + margin
+
+  try {
+    // Simulate the freshFetchPromise pattern from FeatureFlagManager
+    let resolveFresh;
+    const freshFetchPromise = new Promise((resolve) => {
+      resolveFresh = resolve;
+    });
+
+    // Fire-and-forget fetch (like initialize() does)
+    currentFetchPattern(`http://127.0.0.1:${port}/flags.json`)
+      .then(() => resolveFresh())
+      .catch(() => resolveFresh()); // resolve on error too, like the real code
+
+    // Now simulate waitForFreshFlags()
+    const start = Date.now();
+    await freshFetchPromise;
+    const elapsed = Date.now() - start;
+
+    console.log(`   New-user onboarding path waited ${elapsed}ms (limit: ${MAX_ALLOWED}ms)`);
+
+    assert(
+      elapsed < MAX_ALLOWED,
+      `New-user path blocked for ${elapsed}ms waiting for fetch. ` +
+      `This is the exact scenario causing 30s startup delays in issue #465.`
+    );
+  } finally {
+    await closeServer(server);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Runner
+// ---------------------------------------------------------------------------
+
+/**
+ * Test 6: Simulate broken AbortController (the exact #465 scenario)
+ *
+ * On affected platforms, AbortController.abort() fires but the fetch
+ * promise doesn't reject until the OS TCP timeout (~30s). We simulate
+ * this by creating a fetch-like promise that ignores abort and only
+ * resolves after 20s. Then we show that Promise.race still saves us.
+ */
+async function testBrokenAbortControllerSimulation() {
+  // Simulate a fetch that ignores AbortController (the Windows bug)
+  function brokenFetch() {
+    return new Promise((resolve, reject) => {
+      // This simulates the fetch hanging for 20s regardless of abort
+      setTimeout(() => reject(new Error('OS TCP timeout after 20s')), 20000);
+    });
+  }
+
+  // Current pattern: AbortController only — hangs for 20s
+  const start1 = Date.now();
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), 5000);
+  try {
+    await brokenFetch(); // ignores the abort signal
+  } catch (err) {
+    // will take 20s
+  }
+  const elapsed1 = Date.now() - start1;
+  console.log(`   Broken AbortController (current pattern): ${elapsed1}ms`);
+
+  // Fixed pattern: Promise.race — returns in 5s even with broken abort
+  const start2 = Date.now();
+  const timeoutPromise = new Promise((_, reject) =>
+    setTimeout(() => reject(new Error('Hard timeout')), 5000)
+  );
+  try {
+    await Promise.race([brokenFetch(), timeoutPromise]);
+  } catch (err) {
+    // will take 5s thanks to Promise.race
+  }
+  const elapsed2 = Date.now() - start2;
+  console.log(`   Broken AbortController (Promise.race fix): ${elapsed2}ms`);
+
+  assert(
+    elapsed1 > 15000,
+    `Expected broken fetch to hang ~20s but it took ${elapsed1}ms — simulation is wrong`
+  );
+  assert(
+    elapsed2 < 7000,
+    `Promise.race fix should have resolved in ~5s but took ${elapsed2}ms`
+  );
+
+  console.log(`   ✓ Promise.race recovered from broken AbortController (${elapsed1}ms → ${elapsed2}ms)`);
+}
+
+async function main() {
+  console.log('\n🔍 Feature Flags Timeout Tests (issue #465)\n');
+  console.log(`   Node.js: ${process.version}`);
+  console.log(`   Platform: ${process.platform}`);
+  console.log('');
+
+  const results = [];
+
+  results.push(await runTest(
+    'AbortController interrupts fetch to black-hole server (2s)',
+    testAbortControllerBehavior
+  ));
+
+  results.push(await runTest(
+    'Current fetchFlags pattern respects 5s timeout (black-hole)',
+    testCurrentPatternBlackHole
+  ));
+
+  results.push(await runTest(
+    'AbortController-only pattern (pre-fix baseline) against black-hole',
+    testAbortControllerOnlyBlackHole
+  ));
+
+  results.push(await runTest(
+    'Current pattern aborts before 15s slow response arrives',
+    testCurrentPatternSlowResponse
+  ));
+
+  results.push(await runTest(
+    'New-user onboarding path does not block >8s on slow network',
+    testNewUserOnboardingPath
+  ));
+
+  results.push(await runTest(
+    'Promise.race fixes broken AbortController (simulated #465)',
+    testBrokenAbortControllerSimulation
+  ));
+
+  console.log('');
+  const passed = results.filter(Boolean).length;
+  const failed = results.length - passed;
+
+  if (failed > 0) {
+    console.log(`❌ ${failed}/${results.length} test(s) failed`);
+    console.log('   On this platform, issue #465 may be reproducible.');
+    console.log('   The Promise.race fix should resolve it regardless.');
+    process.exit(1);
+  } else {
+    console.log(`✅ All ${passed} tests passed`);
+    console.log('   AbortController works correctly on this platform.');
+    console.log('   The Promise.race fix is still recommended as a safety net.');
+    process.exit(0);
+  }
+}
+
+main().catch((err) => {
+  console.error('Fatal error in test runner:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## **User description**
## Problem

On Windows + Node 24 / undici 7.x, `AbortController.abort()` fails to interrupt an in-progress TCP connect. The fetch hangs until the OS-level TCP timeout (~30s on Windows), blocking the MCP initialize response for users on high-latency networks.

Reported by a user in Australia — every cold start of Desktop Commander blocks for ~30s. With WiFi disabled (DNS fails fast), startup completes in ~1.6s.

See #465 for full details and logs.

## Root Cause

Two paths where the slow fetch can block startup:

1. **`fetchFlags()`** uses `AbortController` with a 5s timeout, but on affected platforms the abort signal doesn't interrupt the TCP socket — it hangs for ~30s
2. **`waitForFreshFlags()`** (called in the MCP initialize handler for new users without a cache) awaits the fetch promise with no upper bound

## Fix

- **`fetchFlags()`**: Wrap fetch in `Promise.race` with a hard 3s timeout alongside AbortController. Even if AbortController fails to interrupt the socket, `Promise.race` ensures rejection at the JS level.
- **`waitForFreshFlags()`**: Add 5s safety timeout so it can never hang indefinitely.
- **Timeout lowered** from 5s to 3s — flags load from cache anyway; a fresh fetch isn't worth perceived startup latency.

## Tests

Added `test/test-feature-flags-timeout.js` with 6 tests:

| Test | What it does |
|---|---|
| AbortController behavior (2s) | Verifies abort interrupts fetch on this platform |
| Current pattern (black-hole) | Promise.race pattern against server that never responds |
| AbortController-only (baseline) | Pre-fix pattern for comparison |
| Slow response (15s server) | Verifies timeout fires before slow response arrives |
| New-user onboarding path | Simulates `waitForFreshFlags()` with hanging fetch |
| Broken AbortController simulation | Mocks a fetch ignoring abort (20s), proves Promise.race recovers to 5s |

**Note:** Tests pass on macOS where AbortController works correctly. The broken AbortController simulation (test 6) proves the fix works regardless of platform. Needs testing on Windows to confirm the real-world fix.

Fixes #465


___

## **CodeAnt-AI Description**
**Prevent feature flags fetch from blocking startup**

### What Changed
- Feature flags now stop waiting after 3 seconds, even if the network request does not cancel cleanly
- New-user startup now has a 5-second safety limit when waiting for fresh flags, so the MCP initialize flow does not hang
- Added tests that cover slow responses, stuck connections, and the new-user startup path

### Impact
`✅ Faster MCP startup on slow networks`
`✅ Fewer startup hangs for new users`
`✅ Clearer protection against stalled feature-flag fetches`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=ijdRvsEnDVJjbiLKSbqyXQVe8yFq0_u5YsuV22Vy3X8&org=wonderwhy-er)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved feature-flag fetching so app startup and updates no longer hang indefinitely under slow or unresponsive network conditions.

* **Tests**
  * Added end-to-end tests that validate timeout and resilience behaviors for feature-flag fetching across various network scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wonderwhy-er/DesktopCommanderMCP/pull/467)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->