### PR TITLE
chore(telemetry): route events through proxy

### DIFF
--- a/setup-claude-server.js
+++ b/setup-claude-server.js
@@ -10,10 +10,10 @@ import { version as nodeVersion } from 'process';
 import * as https from 'https';
 import { randomUUID } from 'crypto';
 
-// Google Analytics configuration
-const GA_MEASUREMENT_ID = 'G-NGGDNL0K4L'; // Replace with your GA4 Measurement ID
-const GA_API_SECRET = '5M0mC--2S_6t94m8WrI60A';   // Replace with your GA4 API Secre
-const GA_BASE_URL = `https://www.google-analytics.com/mp/collect?measurement_id=${GA_MEASUREMENT_ID}&api_secret=${GA_API_SECRET}`;
+// Telemetry proxy configuration
+const TELEMETRY_PROXY_URL = 'https://telemetry.desktopcommander.app/mp/collect';
+const TELEMETRY_PROXY_FALLBACK_URL = 'https://dc-telemetry-proxy-83847352264.europe-west1.run.app/mp/collect';
+const TELEMETRY_PROXY_TOKEN = 'Od44UB_fTrVfGPGRPLr5QdVgFhuKdiGaBmvazTdxVdQ';
 
 // Generate a unique anonymous ID using UUID - consistent with privacy policy
 let uniqueUserId = 'unknown';
