### PR TITLE
fix(windows): preserve quotes in cmd commands (start_process)

### DIFF
--- a/src/terminal-manager.ts
+++ b/src/terminal-manager.ts
@@ -62,6 +62,9 @@ interface ShellSpawnConfig {
   executable: string;
   args: string[];
   useShellOption: string | boolean;
+  // When true, pass args verbatim on Windows (see executeCommand). Only cmd.exe
+  // needs this; its quote parsing conflicts with libuv's default \" escaping.
+  windowsVerbatim?: boolean;
 }
 
 /**
@@ -103,6 +106,7 @@ function getShellSpawnArgs(shellPath: string, command: string): ShellSpawnConfig
     return { 
       executable: shellPath, 
       args: ['/c', command],
+      windowsVerbatim: true,
       useShellOption: false 
     };
   }
@@ -220,6 +224,17 @@ export class TerminalManager {
     // resolution (git, node, python, rg, ...) in the spawned shell. See #481.
     if (process.platform === 'win32' && spawnOptions.env) {
       spawnOptions.env.PATHEXT = getRepairedPathExt();
+    }
+
+    // On Windows, when we invoke cmd.exe directly and pass the user's command as a
+    // single argument, Node/libuv applies MSVCRT-style quoting that escapes embedded
+    // double quotes as \" . cmd.exe does not understand that escaping, so any command
+    // containing quotes (e.g. a quoted path with spaces like "C:\Program Files\app.exe")
+    // is corrupted before the shell ever parses it. Passing arguments verbatim lets
+    // cmd handle its own quoting. Scoped to shells that set windowsVerbatim (cmd only)
+    // because PowerShell/pwsh have different quote rules and must NOT use verbatim.
+    if (process.platform === 'win32' && spawnConfig.windowsVerbatim) {
+      spawnOptions.windowsVerbatimArguments = true;
     }
 
     // Spawn the process with appropriate arguments


### PR DESCRIPTION
## Problem

On Windows, `start_process` corrupts any command containing double quotes when the shell is **cmd**. Examples that fail today:

- `dir "C:\Program Files\Mozilla Firefox\firefox.exe"` -> *The filename, directory name, or volume label syntax is incorrect.*
- `tasklist /fi "imagename eq firefox.exe"` -> *ERROR: Invalid argument/option - 'eq'.*
- `start "" "C:\Program Files\Mozilla Firefox\firefox.exe"` -> silently fails to launch

Minimal repro:

```
echo "hello world" a"b"c
# got:  \"hello world\" a\"b\"c
```

## Root cause

In `terminal-manager.ts`, the cmd branch of `getShellSpawnArgs` returns `{ executable: 'cmd', args: ['/c', command], useShellOption: false }`, and `executeCommand` calls `spawn(executable, args, opts)` **without** `shell: true`. Node/libuv then builds the Windows command line using MSVCRT-style quoting, escaping embedded `"` as `\"`. `cmd.exe` does not treat `\"` as an escape, so the quotes reach cmd mangled and the command breaks. (Node only disables this escaping automatically when `shell: true` is used, which DC deliberately avoids so it can control login flags.)

## Fix

Set `windowsVerbatimArguments = true` for the cmd branch, so cmd parses its own quoting -- exactly what Node does internally for `shell: true`.

Scoped to cmd only via a new `ShellSpawnConfig.windowsVerbatim` flag:

- **cmd** -> verbatim on (fixed)
- **PowerShell / pwsh** -> unchanged. Verbatim is wrong for them: it splits a quoted argument like `"hello world"` into separate tokens. They keep their existing behaviour.
- **bash / zsh / fish (incl. WSL)** -> unaffected; `windowsVerbatimArguments` is a no-op outside win32, and these already pass the command as a clean `-c` argument.
- **macOS / Linux** -> no behaviour change at all (guarded by `process.platform === 'win32'`).

## Testing

Verified on a live local build (Windows 11, Node 24, cmd default shell):

| Command (cmd) | Before | After |
|---|---|---|
| `echo "hello world" a"b"c` | `\"hello world\" a\"b\"c` | `"hello world" a"b"c` |
| `dir "C:\Program Files\Mozilla Firefox\firefox.exe"` | syntax error | lists the file |
| `tasklist /fi "imagename eq explorer.exe"` | `Invalid argument 'eq'` | works |
| `start "" "C:\Program Files\Mozilla Firefox\firefox.exe"` | nothing | Firefox launches |

PowerShell re-checked after scoping: `echo "hello world"` returns `hello world` on a single line (correct), confirming no regression.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced command execution handling on Windows systems to improve reliability and compatibility with the Windows command environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->