### PR TITLE
fix: prune stale Puppeteer Chrome cache

### DIFF
--- a/src/tools/pdf/markdown.ts
+++ b/src/tools/pdf/markdown.ts
@@ -24,10 +24,16 @@ function getPuppeteerCacheDir(): string {
     return join(homedir(), '.cache', 'puppeteer');
 }
 
+/**
+ * Get the cache path where Puppeteer stores Chrome for Testing builds.
+ */
 function getPuppeteerChromeDir(cacheDir = getPuppeteerCacheDir()): string {
     return join(cacheDir, 'chrome');
 }
 
+/**
+ * Find the platform-specific executable within a cached Chrome build directory.
+ */
 function getChromeExecutablePath(chromeDir: string, version: string): string | undefined {
     const chromePath = process.platform === 'win32'
         ? join(chromeDir, version, 'chrome-win64', 'chrome.exe')
@@ -50,6 +56,9 @@ function getChromeExecutablePath(chromeDir: string, version: string): string | u
     return undefined;
 }
 
+/**
+ * Resolve the cached Chrome build directory that owns an executable path.
+ */
 function getCachedChromeBuildDir(chromeDir: string, executablePath: string): string | undefined {
     const relativePath = relative(chromeDir, executablePath);
     if (relativePath === '..' || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath)) {
@@ -91,6 +100,9 @@ export function findPuppeteerChrome(cacheDir = getPuppeteerCacheDir()): CachedPu
     return undefined;
 }
 
+/**
+ * Remove stale Puppeteer Chrome builds while preserving the active build.
+ */
 export async function pruneOldPuppeteerChromeBuilds(activeExecutablePath: string, cacheDir = getPuppeteerCacheDir()): Promise<void> {
     const chromeDir = getPuppeteerChromeDir(cacheDir);
     const activeBuildDir = getCachedChromeBuildDir(chromeDir, activeExecutablePath);

--- a/src/tools/pdf/markdown.ts
+++ b/src/tools/pdf/markdown.ts
@@ -1,7 +1,7 @@
 import fs from 'fs/promises';
-import { existsSync } from 'fs';
+import { existsSync, readdirSync } from 'fs';
 import { homedir } from 'os';
-import { join } from 'path';
+import { isAbsolute, join, relative, resolve, sep } from 'path';
 import { mdToPdf } from 'md-to-pdf';
 import type { PageRange } from './lib/pdf2md.js';
 import { PdfParseResult, pdf2md } from './lib/pdf2md.js';
@@ -13,6 +13,10 @@ const isUrl = (source: string): boolean =>
 let cachedChromePath: string | undefined | null = null; // null = not checked yet
 let chromeCheckPromise: Promise<string | undefined> | null = null;
 
+interface CachedPuppeteerChrome {
+    executablePath: string;
+}
+
 /**
  * Get the puppeteer cache directory
  */
@@ -20,47 +24,101 @@ function getPuppeteerCacheDir(): string {
     return join(homedir(), '.cache', 'puppeteer');
 }
 
+function getPuppeteerChromeDir(cacheDir = getPuppeteerCacheDir()): string {
+    return join(cacheDir, 'chrome');
+}
+
+function getChromeExecutablePath(chromeDir: string, version: string): string | undefined {
+    const chromePath = process.platform === 'win32'
+        ? join(chromeDir, version, 'chrome-win64', 'chrome.exe')
+        : process.platform === 'darwin'
+        ? join(chromeDir, version, 'chrome-mac-x64', 'Google Chrome for Testing.app', 'Contents', 'MacOS', 'Google Chrome for Testing')
+        : join(chromeDir, version, 'chrome-linux64', 'chrome');
+
+    if (existsSync(chromePath)) {
+        return chromePath;
+    }
+
+    // Also check for arm64 mac
+    if (process.platform === 'darwin') {
+        const armPath = join(chromeDir, version, 'chrome-mac-arm64', 'Google Chrome for Testing.app', 'Contents', 'MacOS', 'Google Chrome for Testing');
+        if (existsSync(armPath)) {
+            return armPath;
+        }
+    }
+
+    return undefined;
+}
+
+function getCachedChromeBuildDir(chromeDir: string, executablePath: string): string | undefined {
+    const relativePath = relative(chromeDir, executablePath);
+    if (relativePath === '..' || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath)) {
+        return undefined;
+    }
+
+    const [buildDir] = relativePath.split(sep);
+    return buildDir ? join(chromeDir, buildDir) : undefined;
+}
+
 /**
  * Find Chrome in puppeteer's cache directory
  * Returns the executable path if found, undefined otherwise
  */
