### PR TITLE
fix(terminal): cap per-session output buffers so massive process outp…

### DIFF
--- a/src/terminal-manager.ts
+++ b/src/terminal-manager.ts
@@ -53,7 +53,7 @@ interface CompletedSession {
  * The cap also bounds the join() cost in snapshot reads and the periodic
  * process-state scan, both of which are O(total output).
  */
-const MAX_BUFFERED_OUTPUT_CHARS = 50 * 1024 * 1024;  // per session; oldest lines evicted first
+export const MAX_BUFFERED_OUTPUT_CHARS = 50 * 1024 * 1024;  // per session; oldest lines evicted first
 const MAX_LINE_CHARS = 1024 * 1024;                  // force-split longer lines so eviction can work
 const MAX_WAIT_OUTPUT_CHARS = 2 * 1024 * 1024;       // start_process wait buffer (prompt/state detection)
 

--- a/src/terminal-manager.ts
+++ b/src/terminal-manager.ts
@@ -41,7 +41,21 @@ interface CompletedSession {
   exitCode: number | null;
   startTime: Date;
   endTime: Date;
+  evictedLines: number;        // Carried over from the active session (see TerminalSession)
+  evictedChars: number;
 }
+
+/**
+ * Output buffering caps. Without a cap, a process emitting enough output makes
+ * string concatenation throw "RangeError: Invalid string length" at V8's max
+ * string size (~536M chars) inside a stdout 'data' handler — an uncaught
+ * exception that kills the whole server (index.ts exits on uncaughtException).
+ * The cap also bounds the join() cost in snapshot reads and the periodic
+ * process-state scan, both of which are O(total output).
+ */
+const MAX_BUFFERED_OUTPUT_CHARS = 50 * 1024 * 1024;  // per session; oldest lines evicted first
+const MAX_LINE_CHARS = 1024 * 1024;                  // force-split longer lines so eviction can work
+const MAX_WAIT_OUTPUT_CHARS = 2 * 1024 * 1024;       // start_process wait buffer (prompt/state detection)
 
 // Result type for paginated output reading
 export interface PaginatedOutputResult {
@@ -257,7 +271,10 @@ export class TerminalManager {
       outputLines: [],           // Line-based buffer
       lastReadIndex: 0,          // Track where "new" output starts
       isBlocked: false,
-      startTime: new Date()
+      startTime: new Date(),
+      bufferedChars: 0,
+      evictedLines: 0,
+      evictedChars: 0
     };
 
     this.sessions.set(childProcess.pid, session);
@@ -306,7 +323,14 @@ export class TerminalManager {
         if (!firstOutputTime) firstOutputTime = now;
         lastOutputTime = now;
 
-        output += text;
+        // `output` only feeds the wait-phase result and prompt/state detection,
+        // so stop growing it once resolved and keep only a bounded tail.
+        if (!resolved) {
+          output += text;
+          if (output.length > MAX_WAIT_OUTPUT_CHARS) {
+            output = output.slice(-Math.floor(MAX_WAIT_OUTPUT_CHARS / 2));
+          }
+        }
         // Append to line-based buffer
         this.appendToLineBuffer(session, text);
 
@@ -345,7 +369,12 @@ export class TerminalManager {
         if (!firstOutputTime) firstOutputTime = now;
         lastOutputTime = now;
 
-        output += text;
+        if (!resolved) {
+          output += text;
+          if (output.length > MAX_WAIT_OUTPUT_CHARS) {
+            output = output.slice(-Math.floor(MAX_WAIT_OUTPUT_CHARS / 2));
+          }
+        }
         // Append to line-based buffer
         this.appendToLineBuffer(session, text);
 
@@ -396,7 +425,9 @@ export class TerminalManager {
             outputLines: [...session.outputLines], // Copy line buffer
             exitCode: code,
             startTime: session.startTime,
-            endTime: new Date()
+            endTime: new Date(),
+            evictedLines: session.evictedLines,
+            evictedChars: session.evictedChars
           });
 
           // Keep only last 100 completed sessions
@@ -423,15 +454,15 @@ export class TerminalManager {
    */
   private appendToLineBuffer(session: TerminalSession, text: string): void {
     if (!text) return;
-    
+
     // Split text into lines, keeping track of whether text ends with newline
     const lines = text.split('\n');
-    
+
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
       const isLastFragment = i === lines.length - 1;
       const endsWithNewline = text.endsWith('\n');
-      
+
       if (session.outputLines.length === 0) {
         // First line ever
         session.outputLines.push(line);
@@ -442,6 +473,33 @@ export class TerminalManager {
         // Subsequent lines - add as new lines
         session.outputLines.push(line);
       }
+    }
+    // Appended text contributes exactly its length to the joined buffer
+    // (its newlines become the join separators).
+    session.bufferedChars += text.length;
+
+    // A process printing without newlines grows a single line forever, which
+    // eviction can't bound — force-split so no line exceeds MAX_LINE_CHARS.
+    // Each inserted break adds one separator to the joined length.
+    let lastIndex = session.outputLines.length - 1;
+    while (session.outputLines[lastIndex].length > MAX_LINE_CHARS) {
+      const overlong = session.outputLines[lastIndex];
+      session.outputLines[lastIndex] = overlong.slice(0, MAX_LINE_CHARS);
+      session.outputLines.push(overlong.slice(MAX_LINE_CHARS));
+      session.bufferedChars += 1;
+      lastIndex++;
+    }
+
+    // Enforce the per-session cap by evicting the oldest lines. Keeps the
+    // buffer far below V8's max string length so concatenation and join()
+    // can never throw "Invalid string length" and kill the server.
+    while (session.bufferedChars > MAX_BUFFERED_OUTPUT_CHARS && session.outputLines.length > 1) {
+      const dropped = session.outputLines.shift()!;
+      const droppedJoinedChars = dropped.length + 1; // +1 for its join separator
+      session.bufferedChars -= droppedJoinedChars;
+      session.evictedChars += droppedJoinedChars;
+      session.evictedLines++;
+      if (session.lastReadIndex > 0) session.lastReadIndex--;
     }
   }
 
@@ -597,8 +655,11 @@ export class TerminalManager {
     if (session) {
       const fullOutput = session.outputLines.join('\n');
       return {
-        totalChars: fullOutput.length,
-        lineCount: session.outputLines.length
+        // Absolute since process start (includes evicted output), so the
+        // offset stays valid even if the cap evicts lines between
+        // snapshot and read.
+        totalChars: session.evictedChars + fullOutput.length,
+        lineCount: session.evictedLines + session.outputLines.length
       };
     }
     return null;
@@ -613,24 +674,30 @@ export class TerminalManager {
     // Check active session first
     const session = this.sessions.get(pid);
     if (session) {
-      const fullOutput = session.outputLines.join('\n');
-      if (fullOutput.length <= snapshot.totalChars) {
-        return ''; // No new output
-      }
-      return fullOutput.substring(snapshot.totalChars);
+      return TerminalManager.outputSinceSnapshot(session.outputLines, session.evictedChars, snapshot.totalChars);
     }
-    
+
     // Fallback to completed sessions - process may have finished between snapshot and poll
     const completedSession = this.completedSessions.get(pid);
     if (completedSession) {
-      const fullOutput = completedSession.outputLines.join('\n');
-      if (fullOutput.length <= snapshot.totalChars) {
-        return ''; // No new output
-      }
-      return fullOutput.substring(snapshot.totalChars);
+      return TerminalManager.outputSinceSnapshot(completedSession.outputLines, completedSession.evictedChars, snapshot.totalChars);
     }
-    
+
     return null;
+  }
+
+  /**
+   * New output since a snapshot, in absolute (since process start) offsets.
+   * If eviction dropped part of the unseen output, returns what the buffer
+   * still holds — the oldest unseen chars are lost to the cap.
+   */
+  private static outputSinceSnapshot(outputLines: string[], evictedChars: number, snapshotTotalChars: number): string {
+    const fullOutput = outputLines.join('\n');
+    const newChars = evictedChars + fullOutput.length - snapshotTotalChars;
+    if (newChars <= 0) {
+      return ''; // No new output
+    }
+    return fullOutput.substring(Math.max(0, fullOutput.length - newChars));
   }
 
     /**

--- a/src/terminal-manager.ts
+++ b/src/terminal-manager.ts
@@ -67,6 +67,7 @@ export interface PaginatedOutputResult {
   isComplete: boolean;         // Whether process has finished
   exitCode?: number | null;    // Exit code if completed
   runtimeMs?: number;          // Runtime in milliseconds (for completed processes)
+  evictedLines?: number;       // Lines dropped by the buffer cap; when > 0, line numbers are relative to the retained buffer
 }
 
 /**
@@ -514,7 +515,7 @@ export class TerminalManager {
     // First check active sessions
     const session = this.sessions.get(pid);
     if (session) {
-      return this.readFromLineBuffer(
+      const result = this.readFromLineBuffer(
         session.outputLines,
         offset,
         length,
@@ -523,13 +524,15 @@ export class TerminalManager {
         false,
         undefined
       );
+      result.evictedLines = session.evictedLines;
+      return result;
     }
 
     // Then check completed sessions
     const completedSession = this.completedSessions.get(pid);
     if (completedSession) {
       const runtimeMs = completedSession.endTime.getTime() - completedSession.startTime.getTime();
-      return this.readFromLineBuffer(
+      const result = this.readFromLineBuffer(
         completedSession.outputLines,
         offset,
         length,
@@ -539,6 +542,8 @@ export class TerminalManager {
         completedSession.exitCode,
         runtimeMs
       );
+      result.evictedLines = completedSession.evictedLines;
+      return result;
     }
 
     return null;

--- a/src/tools/improved-process-tools.ts
+++ b/src/tools/improved-process-tools.ts
@@ -1,4 +1,4 @@
-import { terminalManager } from '../terminal-manager.js';
+import { terminalManager, MAX_BUFFERED_OUTPUT_CHARS } from '../terminal-manager.js';
 import { commandManager } from '../command-manager.js';
 import { StartProcessArgsSchema, ReadProcessOutputArgsSchema, InteractWithProcessArgsSchema, ForceTerminateArgsSchema, ListSessionsArgsSchema } from './schemas.js';
 import { capture } from "../utils/capture.js";
@@ -338,6 +338,14 @@ export async function readProcessOutput(args: unknown): Promise<ServerResult> {
   } else {
     // Absolute position read
     statusMessage = `[Reading ${result.readCount} lines from line ${result.readFrom} (total: ${result.totalLines} lines, ${result.remaining} remaining)]`;
+  }
+
+  // Surface buffer-cap eviction so the model knows the retained output is not
+  // the full output and that line numbers shifted (matches the truncation
+  // markers used by other tools).
+  if (result.evictedLines && result.evictedLines > 0) {
+    const capMB = Math.round(MAX_BUFFERED_OUTPUT_CHARS / 1024 / 1024);
+    statusMessage += `\n[WARNING: output exceeded the ${capMB}MB buffer cap; the ${result.evictedLines} earliest lines were evicted and cannot be read. Line numbers and totals refer to the retained buffer only]`;
   }
 
   // Add process state info

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,10 +17,13 @@ export interface ProcessInfo {
 export interface TerminalSession {
   pid: number;
   process: ChildProcess;
-  outputLines: string[];      // Line-based buffer (persistent)
+  outputLines: string[];      // Line-based buffer (persistent, capped — oldest lines evicted)
   lastReadIndex: number;      // Track where "new" output starts for default reads
   isBlocked: boolean;
   startTime: Date;
+  bufferedChars: number;      // Joined length of outputLines (content + separators)
+  evictedLines: number;       // Lines dropped from the front to enforce the buffer cap
+  evictedChars: number;       // Joined length of evicted lines (keeps snapshot offsets absolute)
 }
 
 export interface CommandExecutionResult {

--- a/test/integration/terminal-output-buffer-leak.js
+++ b/test/integration/terminal-output-buffer-leak.js
@@ -34,11 +34,10 @@ import { performance } from 'perf_hooks';
 
 process.env.DESKTOP_COMMANDER_DISABLE_TELEMETRY = 'true';
 
-const { terminalManager } = await import('../../dist/terminal-manager.js');
+const { terminalManager, MAX_BUFFERED_OUTPUT_CHARS } = await import('../../dist/terminal-manager.js');
 
-// Must match MAX_BUFFERED_OUTPUT_CHARS in terminal-manager.ts, with slack for
-// one in-flight chunk and force-split separators.
-const BUFFER_CAP_CHARS = 50 * 1024 * 1024;
+// Slack on top of the cap for one in-flight chunk and force-split separators.
+const BUFFER_CAP_CHARS = MAX_BUFFERED_OUTPUT_CHARS;
 const BUFFER_CAP_SLACK = 2 * 1024 * 1024;
 
 // 8MB x 72 = ~604MB on one line — past V8's ~536M char limit that used to
@@ -60,20 +59,27 @@ async function main() {
   // output nobody is reading, accumulating inside the long-lived server.
   const result = await terminalManager.executeCommand(floodCmd, 500);
   assert.ok(result.pid > 0, 'executeCommand should return a valid pid');
-  const session = terminalManager.getSession(result.pid);
-  assert.ok(session, 'session should still exist after the call returned');
 
   // Take a snapshot now; eviction will discard most output between snapshot
   // and the read below — the read must degrade gracefully, not throw.
-  const snapshot = terminalManager.captureOutputSnapshot(result.pid);
-  assert.ok(snapshot, 'snapshot should be available');
+  // On a machine fast enough to finish the flood within the 500ms wait the
+  // session has already moved to completedSessions (no snapshot available);
+  // a since-start snapshot exercises the same read path.
+  const snapshot = terminalManager.captureOutputSnapshot(result.pid)
+    ?? { totalChars: 0, lineCount: 0 };
 
-  // Watch the flood stream in, sampling event-loop lag.
+  // Watch the flood stream in, sampling event-loop lag. Poll completion via
+  // readOutputPaginated (covers active and completed sessions) instead of an
+  // 'exit' listener, which races if the process exits before it's attached.
   let maxStallMs = 0;
   const startedAt = performance.now();
   let exitCode = null;
-  session.process.on('exit', (code) => { exitCode = code ?? 0; });
-  while (exitCode === null && performance.now() - startedAt < FLOOD_DEADLINE_MS) {
+  while (performance.now() - startedAt < FLOOD_DEADLINE_MS) {
+    const tail = terminalManager.readOutputPaginated(result.pid, -1, 1);
+    if (tail?.isComplete) {
+      exitCode = tail.exitCode ?? 0;
+      break;
+    }
     const t = performance.now();
     await sleep(50);
     maxStallMs = Math.max(maxStallMs, performance.now() - t - 50);

--- a/test/integration/terminal-output-buffer-leak.js
+++ b/test/integration/terminal-output-buffer-leak.js
@@ -86,9 +86,11 @@ async function main() {
   }
   assert.notStrictEqual(exitCode, null, `flood should finish within ${FLOOD_DEADLINE_MS}ms`);
 
-  // 1. Buffer bounded + eviction happened (the fix at work).
+  // 1. Buffer bounded + eviction happened (the fix at work). Eviction must be
+  //    reported so read_process_output can surface it to the model.
   const completedTail = terminalManager.readOutputPaginated(result.pid, -5, 5);
   assert.ok(completedTail, 'should be able to read output after completion');
+  assert.ok(completedTail.evictedLines > 0, 'paginated reads should report evicted line count');
   const joinedLength = completedTail.totalLines <= 0 ? 0
     : terminalManager.getOutputSinceSnapshot(result.pid, { totalChars: 0, lineCount: 0 })?.length ?? 0;
   assert.ok(

--- a/test/integration/terminal-output-buffer-leak.js
+++ b/test/integration/terminal-output-buffer-leak.js
@@ -1,0 +1,123 @@
+/**
+ * Regression test: TerminalManager output buffering must stay bounded.
+ *
+ * Root cause (fixed):
+ *   executeCommand() accumulated process output into unbounded strings
+ *   (`output += text` in the data handlers, plus session.outputLines), and
+ *   kept accumulating even after the call resolved. A process emitting more
+ *   than V8's max string length (~536M chars) made concatenation throw
+ *   "RangeError: Invalid string length" inside a 'data' handler ->
+ *   uncaughtException -> the whole MCP server (shared by every chat) died
+ *   silently, and every command failed until restart. Reported as the
+ *   "Invalid string length" / "freezing in multiple chats" bugs.
+ *
+ * Fix (terminal-manager.ts):
+ *   Per-session buffer cap (evict-oldest), force-splitting of single lines,
+ *   bounded sliding tail for the wait-phase buffer, eviction-aware
+ *   snapshot offsets.
+ *
+ * This test drives the real built TerminalManager in-process (no MCP
+ * transport) with a finite ~600MB flood that keeps streaming AFTER
+ * executeCommand has already returned — the cross-chat leak scenario.
+ * On unfixed code it crashes with "Invalid string length"; on fixed code
+ * it asserts:
+ *   1. the buffer stays bounded and eviction actually happened
+ *   2. the event loop never stalls badly while the flood streams
+ *   3. the output tail (end marker) is still readable after eviction
+ *   4. snapshot reads work across eviction without throwing
+ *
+ * Run:  node test/integration/terminal-output-buffer-leak.js
+ */
+
+import assert from 'assert';
+import { performance } from 'perf_hooks';
+
+process.env.DESKTOP_COMMANDER_DISABLE_TELEMETRY = 'true';
+
+const { terminalManager } = await import('../../dist/terminal-manager.js');
+
+// Must match MAX_BUFFERED_OUTPUT_CHARS in terminal-manager.ts, with slack for
+// one in-flight chunk and force-split separators.
+const BUFFER_CAP_CHARS = 50 * 1024 * 1024;
+const BUFFER_CAP_SLACK = 2 * 1024 * 1024;
+
+// 8MB x 72 = ~604MB on one line — past V8's ~536M char limit that used to
+// crash the process — then a newline-delimited end marker.
+const FLOOD_CHUNK_CHARS = 8 * 1024 * 1024;
+const FLOOD_CHUNKS = 72;
+const END_MARKER = 'FLOOD_END_MARKER';
+
+const MAX_EVENT_LOOP_STALL_MS = 500;
+const FLOOD_DEADLINE_MS = 90000;
+
+function sleep(ms) { return new Promise((r) => setTimeout(r, ms)); }
+
+async function main() {
+  console.log('===== terminal output buffer cap regression test =====');
+  const floodCmd = `node -e "const s='x'.repeat(${FLOOD_CHUNK_CHARS}); for(let i=0;i<${FLOOD_CHUNKS};i++) process.stdout.write(s); process.stdout.write('\\n${END_MARKER}\\n');"`;
+
+  // Return after 500ms while the flood keeps streaming — the leak scenario:
+  // output nobody is reading, accumulating inside the long-lived server.
+  const result = await terminalManager.executeCommand(floodCmd, 500);
+  assert.ok(result.pid > 0, 'executeCommand should return a valid pid');
+  const session = terminalManager.getSession(result.pid);
+  assert.ok(session, 'session should still exist after the call returned');
+
+  // Take a snapshot now; eviction will discard most output between snapshot
+  // and the read below — the read must degrade gracefully, not throw.
+  const snapshot = terminalManager.captureOutputSnapshot(result.pid);
+  assert.ok(snapshot, 'snapshot should be available');
+
+  // Watch the flood stream in, sampling event-loop lag.
+  let maxStallMs = 0;
+  const startedAt = performance.now();
+  let exitCode = null;
+  session.process.on('exit', (code) => { exitCode = code ?? 0; });
+  while (exitCode === null && performance.now() - startedAt < FLOOD_DEADLINE_MS) {
+    const t = performance.now();
+    await sleep(50);
+    maxStallMs = Math.max(maxStallMs, performance.now() - t - 50);
+  }
+  assert.notStrictEqual(exitCode, null, `flood should finish within ${FLOOD_DEADLINE_MS}ms`);
+
+  // 1. Buffer bounded + eviction happened (the fix at work).
+  const completedTail = terminalManager.readOutputPaginated(result.pid, -5, 5);
+  assert.ok(completedTail, 'should be able to read output after completion');
+  const joinedLength = completedTail.totalLines <= 0 ? 0
+    : terminalManager.getOutputSinceSnapshot(result.pid, { totalChars: 0, lineCount: 0 })?.length ?? 0;
+  assert.ok(
+    joinedLength <= BUFFER_CAP_CHARS + BUFFER_CAP_SLACK,
+    `retained output ${joinedLength} chars should be within the ${BUFFER_CAP_CHARS} cap (+slack)`
+  );
+  assert.ok(joinedLength > 0, 'some output should be retained');
+
+  // 2. Event loop stayed healthy while ~600MB streamed through the handlers.
+  assert.ok(
+    maxStallMs < MAX_EVENT_LOOP_STALL_MS,
+    `event loop stalled ${maxStallMs.toFixed(0)}ms during the flood (limit ${MAX_EVENT_LOOP_STALL_MS}ms)`
+  );
+
+  // 3. The most recent output survived eviction.
+  assert.ok(
+    completedTail.lines.join('\n').includes(END_MARKER),
+    'end marker should be readable in the retained tail'
+  );
+
+  // 4. Snapshot read across heavy eviction degrades gracefully (returns the
+  //    retained tail) instead of throwing or returning garbage offsets.
+  const sinceSnapshot = terminalManager.getOutputSinceSnapshot(result.pid, snapshot);
+  assert.ok(typeof sinceSnapshot === 'string', 'snapshot read should return a string');
+  assert.ok(sinceSnapshot.includes(END_MARKER), 'snapshot read should include the newest output');
+
+  const totalEmittedMB = Math.round((FLOOD_CHUNK_CHARS * FLOOD_CHUNKS) / 1024 / 1024);
+  console.log(`flood: ${totalEmittedMB} MB emitted, ${(joinedLength / 1024 / 1024).toFixed(1)} MB retained (cap ${BUFFER_CAP_CHARS / 1024 / 1024} MB)`);
+  console.log(`max event-loop stall: ${maxStallMs.toFixed(0)}ms | exit code: ${exitCode}`);
+  console.log('PASS — output buffer stayed bounded, server-side state healthy throughout.');
+  process.exit(0);
+}
+
+main().catch((err) => {
+  // On unfixed code the flood itself crashes here ("Invalid string length").
+  console.error('FAIL:', err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
A process emitting more output than V8's max string length (~536M chars) made string concatenation throw "RangeError: Invalid string length" inside a stdout 'data' handler in terminal-manager.ts. That uncaught exception hits the handler in index.ts which exits the process — the shared MCP server died silently ~4s into the flood and every command from every chat failed until restart. Reported as the "Invalid string length" / "MCP freezing in multiple chats" bugs. Reproduced with a finite ~600MB single-line flood.

Fix:
- Cap the per-session line buffer at 50MB chars, evicting oldest lines first; lastReadIndex is adjusted so pagination stays correct.
- Force-split single lines past 1MB so a process printing without newlines can't grow one unevictable line.
- Stop growing the start_process wait buffer after the call resolves and keep only a bounded sliding tail. This also bounds the periodic analyzeProcessState scan, which ran regex over the full accumulated output every 100ms.
- Track evicted chars/lines so interact_with_process snapshot offsets remain absolute and join() costs stay bounded.

Trade-offs: only the most recent ~50MB of a session's output remains readable (redirect to a file for full logs), and single lines longer than 1MB are split into multiple buffer lines.

Adds test/integration/terminal-output-buffer-leak.js, which drives the built TerminalManager in-process with a ~600MB flood that continues after executeCommand returns: asserts the buffer stays capped, the event loop never stalls, the output tail stays readable, and snapshot reads survive eviction. Crashes with "Invalid string length" on unfixed code; passes in ~1s with the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal output buffering is now bounded per session with automatic eviction of oldest lines to prevent unbounded memory growth and crashes.
  * Snapshot-based reads and output history remain consistent even when older output has been evicted.
  * Completed session records now include eviction metadata so stored output lengths and snapshots are accurate.

* **New Features**
  * Status messages now indicate if older output was evicted and show the retained-buffer cap.

* **Tests**
  * Added an integration test validating buffer bounds, eviction behavior, and snapshot reads during heavy streaming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->