@@ -302,7 +302,7 @@ async function enhancedGetTrackingProperties(additionalProps = {}) {
 async function trackEvent(eventName, additionalProps = {}) {
     const trackingStep = addSetupStep(`track_event_${eventName}`);
 
-    if (!GA_MEASUREMENT_ID || !GA_API_SECRET) {
+    if (!TELEMETRY_PROXY_TOKEN) {
         updateSetupStep(trackingStep, 'skipped', new Error('GA not configured'));
         return;
     }
@@ -319,7 +319,7 @@ async function trackEvent(eventName, additionalProps = {}) {
             // Get enriched properties
             const eventProperties = await enhancedGetTrackingProperties(additionalProps);
 
-            // Prepare GA4 payload
+            // Prepare telemetry payload
             const payload = {
                 client_id: uniqueUserId,
                 non_personalized_ads: false,
@@ -330,55 +330,20 @@ async function trackEvent(eventName, additionalProps = {}) {
                 }]
             };
 
-            // Send to Google Analytics
+            // Send to telemetry proxy
             const postData = JSON.stringify(payload);
             
             const options = {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${TELEMETRY_PROXY_TOKEN}`,
                     'Content-Length': Buffer.byteLength(postData)
                 }
             };
 
-            const result = await new Promise((resolve, reject) => {
-                const req = https.request(GA_BASE_URL, options);
-
-                // Set timeout to prevent blocking
-                const timeoutId = setTimeout(() => {
-                    req.destroy();
-                    reject(new Error('Request timeout'));
-                }, 5000); // Increased timeout to 5 seconds
-
-                req.on('error', (error) => {
-                    clearTimeout(timeoutId);
-                    reject(error);
-                });
-
-                req.on('response', (res) => {
-                    clearTimeout(timeoutId);
-                    let data = '';
-
-                    res.on('data', (chunk) => {
-                        data += chunk;
-                    });
-
-                    res.on('error', (error) => {
-                        reject(error);
-                    });
-
-                    res.on('end', () => {
-                        if (res.statusCode >= 200 && res.statusCode < 300) {
-                            resolve({ success: true, data });
-                        } else {
-                            reject(new Error(`HTTP error ${res.statusCode}: ${data}`));
-                        }
-                    });
-                });
-
-                req.write(postData);
-                req.end();
-            });
+            const result = await postTelemetryPayload(postData, options);
+            if (!result.success) throw new Error('Telemetry proxy request failed');
 
             updateSetupStep(trackingStep, 'completed');
             return result;
@@ -395,6 +360,42 @@ async function trackEvent(eventName, additionalProps = {}) {
     // All retries failed
     updateSetupStep(trackingStep, 'failed', lastError);
     return false;
+}
+
+async function postTelemetryPayload(postData, options) {
+    for (const endpoint of [TELEMETRY_PROXY_URL, TELEMETRY_PROXY_FALLBACK_URL]) {
+        const result = await new Promise((resolve) => {
+            const req = https.request(endpoint, options);
+
+            const timeoutId = setTimeout(() => {
+                req.destroy();
+                resolve({ success: false, data: '' });
+            }, 5000);
+
+            req.on('error', () => {
+                clearTimeout(timeoutId);
+                resolve({ success: false, data: '' });
+            });
+
+            req.on('response', (res) => {
+                clearTimeout(timeoutId);
+                let data = '';
+                res.on('data', (chunk) => {
+                    data += chunk;
+                });
+                res.on('end', () => {
+                    resolve({ success: res.statusCode >= 200 && res.statusCode < 300, data });
+                });
+            });
+
+            req.write(postData);
+            req.end();
+        });
+
+        if (result.success) return result;
+    }
+
+    return { success: false, data: '' };
 }
 
 // Ensure tracking completes before process exits

--- a/setup-claude-server.js
+++ b/setup-claude-server.js
@@ -13,7 +13,6 @@ import { randomUUID } from 'crypto';
 // Telemetry proxy configuration
 const TELEMETRY_PROXY_URL = 'https://telemetry.desktopcommander.app/mp/collect';
 const TELEMETRY_PROXY_FALLBACK_URL = 'https://dc-telemetry-proxy-83847352264.europe-west1.run.app/mp/collect';
-const TELEMETRY_PROXY_TOKEN = 'Od44UB_fTrVfGPGRPLr5QdVgFhuKdiGaBmvazTdxVdQ';
 
 // Generate a unique anonymous ID using UUID - consistent with privacy policy
 let uniqueUserId = 'unknown';
@@ -302,11 +301,6 @@ async function enhancedGetTrackingProperties(additionalProps = {}) {
 async function trackEvent(eventName, additionalProps = {}) {
     const trackingStep = addSetupStep(`track_event_${eventName}`);
 
-    if (!TELEMETRY_PROXY_TOKEN) {
-        updateSetupStep(trackingStep, 'skipped', new Error('GA not configured'));
-        return;
-    }
-
     // Add retry capability
     const maxRetries = 2;
     let attempt = 0;
@@ -337,7 +331,6 @@ async function trackEvent(eventName, additionalProps = {}) {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
-                    'Authorization': `Bearer ${TELEMETRY_PROXY_TOKEN}`,
                     'Content-Length': Buffer.byteLength(postData)
                 }
             };

--- a/setup-claude-server.js
+++ b/setup-claude-server.js
@@ -365,26 +365,38 @@ async function trackEvent(eventName, additionalProps = {}) {
 async function postTelemetryPayload(postData, options) {
     for (const endpoint of [TELEMETRY_PROXY_URL, TELEMETRY_PROXY_FALLBACK_URL]) {
         const result = await new Promise((resolve) => {
+            let settled = false;
+            let timeoutId;
+            const finish = (result) => {
+                if (settled) return;
+                settled = true;
+                clearTimeout(timeoutId);
+                resolve(result);
+            };
             const req = https.request(endpoint, options);
 
-            const timeoutId = setTimeout(() => {
+            timeoutId = setTimeout(() => {
                 req.destroy();
-                resolve({ success: false, data: '' });
+                finish({ success: false, data: '' });
             }, 5000);
 
             req.on('error', () => {
-                clearTimeout(timeoutId);
-                resolve({ success: false, data: '' });
+                finish({ success: false, data: '' });
             });
 
             req.on('response', (res) => {
-                clearTimeout(timeoutId);
                 let data = '';
                 res.on('data', (chunk) => {
                     data += chunk;
                 });
+                res.on('error', () => {
+                    finish({ success: false, data: '' });
+                });
                 res.on('end', () => {
-                    resolve({ success: res.statusCode >= 200 && res.statusCode < 300, data });
+                    finish({ success: res.statusCode >= 200 && res.statusCode < 300, data });
+                });
+                res.on('close', () => {
+                    finish({ success: false, data: '' });
                 });
             });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1180,7 +1180,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
         // Extract metadata from _meta field if present
         const metadata = request.params._meta as any;
         if (metadata && typeof metadata === 'object') {
-            // add remote flag if present (convert to string for GA4)
+            // add remote flag if present (convert to string for telemetry)
             if (metadata.remote) {
                 telemetryData.remote = String(metadata.remote);
             }

--- a/src/utils/capture.ts
+++ b/src/utils/capture.ts
@@ -15,7 +15,10 @@ try {
 let uniqueUserId = 'unknown';
 
 // --- Telemetry Proxy (direct BigQuery ingestion) ---
-const TELEMETRY_PROXY_URL = 'https://dc-telemetry-proxy-83847352264.europe-west1.run.app/mp/collect';
+// TODO: Move proxy endpoints, auth header setup, request retry/fallback, and
+// transport code into a dedicated telemetry utility once this migration lands.
+const TELEMETRY_PROXY_URL = 'https://telemetry.desktopcommander.app/mp/collect';
+const TELEMETRY_PROXY_FALLBACK_URL = 'https://dc-telemetry-proxy-83847352264.europe-west1.run.app/mp/collect';
 const TELEMETRY_PROXY_TOKEN = 'Od44UB_fTrVfGPGRPLr5QdVgFhuKdiGaBmvazTdxVdQ';
 
 
@@ -54,7 +57,7 @@ export function sanitizeError(error: any): { message: string, code?: string } {
 }
 
 /**
- * Send an event to Google Analytics
+ * Send an event to telemetry
  * @param event Event name
  * @param properties Optional event properties
  */
@@ -199,7 +202,7 @@ export const captureBase = async (captureURL: string, event: string, properties?
             ...sanitizedProperties
         };
 
-        // Prepare GA4 payload
+        // Prepare telemetry payload
         const payload = {
             client_id: uniqueUserId,
             non_personalized_ads: false,
@@ -210,7 +213,7 @@ export const captureBase = async (captureURL: string, event: string, properties?
             }]
         };
 
-        // Send data to Google Analytics
+        // Send data to telemetry endpoint
         const postData = JSON.stringify(payload);
 
         const options = {
@@ -232,7 +235,7 @@ export const captureBase = async (captureURL: string, event: string, properties?
                 const success = res.statusCode === 200 || res.statusCode === 204;
                 if (!success) {
                     // Optional debug logging
-                    // console.debug(`GA tracking error: ${res.statusCode} ${data}`);
+                    // console.debug(`Telemetry tracking error: ${res.statusCode} ${data}`);
                 }
             });
         });
@@ -256,7 +259,7 @@ export const captureBase = async (captureURL: string, event: string, properties?
 };
 
 /**
- * Build the standard event properties used by both GA4 and the telemetry proxy.
+ * Build the standard event properties used by the telemetry proxy.
  * Extracted from captureBase so both paths get identical data.
  */
 const buildEventProperties = async (properties?: any) => {
@@ -361,8 +364,7 @@ const buildEventProperties = async (properties?: any) => {
 
 /**
  * Send event to the telemetry proxy (direct BigQuery ingestion).
- * Runs in parallel with GA4 — used for high-volume events to avoid
- * the 1M/day GA4 BigQuery export limit.
+ * Uses the custom domain first and retries the generated Cloud Run URL on failure.
  */
 const sendToTelemetryProxy = async (event: string, eventProperties: any) => {
     try {
@@ -378,7 +380,18 @@ const sendToTelemetryProxy = async (event: string, eventProperties: any) => {
             }]
         });
 
-        const url = new URL(TELEMETRY_PROXY_URL);
+        const sent = await postTelemetryPayload(TELEMETRY_PROXY_URL, payload);
+        if (!sent) {
+            await postTelemetryPayload(TELEMETRY_PROXY_FALLBACK_URL, payload);
+        }
+    } catch {
+        // Silent fail — telemetry should never break functionality
+    }
+};
+
+const postTelemetryPayload = async (endpoint: string, payload: string): Promise<boolean> => {
+    return await new Promise((resolve) => {
+        const url = new URL(endpoint);
         const options = {
             hostname: url.hostname,
             port: 443,
@@ -392,59 +405,36 @@ const sendToTelemetryProxy = async (event: string, eventProperties: any) => {
         };
 
         const req = https.request(options, (res) => {
-            res.resume(); // drain response
+            res.resume();
+            res.on('end', () => resolve(res.statusCode !== undefined && res.statusCode >= 200 && res.statusCode < 300));
         });
-        req.on('error', () => { }); // silent fail
-        req.setTimeout(3000, () => req.destroy());
+        req.on('error', () => resolve(false));
+        req.setTimeout(3000, () => {
+            req.destroy();
+            resolve(false);
+        });
         req.write(payload);
         req.end();
-    } catch {
-        // Silent fail — telemetry should never break functionality
-    }
+    });
 };
 
 export const capture_call_tool = async (event: string, properties?: any) => {
-    // Old property (G-8L163XZ1CE) — keeps lower-volume tool events
-    const GA_OLD_ID = 'G-8L163XZ1CE';
-    const GA_OLD_SECRET = 'hNxh4TK2TnSy4oLZn4RwTA';
-    const GA_OLD_URL = `https://www.google-analytics.com/mp/collect?measurement_id=${GA_OLD_ID}&api_secret=${GA_OLD_SECRET}`;
-
-    // New property (dc_high_volume) — receives highest-volume tool events to avoid 1M/day BQ export limit
-    const GA_NEW_ID = 'G-ZDF1M5403Z';
-    const GA_NEW_SECRET = 'cUEilpa0SpWfc2UjblDtKQ';
-    const GA_NEW_URL = `https://www.google-analytics.com/mp/collect?measurement_id=${GA_NEW_ID}&api_secret=${GA_NEW_SECRET}`;
-
-    // Route highest-volume tools to new property, rest to old
-    const HIGH_VOLUME_TOOLS = ['start_process',  'track_ui_event'];
-    const toolName = properties?.tool_name ?? properties?.name;
-    const gaUrl = HIGH_VOLUME_TOOLS.includes(toolName) ? GA_NEW_URL : GA_OLD_URL;
-
-    // Build properties once, send to GA4 + telemetry proxy in parallel
+    // TODO: Aggregate capture(), capture_call_tool(), and capture_ui_event() after
+    // the GA-to-proxy migration is stable. They now share the same destination.
+    // Build properties once, send to telemetry proxy.
     const eventProperties = await buildEventProperties(properties);
-    await Promise.all([
-        captureBase(gaUrl, event, properties),                 // GA4 (routed by tool name)
-        sendToTelemetryProxy(event, eventProperties),          // direct BigQuery (all events)
-    ]);
+    await sendToTelemetryProxy(event, eventProperties);
 }
 
 export const capture = async (event: string, properties?: any) => {
-    const GA_MEASUREMENT_ID = 'G-F3GK01G39Y';
-    const GA_API_SECRET = 'SqdcIAweSQS1RQErURMdEA';
-    const GA_BASE_URL = `https://www.google-analytics.com/mp/collect?measurement_id=${GA_MEASUREMENT_ID}&api_secret=${GA_API_SECRET}`;
-
-    // Build properties once, send to both GA4 and telemetry proxy in parallel
+    // Build properties once, send to telemetry proxy.
     const eventProperties = await buildEventProperties(properties);
-    await Promise.all([
-        captureBase(GA_BASE_URL, event, properties),           // existing GA4
-        sendToTelemetryProxy(event, eventProperties),          // new: direct BigQuery
-    ]);
+    await sendToTelemetryProxy(event, eventProperties);
 }
 
 export const capture_ui_event = async (event: string, properties?: any) => {
-    const GA_MEASUREMENT_ID = 'G-MPFSWEGQ0T';
-    const GA_API_SECRET = 'BeK3uyAOQ6-TK6wnaDG2Ww';
-    const GA_BASE_URL = `https://www.google-analytics.com/mp/collect?measurement_id=${GA_MEASUREMENT_ID}&api_secret=${GA_API_SECRET}`;
-    return await captureBase(GA_BASE_URL, event, properties);
+    const eventProperties = await buildEventProperties(properties);
+    await sendToTelemetryProxy(event, eventProperties);
 }
 
 /**

--- a/src/utils/capture.ts
+++ b/src/utils/capture.ts
@@ -17,6 +17,9 @@ let uniqueUserId = 'unknown';
 // --- Telemetry Proxy (direct BigQuery ingestion) ---
 // TODO: Move proxy endpoints, auth header setup, request retry/fallback, and
 // transport code into a dedicated telemetry utility once this migration lands.
+// TODO(security): bearer token was removed, so this endpoint is now unauthenticated.
+// Confirm the proxy enforces rate limiting / payload validation server-side,
+// otherwise anyone can POST arbitrary events straight into BigQuery ingestion.
 const TELEMETRY_PROXY_URL = 'https://telemetry.desktopcommander.app/mp/collect';
 const TELEMETRY_PROXY_FALLBACK_URL = 'https://dc-telemetry-proxy-83847352264.europe-west1.run.app/mp/collect';
 
@@ -60,6 +63,9 @@ export function sanitizeError(error: any): { message: string, code?: string } {
  * @param event Event name
  * @param properties Optional event properties
  */
+// TODO(cleanup): captureBase is now dead code — no caller remains after the GA
+// removal (only referenced in a comment). It still carries the full GA4-flavored
+// send path. Remove it, or repurpose it as the shared proxy transport.
 export const captureBase = async (captureURL: string, event: string, properties?: any) => {
     try {
         // Check if telemetry is enabled in config (defaults to true if not set)
@@ -416,6 +422,11 @@ const postTelemetryPayload = async (endpoint: string, payload: string): Promise<
     });
 };
 
+// TODO(behavior): capture() is now fire-and-forget — every `await capture(...)`
+// call site resolves before the network send completes. Fine for the long-running
+// MCP server, but events fired right before process exit (e.g. opt-out, feedback)
+// can be silently dropped. If we need delivery guarantees on short-lived paths,
+// expose an awaitable variant or flush-before-exit hook.
 export const capture = async (event: string, properties?: any) => {
     void (async () => {
         try {

--- a/src/utils/capture.ts
+++ b/src/utils/capture.ts
@@ -19,7 +19,6 @@ let uniqueUserId = 'unknown';
 // transport code into a dedicated telemetry utility once this migration lands.
 const TELEMETRY_PROXY_URL = 'https://telemetry.desktopcommander.app/mp/collect';
 const TELEMETRY_PROXY_FALLBACK_URL = 'https://dc-telemetry-proxy-83847352264.europe-west1.run.app/mp/collect';
-const TELEMETRY_PROXY_TOKEN = 'Od44UB_fTrVfGPGRPLr5QdVgFhuKdiGaBmvazTdxVdQ';
 
 
 /**
@@ -399,7 +398,6 @@ const postTelemetryPayload = async (endpoint: string, payload: string): Promise<
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
-                'Authorization': `Bearer ${TELEMETRY_PROXY_TOKEN}`,
                 'Content-Length': Buffer.byteLength(payload)
             }
         };

--- a/src/utils/capture.ts
+++ b/src/utils/capture.ts
@@ -418,24 +418,19 @@ const postTelemetryPayload = async (endpoint: string, payload: string): Promise<
     });
 };
 
-export const capture_call_tool = async (event: string, properties?: any) => {
-    // TODO: Aggregate capture(), capture_call_tool(), and capture_ui_event() after
-    // the GA-to-proxy migration is stable. They now share the same destination.
-    // Build properties once, send to telemetry proxy.
-    const eventProperties = await buildEventProperties(properties);
-    await sendToTelemetryProxy(event, eventProperties);
-}
-
 export const capture = async (event: string, properties?: any) => {
-    // Build properties once, send to telemetry proxy.
-    const eventProperties = await buildEventProperties(properties);
-    await sendToTelemetryProxy(event, eventProperties);
+    void (async () => {
+        try {
+            const eventProperties = await buildEventProperties(properties);
+            await sendToTelemetryProxy(event, eventProperties);
+        } catch {
+            // Silent fail — telemetry should never break functionality
+        }
+    })();
 }
 
-export const capture_ui_event = async (event: string, properties?: any) => {
-    const eventProperties = await buildEventProperties(properties);
-    await sendToTelemetryProxy(event, eventProperties);
-}
+export const capture_call_tool = capture;
+export const capture_ui_event = capture;
 
 /**
  * Wrapper for capture() that automatically adds remote flag for remote-device telemetry

--- a/track-installation.js
+++ b/track-installation.js
@@ -314,6 +314,12 @@ async function trackInstallation(installationData) {
     }
 }
 
+// TODO(dedup): postTelemetryPayload is copy-pasted across setup/uninstall/track
+// scripts + a variant in src/utils/capture.ts. Consolidate into one shared module.
+// TODO(timeout): per-endpoint timeout here is 5s, but ensureTrackingCompleted caps
+// the whole flow at 6s — so if the primary times out, the fallback gets ~1s and
+// almost never completes. Lower per-endpoint timeout (capture.ts uses 3s) or raise
+// the overall budget so the fallback is actually usable.
 async function postTelemetryPayload(endpoint, postData, options) {
     return await new Promise((resolve) => {
         let settled = false;

--- a/track-installation.js
+++ b/track-installation.js
@@ -73,10 +73,10 @@ async function getClientId() {
     }
 }
 
-// Google Analytics configuration (same as setup script)
-const GA_MEASUREMENT_ID = 'G-NGGDNL0K4L';
-const GA_API_SECRET = '5M0mC--2S_6t94m8WrI60A';
-const GA_BASE_URL = `https://www.google-analytics.com/mp/collect?measurement_id=${GA_MEASUREMENT_ID}&api_secret=${GA_API_SECRET}`;
+// Telemetry proxy configuration (same as setup script)
+const TELEMETRY_PROXY_URL = 'https://telemetry.desktopcommander.app/mp/collect';
+const TELEMETRY_PROXY_FALLBACK_URL = 'https://dc-telemetry-proxy-83847352264.europe-west1.run.app/mp/collect';
+const TELEMETRY_PROXY_TOKEN = 'Od44UB_fTrVfGPGRPLr5QdVgFhuKdiGaBmvazTdxVdQ';
 
 /**
  * Detect installation source from environment and process context
@@ -267,10 +267,10 @@ async function detectInstallationSource() {
 }
 
 /**
- * Send installation tracking to analytics
+ * Send installation tracking to telemetry proxy
  */
 async function trackInstallation(installationData) {
-    if (!GA_MEASUREMENT_ID || !GA_API_SECRET) {
+    if (!TELEMETRY_PROXY_TOKEN) {
         debug('Analytics not configured, skipping tracking');
         return;
     }
@@ -278,7 +278,7 @@ async function trackInstallation(installationData) {
     try {
         const uniqueUserId = await getClientId();
         log("user id", uniqueUserId)
-        // Prepare GA4 payload
+        // Prepare telemetry payload
         const payload = {
             client_id: uniqueUserId,
             non_personalized_ads: false,
@@ -304,42 +304,49 @@ async function trackInstallation(installationData) {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
+                'Authorization': `Bearer ${TELEMETRY_PROXY_TOKEN}`,
                 'Content-Length': Buffer.byteLength(postData)
             }
         };
 
-        await new Promise((resolve, reject) => {
-            const req = https.request(GA_BASE_URL, options);
-            
-            const timeoutId = setTimeout(() => {
-                req.destroy();
-                reject(new Error('Request timeout'));
-            }, 5000);
-
-            req.on('error', (error) => {
-                clearTimeout(timeoutId);
-                debug(`Analytics error: ${error.message}`);
-                resolve(); // Don't fail installation on analytics error
-            });
-
-            req.on('response', (res) => {
-                clearTimeout(timeoutId);
-                // Consume the response data to complete the request
-                res.on('data', () => {}); // Ignore response data
-                res.on('end', () => {
-                    log(`Installation tracked: ${installationData.source}`);
-                    resolve();
-                });
-            });
-
-            req.write(postData);
-            req.end();
-        });
+        const sent = await postTelemetryPayload(TELEMETRY_PROXY_URL, postData, options);
+        if (!sent) {
+            await postTelemetryPayload(TELEMETRY_PROXY_FALLBACK_URL, postData, options);
+        }
+        log(`Installation tracked: ${installationData.source}`);
 
     } catch (error) {
         debug(`Failed to track installation: ${error.message}`);
         // Don't fail the installation process
     }
+}
+
+async function postTelemetryPayload(endpoint, postData, options) {
+    return await new Promise((resolve) => {
+        const req = https.request(endpoint, options);
+        
+        const timeoutId = setTimeout(() => {
+            req.destroy();
+            resolve(false);
+        }, 5000);
+
+        req.on('error', (error) => {
+            clearTimeout(timeoutId);
+            debug(`Telemetry error: ${error.message}`);
+            resolve(false);
+        });
+
+        req.on('response', (res) => {
+            clearTimeout(timeoutId);
+            res.on('data', () => {});
+            res.on('end', () => {
+                resolve(res.statusCode >= 200 && res.statusCode < 300);
+            });
+        });
+
+        req.write(postData);
+        req.end();
+    });
 }
 
 /**

--- a/track-installation.js
+++ b/track-installation.js
@@ -76,7 +76,6 @@ async function getClientId() {
 // Telemetry proxy configuration (same as setup script)
 const TELEMETRY_PROXY_URL = 'https://telemetry.desktopcommander.app/mp/collect';
 const TELEMETRY_PROXY_FALLBACK_URL = 'https://dc-telemetry-proxy-83847352264.europe-west1.run.app/mp/collect';
-const TELEMETRY_PROXY_TOKEN = 'Od44UB_fTrVfGPGRPLr5QdVgFhuKdiGaBmvazTdxVdQ';
 
 /**
  * Detect installation source from environment and process context
@@ -270,11 +269,6 @@ async function detectInstallationSource() {
  * Send installation tracking to telemetry proxy
  */
 async function trackInstallation(installationData) {
-    if (!TELEMETRY_PROXY_TOKEN) {
-        debug('Analytics not configured, skipping tracking');
-        return;
-    }
-
     try {
         const uniqueUserId = await getClientId();
         log("user id", uniqueUserId)
@@ -304,7 +298,6 @@ async function trackInstallation(installationData) {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
-                'Authorization': `Bearer ${TELEMETRY_PROXY_TOKEN}`,
                 'Content-Length': Buffer.byteLength(postData)
             }
         };

--- a/track-installation.js
+++ b/track-installation.js
@@ -323,24 +323,37 @@ async function trackInstallation(installationData) {
 
 async function postTelemetryPayload(endpoint, postData, options) {
     return await new Promise((resolve) => {
+        let settled = false;
+        let timeoutId;
+        const finish = (result) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timeoutId);
+            resolve(result);
+        };
         const req = https.request(endpoint, options);
         
-        const timeoutId = setTimeout(() => {
+        timeoutId = setTimeout(() => {
             req.destroy();
-            resolve(false);
+            finish(false);
         }, 5000);
 
         req.on('error', (error) => {
-            clearTimeout(timeoutId);
             debug(`Telemetry error: ${error.message}`);
-            resolve(false);
+            finish(false);
         });
 
         req.on('response', (res) => {
-            clearTimeout(timeoutId);
             res.on('data', () => {});
+            res.on('error', (error) => {
+                debug(`Telemetry response error: ${error.message}`);
+                finish(false);
+            });
             res.on('end', () => {
-                resolve(res.statusCode >= 200 && res.statusCode < 300);
+                finish(res.statusCode >= 200 && res.statusCode < 300);
+            });
+            res.on('close', () => {
+                finish(false);
             });
         });
 

--- a/uninstall-claude-server.js
+++ b/uninstall-claude-server.js
@@ -279,26 +279,38 @@ async function trackEvent(eventName, additionalProps = {}) {
 async function postTelemetryPayload(postData, options) {
     for (const endpoint of [TELEMETRY_PROXY_URL, TELEMETRY_PROXY_FALLBACK_URL]) {
         const result = await new Promise((resolve) => {
+            let settled = false;
+            let timeoutId;
+            const finish = (result) => {
+                if (settled) return;
+                settled = true;
+                clearTimeout(timeoutId);
+                resolve(result);
+            };
             const req = https.request(endpoint, options);
 
-            const timeoutId = setTimeout(() => {
+            timeoutId = setTimeout(() => {
                 req.destroy();
-                resolve({ success: false, data: '' });
+                finish({ success: false, data: '' });
             }, 5000);
 
             req.on('error', () => {
-                clearTimeout(timeoutId);
-                resolve({ success: false, data: '' });
+                finish({ success: false, data: '' });
             });
 
             req.on('response', (res) => {
-                clearTimeout(timeoutId);
                 let data = '';
                 res.on('data', (chunk) => {
                     data += chunk;
                 });
+                res.on('error', () => {
+                    finish({ success: false, data: '' });
+                });
                 res.on('end', () => {
-                    resolve({ success: res.statusCode >= 200 && res.statusCode < 300, data });
+                    finish({ success: res.statusCode >= 200 && res.statusCode < 300, data });
+                });
+                res.on('close', () => {
+                    finish({ success: false, data: '' });
                 });
             });
 

--- a/uninstall-claude-server.js
+++ b/uninstall-claude-server.js
@@ -10,10 +10,10 @@ import { version as nodeVersion } from 'process';
 import * as https from 'https';
 import { randomUUID } from 'crypto';
 
-// Google Analytics configuration
-const GA_MEASUREMENT_ID = 'G-NGGDNL0K4L'; // Replace with your GA4 Measurement ID
-const GA_API_SECRET = '5M0mC--2S_6t94m8WrI60A';   // Replace with your GA4 API Secret
-const GA_BASE_URL = `https://www.google-analytics.com/mp/collect?measurement_id=${GA_MEASUREMENT_ID}&api_secret=${GA_API_SECRET}`;
+// Telemetry proxy configuration
+const TELEMETRY_PROXY_URL = 'https://telemetry.desktopcommander.app/mp/collect';
+const TELEMETRY_PROXY_FALLBACK_URL = 'https://dc-telemetry-proxy-83847352264.europe-west1.run.app/mp/collect';
+const TELEMETRY_PROXY_TOKEN = 'Od44UB_fTrVfGPGRPLr5QdVgFhuKdiGaBmvazTdxVdQ';
 
 // Read clientId and telemetry settings from existing config
 let uniqueUserId = 'unknown';
@@ -222,7 +222,7 @@ async function trackEvent(eventName, additionalProps = {}) {
         return true; // Return success since this is expected behavior
     }
 
-    if (!GA_MEASUREMENT_ID || !GA_API_SECRET) {
+    if (!TELEMETRY_PROXY_TOKEN) {
         updateUninstallStep(trackingStep, 'skipped', new Error('GA not configured'));
         return;
     }
@@ -253,47 +253,13 @@ async function trackEvent(eventName, additionalProps = {}) {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${TELEMETRY_PROXY_TOKEN}`,
                     'Content-Length': Buffer.byteLength(postData)
                 }
             };
 
-            const result = await new Promise((resolve, reject) => {
-                const req = https.request(GA_BASE_URL, options);
-
-                const timeoutId = setTimeout(() => {
-                    req.destroy();
-                    reject(new Error('Request timeout'));
-                }, 5000);
-
-                req.on('error', (error) => {
-                    clearTimeout(timeoutId);
-                    reject(error);
-                });
-
-                req.on('response', (res) => {
-                    clearTimeout(timeoutId);
-                    let data = '';
-
-                    res.on('data', (chunk) => {
-                        data += chunk;
-                    });
-
-                    res.on('error', (error) => {
-                        reject(error);
-                    });
-
-                    res.on('end', () => {
-                        if (res.statusCode >= 200 && res.statusCode < 300) {
-                            resolve({ success: true, data });
-                        } else {
-                            reject(new Error(`HTTP error ${res.statusCode}: ${data}`));
-                        }
-                    });
-                });
-
-                req.write(postData);
-                req.end();
-            });
+            const result = await postTelemetryPayload(postData, options);
+            if (!result.success) throw new Error('Telemetry proxy request failed');
 
             updateUninstallStep(trackingStep, 'completed');
             return result;
@@ -308,6 +274,42 @@ async function trackEvent(eventName, additionalProps = {}) {
 
     updateUninstallStep(trackingStep, 'failed', lastError);
     return false;
+}
+
+async function postTelemetryPayload(postData, options) {
+    for (const endpoint of [TELEMETRY_PROXY_URL, TELEMETRY_PROXY_FALLBACK_URL]) {
+        const result = await new Promise((resolve) => {
+            const req = https.request(endpoint, options);
+
+            const timeoutId = setTimeout(() => {
+                req.destroy();
+                resolve({ success: false, data: '' });
+            }, 5000);
+
+            req.on('error', () => {
+                clearTimeout(timeoutId);
+                resolve({ success: false, data: '' });
+            });
+
+            req.on('response', (res) => {
+                clearTimeout(timeoutId);
+                let data = '';
+                res.on('data', (chunk) => {
+                    data += chunk;
+                });
+                res.on('end', () => {
+                    resolve({ success: res.statusCode >= 200 && res.statusCode < 300, data });
+                });
+            });
+
+            req.write(postData);
+            req.end();
+        });
+
+        if (result.success) return result;
+    }
+
+    return { success: false, data: '' };
 }
 // Ensure tracking completes before process exits
 async function ensureTrackingCompleted(eventName, additionalProps = {}, timeoutMs = 6000) {

--- a/uninstall-claude-server.js
+++ b/uninstall-claude-server.js
@@ -13,7 +13,6 @@ import { randomUUID } from 'crypto';
 // Telemetry proxy configuration
 const TELEMETRY_PROXY_URL = 'https://telemetry.desktopcommander.app/mp/collect';
 const TELEMETRY_PROXY_FALLBACK_URL = 'https://dc-telemetry-proxy-83847352264.europe-west1.run.app/mp/collect';
-const TELEMETRY_PROXY_TOKEN = 'Od44UB_fTrVfGPGRPLr5QdVgFhuKdiGaBmvazTdxVdQ';
 
 // Read clientId and telemetry settings from existing config
 let uniqueUserId = 'unknown';
@@ -222,11 +221,6 @@ async function trackEvent(eventName, additionalProps = {}) {
         return true; // Return success since this is expected behavior
     }
 
-    if (!TELEMETRY_PROXY_TOKEN) {
-        updateUninstallStep(trackingStep, 'skipped', new Error('GA not configured'));
-        return;
-    }
-
     const maxRetries = 2;
     let attempt = 0;
     let lastError = null;
@@ -253,7 +247,6 @@ async function trackEvent(eventName, additionalProps = {}) {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
-                    'Authorization': `Bearer ${TELEMETRY_PROXY_TOKEN}`,
                     'Content-Length': Buffer.byteLength(postData)
                 }
             };


### PR DESCRIPTION
- Removed direct GA sends.
- New telemetry primary: https://telemetry.desktopcommander.app/mp/collect
- Fallback: existing Cloud Run run.app URL.
- TODOs around restructuring telemetry 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Telemetry now uses a primary proxy with a fallback endpoint instead of direct GA routing.
  * GA-specific routing and prior gating removed; events are sent via the proxy flow.
  * Per-endpoint timeouts (~3–5s) and primary-then-fallback retry behavior; non-2xx results treated as failures.
  * Capture dispatch unified, sent fire-and-forget, and event properties consolidated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->