### PR TITLE
fix(list_directory): include listing in structuredContent

### DIFF
--- a/src/handlers/filesystem-handlers.ts
+++ b/src/handlers/filesystem-handlers.ts
@@ -361,6 +361,11 @@ export async function handleListDirectory(args: unknown): Promise<ServerResult> 
                 fileName: path.basename(resolvedPath),
                 filePath: resolvedPath,
                 fileType: 'directory' as const,
+                sourceTool: 'list_directory',
+                // Carry the listing in structuredContent too. Chat reads the text
+                // content array, but structuredContent-only consumers (e.g. Cowork)
+                // render from here and would otherwise show an empty directory.
+                content: resultText,
             },
         };
     } catch (error) {


### PR DESCRIPTION
## What

`list_directory` now includes the directory listing in `structuredContent` (a `content` field plus `sourceTool: 'list_directory'`), matching the `read_file` convention.

## Why

`handleListDirectory` returned the `[DIR]`/`[FILE]` listing only in the text `content` array. Its `structuredContent` was just:

```ts
{ fileName, filePath, fileType: 'directory' }
```

— no entries, no listing text. Clients that render from the **text content** (the in-chat file-preview widget, which parses `[DIR]`/`[FILE]` lines) worked fine. But clients that render from **`structuredContent`** — e.g. **Cowork** — received a directory object with nothing inside and showed "directory empty."

Confirmed by comparing the same call across clients:

- Chat → full `[DIR]`/`[FILE]` listing
- Cowork → `{"fileName":"eduardsruzga","filePath":"/Users/eduardsruzga","fileType":"directory"}`

## Fix

```ts
structuredContent: {
    fileName, filePath,
    fileType: 'directory',
    sourceTool: 'list_directory',
    content: resultText,   // the listing
}
```

Every `read_file` path already carries `content` in `structuredContent`; `list_directory` was the outlier. This aligns it.

## Impact

- Model-facing `content` array: **unchanged**.
- Chat preview widget: **unchanged** (still parses the same text).
- structuredContent-only consumers (Cowork): now receive the listing → render correctly.

## Notes

- A sibling report (image previews never resolving in Cowork) is **not** addressed here — image `structuredContent` already carries `content`/`imageData`/`mimeType`, so that's a separate failure (likely the preview rehydration path) tracked separately.
- Follow-up worth adding: a regression test asserting `list_directory` `structuredContent.content` is populated — the existing `test-file-preview-directory-runtime.js` exercised the text-content path and didn't catch this.

## Test

`npm run build` clean; verified the handler emits `structuredContent.content` with the listing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved data consistency by ensuring directory listings are included in structured content responses alongside standard content output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->