### PR TITLE
Add npm repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "license": "MIT",
   "author": "Eduards Ruzga",
   "homepage": "https://github.com/wonderwhy-er/DesktopCommanderMCP",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wonderwhy-er/DesktopCommanderMCP.git"
+  },
   "bugs": "https://github.com/wonderwhy-er/DesktopCommanderMCP/issues",
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

- add standard npm `repository` metadata pointing to this GitHub repo

## Why

The published `@wonderwhy-er/desktop-commander@0.2.42` package exposes `homepage` and `bugs`, while npm metadata currently omits `repository`. Adding the standard repository field improves package discoverability and lets npm users and tooling trace the package back to its source repo directly.

## Verification

- `node -e "const p=require('./package.json'); if(!p.repository?.url) process.exit(1); console.log(p.repository.url); console.log(p.bugs);"`
- `npm pack --dry-run --ignore-scripts`
- `git diff --check`

This is a package metadata-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository metadata in package configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->