-function findPuppeteerChrome(): string | undefined {
-    const cacheDir = getPuppeteerCacheDir();
-    const chromeDir = join(cacheDir, 'chrome');
-    
+export function findPuppeteerChrome(cacheDir = getPuppeteerCacheDir()): CachedPuppeteerChrome | undefined {
+    const chromeDir = getPuppeteerChromeDir(cacheDir);
+
     if (!existsSync(chromeDir)) {
         return undefined;
     }
-    
+
     try {
         // Look for chrome directories (e.g., win64-143.0.7499.169)
-        const { readdirSync } = require('fs');
-        const versions = readdirSync(chromeDir);
+        const versions = readdirSync(chromeDir, { withFileTypes: true })
+            .filter(entry => entry.isDirectory())
+            .map(entry => entry.name)
+            .sort((a, b) => b.localeCompare(a, undefined, { numeric: true }));
         
         for (const version of versions) {
-            const chromePath = process.platform === 'win32'
-                ? join(chromeDir, version, 'chrome-win64', 'chrome.exe')
-                : process.platform === 'darwin'
-                ? join(chromeDir, version, 'chrome-mac-x64', 'Google Chrome for Testing.app', 'Contents', 'MacOS', 'Google Chrome for Testing')
-                : join(chromeDir, version, 'chrome-linux64', 'chrome');
-            
-            if (existsSync(chromePath)) {
-                return chromePath;
-            }
-            
-            // Also check for arm64 mac
-            if (process.platform === 'darwin') {
-                const armPath = join(chromeDir, version, 'chrome-mac-arm64', 'Google Chrome for Testing.app', 'Contents', 'MacOS', 'Google Chrome for Testing');
-                if (existsSync(armPath)) {
-                    return armPath;
-                }
+            const executablePath = getChromeExecutablePath(chromeDir, version);
+            if (executablePath) {
+                return { executablePath };
             }
         }
     } catch {
         // Ignore errors reading cache directory
     }
-    
+
     return undefined;
+}
+
+export async function pruneOldPuppeteerChromeBuilds(activeExecutablePath: string, cacheDir = getPuppeteerCacheDir()): Promise<void> {
+    const chromeDir = getPuppeteerChromeDir(cacheDir);
+    const activeBuildDir = getCachedChromeBuildDir(chromeDir, activeExecutablePath);
+    if (!activeBuildDir) {
+        return;
+    }
+
+    let entries;
+    try {
+        entries = await fs.readdir(chromeDir, { withFileTypes: true });
+    } catch {
+        return;
+    }
+
+    await Promise.all(entries
+        .filter(entry => entry.isDirectory())
+        .map(async entry => {
+            const buildDir = join(chromeDir, entry.name);
+            if (resolve(buildDir) === resolve(activeBuildDir)) {
+                return;
+            }
+
+            try {
+                await fs.rm(buildDir, { recursive: true, force: true });
+            } catch (error) {
+                console.error(`Failed to remove old Chrome cache build at ${buildDir}:`, error);
+            }
+        }));
 }
 
 /**
@@ -98,7 +156,7 @@ function findSystemChrome(): string | undefined {
  * Download and install Chrome using @puppeteer/browsers
  * Returns the executable path after installation
  */
-async function installChrome(): Promise<string> {
+async function installChrome(): Promise<CachedPuppeteerChrome> {
     // Dynamic import to avoid loading if not needed
     const { install, Browser, detectBrowserPlatform, resolveBuildId } = await import('@puppeteer/browsers');
     
@@ -120,7 +178,9 @@ async function installChrome(): Promise<string> {
     
     console.error('\nChrome download complete.');
     
-    return installedBrowser.executablePath;
+    return {
+        executablePath: installedBrowser.executablePath,
+    };
 }
 
 /**
@@ -144,8 +204,9 @@ async function getChromePath(): Promise<string | undefined> {
         // 1. Check puppeteer cache first (exact compatible version)
         const cachedChrome = findPuppeteerChrome();
         if (cachedChrome) {
-            cachedChromePath = cachedChrome;
-            return cachedChrome;
+            await pruneOldPuppeteerChromeBuilds(cachedChrome.executablePath);
+            cachedChromePath = cachedChrome.executablePath;
+            return cachedChrome.executablePath;
         }
         
         // 2. Check system Chrome
@@ -158,8 +219,9 @@ async function getChromePath(): Promise<string | undefined> {
         // 3. Install Chrome as last resort
         try {
             const installedChrome = await installChrome();
-            cachedChromePath = installedChrome;
-            return installedChrome;
+            await pruneOldPuppeteerChromeBuilds(installedChrome.executablePath);
+            cachedChromePath = installedChrome.executablePath;
+            return installedChrome.executablePath;
         } catch (error) {
             console.error('Failed to install Chrome:', error);
             cachedChromePath = undefined;

--- a/src/tools/pdf/markdown.ts
+++ b/src/tools/pdf/markdown.ts
@@ -1,10 +1,10 @@
 import fs from 'fs/promises';
 import { existsSync, readdirSync } from 'fs';
-import { homedir } from 'os';
-import { isAbsolute, join, relative, resolve, sep } from 'path';
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'path';
 import { mdToPdf } from 'md-to-pdf';
 import type { PageRange } from './lib/pdf2md.js';
 import { PdfParseResult, pdf2md } from './lib/pdf2md.js';
+import { CONFIG_FILE } from '../../config.js';
 
 const isUrl = (source: string): boolean =>
     source.startsWith('http://') || source.startsWith('https://');
@@ -18,10 +18,10 @@ interface CachedPuppeteerChrome {
 }
 
 /**
- * Get the puppeteer cache directory
+ * Get Desktop Commander's private Puppeteer cache directory.
  */
 function getPuppeteerCacheDir(): string {
-    return join(homedir(), '.cache', 'puppeteer');
+    return join(dirname(CONFIG_FILE), 'puppeteer-cache');
 }
 
 /**
@@ -177,7 +177,8 @@ async function installChrome(): Promise<CachedPuppeteerChrome> {
     const buildId = await resolveBuildId(Browser.CHROME, platform, 'stable');
     
     console.error('Downloading Chrome for PDF generation (this may take a few minutes)...');
-    
+    await fs.mkdir(cacheDir, { recursive: true });
+
     const installedBrowser = await install({
         browser: Browser.CHROME,
         buildId,

--- a/test/test-pdf-chrome-cache.js
+++ b/test/test-pdf-chrome-cache.js
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+
+/**
+ * Test Chrome for Testing cache pruning used by PDF generation.
+ */
+
+import assert from 'assert';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+import {
+    findPuppeteerChrome,
+    pruneOldPuppeteerChromeBuilds,
+} from '../dist/tools/pdf/markdown.js';
+
+function executablePathForBuild(chromeDir, buildDirName) {
+    if (process.platform === 'win32') {
+        return path.join(chromeDir, buildDirName, 'chrome-win64', 'chrome.exe');
+    }
+
+    if (process.platform === 'darwin') {
+        return path.join(
+            chromeDir,
+            buildDirName,
+            'chrome-mac-arm64',
+            'Google Chrome for Testing.app',
+            'Contents',
+            'MacOS',
+            'Google Chrome for Testing',
+        );
+    }
+
+    return path.join(chromeDir, buildDirName, 'chrome-linux64', 'chrome');
+}
+
+async function createChromeBuild(chromeDir, buildDirName) {
+    const executablePath = executablePathForBuild(chromeDir, buildDirName);
+    await fs.mkdir(path.dirname(executablePath), { recursive: true });
+    await fs.writeFile(executablePath, '');
+    return executablePath;
+}
+
+async function pathExists(filePath) {
+    try {
+        await fs.access(filePath);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+async function main() {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'desktop-commander-chrome-cache-'));
+
+    try {
+        const cacheDir = path.join(tempRoot, 'puppeteer');
+        const chromeDir = path.join(cacheDir, 'chrome');
+        const oldBuildDir = path.join(chromeDir, 'mac_arm-148.0.7778.56');
+        const activeBuildDir = path.join(chromeDir, 'mac_arm-149.0.7827.54');
+
+        const oldExecutablePath = await createChromeBuild(chromeDir, path.basename(oldBuildDir));
+        const activeExecutablePath = await createChromeBuild(chromeDir, path.basename(activeBuildDir));
+
+        const foundChrome = findPuppeteerChrome(cacheDir);
+        assert.strictEqual(
+            foundChrome?.executablePath,
+            activeExecutablePath,
+            'newest cached Chrome build should be selected',
+        );
+
+        await pruneOldPuppeteerChromeBuilds(activeExecutablePath, cacheDir);
+
+        assert.strictEqual(
+            await pathExists(activeExecutablePath),
+            true,
+            'active Chrome executable should remain',
+        );
+        assert.strictEqual(
+            await pathExists(oldExecutablePath),
+            false,
+            'old Chrome executable should be removed',
+        );
+        assert.strictEqual(
+            await pathExists(oldBuildDir),
+            false,
+            'old Chrome build directory should be removed',
+        );
+    } finally {
+        await fs.rm(tempRoot, { recursive: true, force: true });
+    }
+
+    console.log('Chrome cache pruning test passed');
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+    main().catch(error => {
+        console.error(error);
+        process.exit(1);
+    });
+}

--- a/test/test-pdf-chrome-cache.js
+++ b/test/test-pdf-chrome-cache.js
@@ -8,6 +8,7 @@ import assert from 'assert';
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
+import { fileURLToPath } from 'url';
 
 import {
     findPuppeteerChrome,
@@ -93,7 +94,9 @@ async function main() {
     console.log('Chrome cache pruning test passed');
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+const isDirectRun = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+
+if (isDirectRun) {
     main().catch(error => {
         console.error(error);
         process.exit(1);


### PR DESCRIPTION
## Summary
- use a Desktop Commander-owned Puppeteer cache under the config directory instead of the shared `~/.cache/puppeteer` cache
- select the newest usable Chrome for Testing build from that private cache and prune only older builds there
- add a fake-cache regression test that avoids downloads and does not touch the real user cache

Fixes #483.

## Tests
- npm run build
- node test/test-pdf-chrome-cache.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Chrome cache management—automatically removes outdated cached Chrome builds to save disk space while preserving the active version.
  * More reliable Chrome executable detection (including platform-specific variants) and project-tied cache location for steadier PDF generation.

* **Tests**
  * Added tests to verify cache selection and removal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->