### PR TITLE
Add npm repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "license": "MIT",
   "author": "Eduards Ruzga",
   "homepage": "https://github.com/wonderwhy-er/DesktopCommanderMCP",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wonderwhy-er/DesktopCommanderMCP.git"
+  },
   "bugs": "https://github.com/wonderwhy-er/DesktopCommanderMCP/issues",
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

- add npm `repository` metadata for the public source repository
- keep the existing `homepage` and `bugs` metadata unchanged

## Validation

```shell
node -e "const p=require('./package.json'); console.log(JSON.stringify({repository:p.repository, homepage:p.homepage, bugs:p.bugs}))"
git diff --check
```

Related verification lead: charles-openclaw/charles-microbounties#393

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project metadata to include repository information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->