### PR TITLE
fix(telemetry): propagate remote flag to per-tool events

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -130,6 +130,23 @@ server.setRequestHandler(ListPromptsRequestSchema, async () => {
 // Store current client info (simple variable)
 let currentClient = { name: 'uninitialized', version: 'uninitialized' };
 
+// Tracks whether the in-flight tool call originated from a remote device.
+// Mirrors the module-level `currentClient` pattern so that telemetry events
+// emitted deeper inside tool handlers (e.g. server_start_process,
+// server_read_file) can be attributed to the remote path. The CallTool
+// handler sets this on every call (true when _meta.remote is present,
+// false otherwise) so the flag never leaks from a remote call to a
+// subsequent local call.
+let currentCallIsRemote = false;
+
+/**
+ * Set whether the current tool call is from a remote device.
+ * Called once per tool call by the CallTool handler.
+ */
+function setCurrentCallIsRemote(isRemote: boolean) {
+    currentCallIsRemote = isRemote;
+}
+
 /**
  * Unified way to update client information
  */
@@ -199,7 +216,7 @@ server.setRequestHandler(InitializeRequestSchema, async (request: InitializeRequ
 });
 
 // Export current client info for access by other modules
-export { currentClient };
+export { currentClient, currentCallIsRemote };
 
 deferLog('info', 'Setting up request handlers...');
 
@@ -1179,6 +1196,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
         const telemetryData: any = { tool_name: name };
         // Extract metadata from _meta field if present
         const metadata = request.params._meta as any;
+        // Reset remote attribution for every call so a prior remote call never
+        // leaks its flag onto a subsequent local call. Set to true only when
+        // this call carries the remote marker in _meta.
+        const isRemoteCall = !!(metadata && typeof metadata === 'object' && metadata.remote);
+        setCurrentCallIsRemote(isRemoteCall);
         if (metadata && typeof metadata === 'object') {
             // add remote flag if present (convert to string for GA4)
             if (metadata.remote) {

--- a/src/utils/capture.ts
+++ b/src/utils/capture.ts
@@ -1,7 +1,7 @@
 import { platform } from 'os';
 import * as https from 'https';
 import { configManager, isTelemetryDisabledValue } from '../config-manager.js';
-import { currentClient } from '../server.js';
+import { currentClient, currentCallIsRemote } from '../server.js';
 
 let VERSION = 'unknown';
 try {
@@ -196,6 +196,10 @@ export const captureBase = async (captureURL: string, event: string, properties?
         const eventProperties = {
             ...baseProperties,
             ...clientContext,
+            // Attribute events to the remote path when the in-flight tool call
+            // came from a remote device. Placed before sanitizedProperties so an
+            // explicit `remote` passed by the caller (e.g. captureRemote) wins.
+            ...(currentCallIsRemote ? { remote: String(true) } : {}),
             ...sanitizedProperties
         };
 
@@ -355,6 +359,10 @@ const buildEventProperties = async (properties?: any) => {
         app_version: VERSION,
         engagement_time_msec: "100",
         ...clientContext,
+        // Attribute events to the remote path when the in-flight tool call
+        // came from a remote device. Placed before sanitizedProperties so an
+        // explicit `remote` passed by the caller (e.g. captureRemote) wins.
+        ...(currentCallIsRemote ? { remote: String(true) } : {}),
         ...sanitizedProperties,
     };
 };


### PR DESCRIPTION
## Problem

Remote tool calls are a telemetry blind spot for **content detail**. We can see *that* a remote user called `start_process` (via `server_call_tool` with `remote=true`), but **not what file types they read/wrote or what commands they ran**.

Investigating BigQuery, every detailed per-tool event — `server_start_process` (carries `command`/`commands`), `server_read_file`/`server_write_file`/`server_edit_block` (carry `fileExtension`/`fileSize`) — is recorded as `remote=not_set`, even for calls that clearly came from a remote device. Confirmed: 0 of these events across late May carry `remote=true`.

## Root cause

In the `CallTool` handler (`server.ts`), `_meta.clientInfo` and `_meta.remote` were handled **asymmetrically**:

- `clientInfo` → persisted to the module-level `currentClient` via `updateCurrentClient()`, which `buildEventProperties` (in `capture.ts`) reads for **every** event. So client attribution "leaks" correctly to all downstream events.
- `remote` → written **only** to the local `telemetryData` object passed to the single `capture_call_tool('server_call_tool', ...)` call. It was never persisted anywhere the tool handlers' own `capture()` calls could see it.

So when `improved-process-tools.ts`, `filesystem.ts`, `edit.ts` etc. fire their detailed `capture('server_start_process', { command, commands })` events, there's no remote context available → `remote=not_set`.

## Fix

Mirror the existing `currentClient` pattern:

1. Add a module-level `currentCallIsRemote` flag + `setCurrentCallIsRemote()` setter in `server.ts`, exported alongside `currentClient`.
2. The `CallTool` handler sets it on **every** call — `true` when `_meta.remote` is present, `false` otherwise. The explicit reset-to-false guard prevents a remote call from leaking its flag onto a subsequent local call.
3. `buildEventProperties` (proxy/BigQuery path) and `captureBase` (legacy GA4 path) both stamp `remote: "true"` onto every event when `currentCallIsRemote` is set. Placed before the caller's `sanitizedProperties` spread so an explicit `remote` (e.g. from `captureRemote`) still wins.

After this lands, `server_start_process` / `server_read_file` / etc. from remote clients will carry `remote=true`, giving us file-type and command visibility for remote usage at parity with local.

## Notes / caveat for reviewers

- This relies on ES module live bindings — the same mechanism `currentClient` already uses (it's reassigned in `updateCurrentClient` and read live by `capture.ts`). The circular import `capture.ts` ↔ `server.ts` already exists for `currentClient`; this adds nothing new.
- **Known limitation (pre-existing):** like `currentClient`, this is module-level mutable state, so it assumes one logical call in flight at a time. If local and remote calls interleave concurrently, attribution could be momentarily wrong. The fully-correct solution is request-scoped context (`AsyncLocalStorage`), but that's a larger refactor; this change reaches parity with the existing accepted behavior and fixes the vast majority of real cases (users typically run one client at a time).

## Testing

- `npx tsc --noEmit` — clean (exit 0)
- `npm run build` — succeeds; verified `currentCallIsRemote` present in compiled `dist/server.js` and `dist/utils/capture.js`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced telemetry capabilities to differentiate and track tool calls originating from remote versus local devices, enabling better diagnostics and usage insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->