### PR TITLE
test: align read_file image-content assertions with #488

### DIFF
--- a/test/test-file-handlers.js
+++ b/test/test-file-handlers.js
@@ -327,7 +327,10 @@ async function testReadFilePreviewMetadata() {
 
   const imageResult = await handleReadFile({ path: IMAGE_FILE });
   assert.ok(Array.isArray(imageResult.content), 'Image result should include content array');
-  assert.ok(!imageResult.content.some((item) => item.type === 'image'), 'Image result should avoid image content item for host compatibility');
+  const imageContentItem = imageResult.content.find((item) => item.type === 'image');
+  assert.ok(imageContentItem, 'Image result should include an image content item so the host model can see the image');
+  assert.strictEqual(imageContentItem.mimeType, 'image/png', 'Image content item should carry the png mimeType');
+  assert.ok(typeof imageContentItem.data === 'string' && imageContentItem.data.length > 0, 'Image content item should carry non-empty base64 data');
   assert.ok(imageResult.structuredContent, 'Image should include structuredContent');
   assert.strictEqual(imageResult.structuredContent.fileType, 'image', 'Image fileType should map to image preview state');
   assert.strictEqual(typeof imageResult.structuredContent.imageData, 'string', 'Image structured payload should include imageData');
@@ -339,7 +342,10 @@ async function testReadFilePreviewMetadata() {
 
   const svgResult = await handleReadFile({ path: SVG_FILE });
   assert.ok(Array.isArray(svgResult.content), 'SVG result should include content array');
-  assert.ok(!svgResult.content.some((item) => item.type === 'image'), 'SVG result should avoid image content item for host compatibility');
+  const svgContentItem = svgResult.content.find((item) => item.type === 'image');
+  assert.ok(svgContentItem, 'SVG result should include an image content item so the host model can see the image');
+  assert.strictEqual(svgContentItem.mimeType, 'image/svg+xml', 'SVG content item should carry the svg mimeType');
+  assert.ok(typeof svgContentItem.data === 'string' && svgContentItem.data.length > 0, 'SVG content item should carry non-empty base64 data');
   assert.ok(svgResult.structuredContent, 'SVG should include structuredContent');
   assert.strictEqual(svgResult.structuredContent.fileType, 'image', 'SVG should map to image preview state');
   assert.strictEqual(svgResult.structuredContent.mimeType, 'image/svg+xml', 'SVG structured payload should include SVG mimeType');


### PR DESCRIPTION
## What

Fixes the only failing test in the suite (`test/test-file-handlers.js`, Test 9).

## Why

[#488](https://github.com/wonderwhy-er/DesktopCommanderMCP/pull/488) intentionally added the image bytes back into `read_file`'s MCP `content` array so the host model can actually see images. The test was never updated and still asserted the **pre-#488** contract:

```js
assert.ok(!imageResult.content.some(item => item.type === 'image'),
  'Image result should avoid image content item for host compatibility');
```

That assertion is now inverted from shipped behaviour, so the suite went red (39/40). This is a stale test, not a regression.

## Change

Test 9 now asserts the current contract for both raster (PNG) and SVG reads: the `content` array includes an `image` item carrying non-empty base64 `data` and the correct `mimeType` (`image/png`, `image/svg+xml`), alongside the existing `structuredContent` checks (which were already correct).

**No production code changes** — handler behaviour is unchanged.

## Note / open question

`.svg` is routed through `ImageFileHandler` (`isImage: true`), so `read_file` on an SVG emits an MCP `image` content block with `mimeType: image/svg+xml`. Not every host renders SVG image blocks, and SVG is also readable as text. This PR matches the **current** handler behaviour; if SVG should fall through to the text branch instead, that's a handler-side decision and a separate change.

## Test

```
node test/test-file-handlers.js  →  ✅ all 10 tests pass (exit 0)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced image preview metadata validation for PNG and SVG files to ensure proper MIME type information and encoded image data are captured correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->