### PR TITLE
fix(windows): repair PATHEXT in spawned shells + ESM ripgrep wrapper

### DIFF
--- a/scripts/ripgrep-wrapper.js
+++ b/scripts/ripgrep-wrapper.js
@@ -1,13 +1,24 @@
-// Runtime platform detection wrapper for @vscode/ripgrep
-// This replaces the original index.js to support cross-platform MCPB bundles
+// Runtime platform detection wrapper for @vscode/ripgrep.
+// This replaces the package's index.js in MCPB bundles so a single bundle can
+// resolve the correct ripgrep binary at runtime across platforms.
+//
+// IMPORTANT: @vscode/ripgrep 1.18.0+ ships package.json with "type": "module",
+// so this wrapper MUST be ESM. The previous CommonJS version (require /
+// module.exports) threw "require is not defined in ES module scope" the moment
+// the dependency went ESM. That error was swallowed by the resolver's try/catch
+// and surfaced as a misleading "ripgrep binary not found", silently breaking
+// search on Windows even though the bundled binaries were present.
 
-const os = require('os');
-const path = require('path');
-const fs = require('fs');
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 function getTarget() {
   const arch = process.env.npm_config_arch || os.arch();
-  
+
   switch (os.platform()) {
     case 'darwin':
       return arch === 'arm64' ? 'aarch64-apple-darwin' : 'x86_64-apple-darwin';
@@ -32,34 +43,25 @@ const target = getTarget();
 const isWindows = os.platform() === 'win32';
 const binaryName = isWindows ? `rg-${target}.exe` : `rg-${target}`;
 // __dirname is lib/, so go up one level to reach bin/
-const rgPath = path.join(__dirname, '..', 'bin', binaryName);
+let resolvedRgPath = path.join(__dirname, '..', 'bin', binaryName);
 
-// Verify binary exists and ensure executable permissions
-if (!fs.existsSync(rgPath)) {
-  // Try fallback to original rg location
+if (!fs.existsSync(resolvedRgPath)) {
+  // Fallback to a plain rg binary if the platform-specific one is missing
   const fallbackPath = path.join(__dirname, '..', 'bin', isWindows ? 'rg.exe' : 'rg');
-  if (fs.existsSync(fallbackPath)) {
-    // Ensure executable permissions on Unix systems
-    if (!isWindows) {
-      try {
-        fs.chmodSync(fallbackPath, 0o755);
-      } catch (err) {
-        // Ignore permission errors - might not have write access
-      }
-    }
-    module.exports.rgPath = fallbackPath;
-  } else {
-    throw new Error(`ripgrep binary not found for platform ${target}: ${rgPath}`);
+  if (!fs.existsSync(fallbackPath)) {
+    throw new Error(`ripgrep binary not found for platform ${target}: ${resolvedRgPath}`);
   }
-} else {
-  // Ensure executable permissions on Unix systems
-  // This fixes issues when extracting from zip archives that don't preserve permissions
-  if (!isWindows) {
-    try {
-      fs.chmodSync(rgPath, 0o755);
-    } catch (err) {
-      // Ignore permission errors - might not have write access
-    }
-  }
-  module.exports.rgPath = rgPath;
+  resolvedRgPath = fallbackPath;
 }
+
+// Ensure executable permissions on Unix systems.
+// Fixes issues when extracting from zip archives that don't preserve permissions.
+if (!isWindows) {
+  try {
+    fs.chmodSync(resolvedRgPath, 0o755);
+  } catch (err) {
+    // Ignore permission errors - might not have write access
+  }
+}
+
+export const rgPath = resolvedRgPath;

--- a/src/terminal-manager.ts
+++ b/src/terminal-manager.ts
@@ -6,6 +6,35 @@ import { configManager } from './config-manager.js';
 import {capture} from "./utils/capture.js";
 import { analyzeProcessState } from './utils/process-detection.js';
 
+/**
+ * Standard Windows PATHEXT value, used to repair a corrupted PATHEXT before
+ * spawning child shells.
+ *
+ * On some Windows Claude Desktop / DXT launches the server process inherits a
+ * broken PATHEXT (observed as ".CPL" only). Because we build the child env from
+ * { ...process.env }, that broken value would propagate into every spawned
+ * shell, stripping ".EXE" and breaking resolution of git / node / python / rg /
+ * etc. (and even full-path .exe invocations under PowerShell). See issue #481.
+ */
+const STANDARD_PATHEXT = '.COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC';
+
+/**
+ * Return a healthy PATHEXT for spawned Windows shells.
+ * - Unset           -> use the standard list.
+ * - Missing ".EXE"  -> corrupted; merge the standard list with whatever was
+ *                      present (preserves any extra extensions, order-stable).
+ * - Otherwise       -> leave the inherited value untouched.
+ */
+function getRepairedPathExt(): string {
+  const current = process.env.PATHEXT;
+  if (!current) return STANDARD_PATHEXT;
+  const exts = current.split(';').map(e => e.trim().toUpperCase()).filter(Boolean);
+  if (!exts.includes('.EXE')) {
+    return [...new Set([...STANDARD_PATHEXT.split(';'), ...exts])].join(';');
+  }
+  return current;
+}
+
 interface CompletedSession {
   pid: number;
   outputLines: string[];       // Line-based buffer (consistent with active sessions)
@@ -183,6 +212,14 @@ export class TerminalManager {
         },
         windowsHide: true  // Prevent visible console windows on Windows
       };
+    }
+
+    // Repair PATHEXT on Windows before spawning. On some Windows DXT launches
+    // the server process inherits a corrupted PATHEXT (e.g. ".CPL"), which we
+    // would otherwise propagate via { ...process.env } and break command
+    // resolution (git, node, python, rg, ...) in the spawned shell. See #481.
+    if (process.platform === 'win32' && spawnOptions.env) {
+      spawnOptions.env.PATHEXT = getRepairedPathExt();
     }
 
     // Spawn the process with appropriate arguments


### PR DESCRIPTION
## Summary

Two Windows-specific fixes, both surfaced while investigating #481.

Investigates: #481

### 1. Repair corrupted `PATHEXT` before spawning shells (the #481 report)

On some Windows Claude Desktop / DXT launches, the Desktop Commander server
process inherits a **broken `PATHEXT` (observed as `.CPL` only)**. Because
`terminal-manager.ts` builds each child shell's environment from
`{ ...process.env }`, that broken value propagated into every spawned shell,
stripping `.EXE` and breaking resolution of `git` / `node` / `python` / `rg`
(and even full-path `.exe` invocations under PowerShell).

**Findings that refine the original report:**
- **Not ARM64-specific** — reproduced on AMD64/x64 as well. It affects the
  Windows DXT v0.2.41 launch path generally.
- DC's own code never sets `PATHEXT`; the value is inherited from how the DXT
  host launches the server, then faithfully copied to children. Root cause is
  upstream (Claude Desktop's DXT launcher), but DC is the right place to defend
  since it controls the env handed to child shells.

**Fix:** on `win32`, repair `PATHEXT` immediately before `spawn`. If `.EXE` is
missing, merge the standard extension list with whatever was present
(non-destructive when `PATHEXT` is already healthy).

### 2. Make the bundled ripgrep wrapper ESM

`@vscode/ripgrep` 1.18.0+ ships `package.json` with `"type": "module"`. The
MCPB build copies `scripts/ripgrep-wrapper.js` over the package's
`lib/index.js`, but the wrapper was CommonJS (`require` / `module.exports`), so
it threw `require is not defined in ES module scope` on import. That throw was
swallowed by `getRipgrepPath()`'s `try/catch` and surfaced as a misleading
`ripgrep binary not found`, **silently breaking `start_search` on Windows even
though the bundled binaries were present.**

**Fix:** rewrite the wrapper as ESM (`import` + `export const rgPath`,
`__dirname` via `fileURLToPath`). Verified with a fresh Node import against the
deployed extension: `rgPath` resolves to `rg-x86_64-pc-windows-msvc.exe` and the
binary exists.

## Testing

- `tsc --noEmit`: no new type errors from these changes.
- ripgrep wrapper: validated via fresh `import()` against the bundled package on
  Windows x64 — named `rgPath` export resolves and the target binary exists.
- PATHEXT: confirmed the broken `.CPL` value at process level on x64, and that
  restoring `PATHEXT` makes `git`/`node`/etc. resolve again.

## Notes

- Both fixes are Windows-only in effect; non-Windows behavior is unchanged.
- The PATHEXT issue likely also warrants a parallel report to Claude Desktop's
  DXT launcher, but this PR lets DC self-heal without waiting on that.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows shell command resolution issues caused by corrupted inherited environment variables.

* **Improvements**
  * Enhanced ripgrep binary discovery with improved fallback logic for platform-specific binaries and clearer error messages when unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->