### PR TITLE
fix(read_file): return image bytes in MCP content so the model can see images

### DIFF
--- a/src/handlers/filesystem-handlers.ts
+++ b/src/handlers/filesystem-handlers.ts
@@ -147,8 +147,9 @@ export async function handleReadFile(args: unknown): Promise<ServerResult> {
 
         // Handle image files
         if (fileResult.metadata?.isImage) {
-            // For image files, keep content payload text-only for broad host compatibility.
-            // The preview widget reads image bytes from structuredContent.
+            // Return the image bytes in the MCP content array so the host model can
+            // actually see the image. structuredContent additionally carries the bytes
+            // for the preview widget to render.
             const imageData = typeof fileResult.content === 'string'
                 ? fileResult.content
                 : fileResult.content.toString('base64');
@@ -158,6 +159,11 @@ export async function handleReadFile(args: unknown): Promise<ServerResult> {
                     {
                         type: "text",
                         text: imageSummary
+                    },
+                    {
+                        type: "image",
+                        data: imageData,
+                        mimeType: fileResult.mimeType
                     }
                 ],
                 structuredContent: {


### PR DESCRIPTION
## Problem

`read_file` on an image returned the image bytes **only** in `structuredContent` (consumed by the preview widget) and sent the host model a text-only summary like `Image file: ... (image/png)`.

The model received no image content block, so reading an image was effectively a no-op for the model — it could never actually see the image. The previous code comment described this as "text-only for broad host compatibility," but it blinded every host that *can* handle images, which is the common case.

## Fix

Add the image content block back into the MCP `content` array (text summary + `type: "image"` block), while leaving `structuredContent` unchanged so the preview widget keeps rendering as before.

Result:
- the host model receives the image and can analyze it
- the preview widget still renders from `structuredContent`

## Testing

- `npm run build` clean
- Verified live: after rebuild + MCP restart, `read_file` on a PNG now returns the image to the model (previously only the text summary came back).

## Notes

This is scoped to the image branch of `handleReadFile`. The separate `edit_block` freeze (DOCX) is being investigated independently and is not part of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image file responses now include renderable image content with base64-encoded data and MIME type information, enabling direct image display alongside text summaries and preview widgets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->