### PR TITLE
feat(telemetry): send tool-call duration_ms with server_call_tool

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1190,11 +1190,14 @@ import { ServerResult } from './types.js';
 server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest): Promise<ServerResult> => {
     const { name, arguments: args } = request.params;
     const startTime = Date.now();
+    // Hoisted above the try so the finally block can read them when emitting the
+    // server_call_tool completion event (duration + status), even on the crash path.
+    let telemetryData: any = { tool_name: name };
+    let result: ServerResult;
+    let isError = false;
 
     try {
-        // Prepare telemetry data - add config key for set_config_value
-        const telemetryData: any = { tool_name: name };
-        // Extract metadata from _meta field if present
+        // telemetryData declared above; extract metadata from _meta field if present
         const metadata = request.params._meta as any;
         // Reset remote attribution for every call so a prior remote call never
         // leaks its flag onto a subsequent local call. Set to true only when
@@ -1231,13 +1234,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
             }
         }
 
-        capture_call_tool('server_call_tool', telemetryData);
-
         // Track tool call
         trackToolCall(name, args);
 
         // Using a more structured approach with dedicated handlers
-        let result: ServerResult;
+        // (result is declared above so the finally block can read execution status)
 
         switch (name) {
             // Config tools
@@ -1453,6 +1454,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
 
         // Add tool call to history (exclude only get_recent_tool_calls to prevent recursion)
         const duration = Date.now() - startTime;
+        isError = !!result.isError;
         const EXCLUDED_TOOLS = [
             'get_recent_tool_calls',
             'track_ui_event'
@@ -1557,6 +1559,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
 
         return result;
     } catch (error) {
+        isError = true;
         const errorMessage = error instanceof Error ? error.message : String(error);
 
         // Track the failure
@@ -1569,6 +1572,15 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
             content: [{ type: "text", text: `Error: ${errorMessage}` }],
             isError: true,
         };
+    } finally {
+        // Single tool-call telemetry event, fired AFTER execution so it can carry
+        // timing. In a finally so it still fires on the hard-crash path (the catch
+        // above). Only missed if a tool never returns or throws (a true hang).
+        capture_call_tool('server_call_tool', {
+            ...telemetryData,
+            duration_ms: Date.now() - startTime,
+            is_error: String(isError),
+        });
     }
 });
 


### PR DESCRIPTION
## What

Makes per-tool-call latency observable in telemetry so we can detect MCP performance regressions/improvements across versions and clients.

Previously `server_call_tool` was fired *before* the handler ran, so it could never carry timing. Duration was computed after execution but only fed into the local in-memory `toolHistory` (surfaced via `get_recent_tool_calls`) and never sent anywhere.

## Change

Moves the single `server_call_tool` capture from before the `switch` into a `finally` block at the end of the `CallToolRequestSchema` handler, enriched with two new fields:

- `duration_ms` — `Date.now() - startTime`
- `is_error` — sent as a string (consistent with how `remote` is sent)

To make this possible, `telemetryData`, `result`, and a new `isError` flag are hoisted above the `try` so the `finally` can read them. `isError` is taken from `result.isError` on the normal path and set to `true` in the catch.

**No new event, no volume change** — just two new params on the existing `server_call_tool`.

## Why `finally`

It fires on all exit paths: success, handled-error (`isError` result), and hard crash (the top-level catch). The event is only missed if a tool never returns *and* never throws — a true hang. That's an accepted, known limitation (and the price of not adding a second start-fired event).

Local `toolHistory` duration tracking is unchanged.

## Testing

- `npm run build` — clean, no TS errors
- `test-telemetry-handling.js`, `test-ui-event-tracking.js` — pass
- Full suite: 39/40. The single failure (`test-file-handlers.js` Test 9, `read_file` image-content host compatibility) reproduces on clean `origin/main` and is unrelated to this change.

## Follow-up for reviewer

Once this is collecting, we can build BigQuery views on `mcp.merged` for p50/p95 `duration_ms` per `tool_name` per `app_version` to watch for regressions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal telemetry event handling to ensure reliable tracking across all execution paths, including error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->