### PR TITLE
chore(plugins): add Claude display name

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,6 +11,7 @@
   "plugins": [
     {
       "name": "desktop-commander",
+      "displayName": "Desktop Commander",
       "source": "./plugins/claude",
       "description": "MCP server for terminal commands, process management, and file operations across text, code, PDF, DOCX, Excel, images, and structured data"
     }

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "desktop-commander",
+  "displayName": "Desktop Commander",
   "description": "MCP server for terminal commands, process management, and file operations across text, code, PDF, DOCX, Excel, images, and structured data",
   "author": {
     "name": "Desktop Commander",


### PR DESCRIPTION
Adding CC plugin displayname for better visibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin configuration to include display name metadata for the Desktop Commander plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->