### PR TITLE
fix: distinguish NOT_FOUND from DENIED in list_directory

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -520,6 +520,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                         [FILE] src/tools/filesystem.ts
                         
                         If a directory cannot be accessed, it will show [DENIED] instead.
+                        If a path does not exist, it will show [NOT_FOUND] instead.
                         Only works within allowed directories.
                         
                         ${PATH_GUIDANCE}

--- a/src/tools/filesystem.ts
+++ b/src/tools/filesystem.ts
@@ -686,9 +686,10 @@ export async function listDirectory(dirPath: string, depth: number = 2): Promise
         } catch (error) {
             const err = error as NodeJS.ErrnoException;
             const displayPath = relativePath || path.basename(currentPath);
-            // Keep [DENIED] prefix so UI parser regex still matches.
-            // Append a hint for permission/timeout errors so user gets context.
-            if (err.code === 'EPERM' || err.code === 'EACCES' || err.code === 'ETIMEDOUT') {
+            // Distinguish "not found" from "permission denied" so AI and UI get accurate info.
+            if (err.code === 'ENOENT') {
+                results.push(`[NOT_FOUND] ${displayPath} — path does not exist`);
+            } else if (err.code === 'EPERM' || err.code === 'EACCES' || err.code === 'ETIMEDOUT') {
                 results.push(`[DENIED] ${displayPath} — not accessible (permission denied, cloud-only file, or Full Disk Access not granted)`);
             } else {
                 results.push(`[DENIED] ${displayPath}`);

--- a/src/ui/file-preview/src/directory-controller.ts
+++ b/src/ui/file-preview/src/directory-controller.ts
@@ -123,7 +123,7 @@ function renderDirTree(entries: DirEntry[], rootPath: string): string {
                 return `<div class="dir-entry"><span class="dir-icon">🚫</span> <span class="dir-name-denied">${escapeHtml(item.name)}</span></div>`;
             }
             if (item.isNotFound) {
-                return `<div class="dir-entry"><span class="dir-icon">❓</span> <span class="dir-name-denied">${escapeHtml(item.name)} — path does not exist</span></div>`;
+                return `<div class="dir-entry"><span class="dir-icon">❓</span> <span class="dir-name-denied">${escapeHtml(item.name)}</span></div>`;
             }
             if (item.isDir) {
                 const hasChildren = item.children.length > 0;

--- a/src/ui/file-preview/src/directory-controller.ts
+++ b/src/ui/file-preview/src/directory-controller.ts
@@ -6,6 +6,7 @@ interface DirEntry {
     name: string;
     isDir: boolean;
     isDenied: boolean;
+    isNotFound: boolean;
     isWarning: boolean;
     warningText: string;
     children: DirEntry[];
@@ -17,7 +18,7 @@ function parseDirectoryEntries(content: string): { hint: string; entries: DirEnt
     const hintLines: string[] = [];
     const entryLines: string[] = [];
     for (const line of lines) {
-        if (/^\[(DIR|FILE|DENIED|WARNING)\]/.test(line.trim())) {
+        if (/^\[(DIR|FILE|DENIED|NOT_FOUND|WARNING)\]/.test(line.trim())) {
             entryLines.push(line.trim());
         } else if (entryLines.length === 0) {
             hintLines.push(line);
@@ -29,6 +30,7 @@ function parseDirectoryEntries(content: string): { hint: string; entries: DirEnt
         fullPath: string;
         isDir: boolean;
         isDenied: boolean;
+        isNotFound: boolean;
         isWarning: boolean;
         warningText: string;
         depth: number;
@@ -45,6 +47,7 @@ function parseDirectoryEntries(content: string): { hint: string; entries: DirEnt
                 fullPath: dirName,
                 isDir: false,
                 isDenied: false,
+                isNotFound: false,
                 isWarning: true,
                 warningText: msg,
                 depth: parts.length,
@@ -54,13 +57,15 @@ function parseDirectoryEntries(content: string): { hint: string; entries: DirEnt
 
         const isDir = line.startsWith('[DIR]');
         const isDenied = line.startsWith('[DENIED]');
-        const name = line.replace(/^\[(DIR|FILE|DENIED)\]\s*/, '');
+        const isNotFound = line.startsWith('[NOT_FOUND]');
+        const name = line.replace(/^\[(DIR|FILE|DENIED|NOT_FOUND)\]\s*/, '');
         const parts = name.replace(/\\/g, '/').split('/');
         flat.push({
             name,
             fullPath: name,
             isDir,
             isDenied,
+            isNotFound,
             isWarning: false,
             warningText: '',
             depth: parts.length - 1,
@@ -76,6 +81,7 @@ function parseDirectoryEntries(content: string): { hint: string; entries: DirEnt
             name: baseName,
             isDir: item.isDir,
             isDenied: item.isDenied,
+            isNotFound: item.isNotFound,
             isWarning: item.isWarning,
             warningText: item.warningText,
             children: [],
@@ -115,6 +121,9 @@ function renderDirTree(entries: DirEntry[], rootPath: string): string {
             }
             if (item.isDenied) {
                 return `<div class="dir-entry"><span class="dir-icon">🚫</span> <span class="dir-name-denied">${escapeHtml(item.name)}</span></div>`;
+            }
+            if (item.isNotFound) {
+                return `<div class="dir-entry"><span class="dir-icon">❓</span> <span class="dir-name-denied">${escapeHtml(item.name)} — path does not exist</span></div>`;
             }
             if (item.isDir) {
                 const hasChildren = item.children.length > 0;


### PR DESCRIPTION
When listing a nonexistent directory, the error was reported as `[DENIED]` which is misleading — it implies a permission issue rather than a missing path.

Now `ENOENT` errors produce `[NOT_FOUND]` with a clear message, while `EPERM`/`EACCES`/`ETIMEDOUT` remain as `[DENIED]`.

### Changes
- `src/tools/filesystem.ts`: Added `ENOENT` check in `listRecursive` catch block
- `src/ui/file-preview/src/directory-controller.ts`: Added `isNotFound` to parser, regex, and renderer (❓ icon)
- `src/server.ts`: Updated tool description to document `[NOT_FOUND]`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory-listing error handling to clearly distinguish missing paths from permission or access failures.
  * UI now shows explicit "path does not exist" feedback with a dedicated indicator when a specified directory cannot be found.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wonderwhy-er/DesktopCommanderMCP/pull/468)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wonderwhy-er/DesktopCommanderMCP/pull/468)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->