### PR TITLE
chore(deps): override transitive exceljs uuid to clear npm-audit advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13750,12 +13750,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -136,5 +136,10 @@
     "ts-node": "^10.9.2",
     "tsx": "^4.21.0",
     "typescript": "^5.3.3"
+  },
+  "overrides": {
+    "exceljs": {
+      "uuid": "^14.0.0"
+    }
   }
 }


### PR DESCRIPTION
## Summary

`exceljs@4.4.0` (the latest release) pins `uuid: ^8.3.0`, resolving `uuid@8.3.2`, which `npm audit` flags as moderate advisory [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq). This adds a scoped npm `overrides` forcing `exceljs` onto `uuid ^14.0.0`, clearing the advisory.

The change is two files only — the `overrides` block in `package.json` and the corresponding `uuid` entry in `package-lock.json` (`8.3.2 → 14.0.0`, single hoisted node). No other dependency and no application code is touched.

## Why an override (not an exceljs bump)

exceljs is unmaintained — last release `v4.4.0` (Oct 2023), and the upstream remediation PR exceljs/exceljs#3042 was closed unmerged. A consumer-side `overrides` is the pragmatic fix the exceljs maintainers now point users to.

## Safety

exceljs imports uuid via the named CommonJS form `const {v4: uuidv4} = require('uuid')` and only ever calls `v4()` with no buffer argument (`lib/xlsx/xform/sheet/cf-ext/cf-rule-ext-xform.js`). That form works unchanged on uuid 14 in a Node/CommonJS consumer like this one, and uuid is dependency-free, so the override introduces no new packages.

## Test plan

With this change applied in a clone:

- `npm install --package-lock-only` resolves `exceljs`'s transitive `uuid` to `14.0.0` (single hoisted node).
- `npm audit` no longer reports `GHSA-w5hq-g745-h8pq`. (The other audit findings present in the tree are pre-existing and unrelated to this change.)
- In an isolated repro, `exceljs` still writes a workbook with a `dataBar` conditional-format rule — which exercises the `uuidv4()` code path — producing a valid `.xlsx`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency resolution configuration to ensure compatibility and prevent version conflicts with external libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->