### PR TITLE
feat(telemetry): attribute remote tool calls to the originating MCP c…

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -154,6 +154,21 @@ function setCurrentCallIsRemote(isRemote: boolean) {
     currentCallIsRemote = isRemote;
 }
 
+// The remote caller's client for the in-flight tool call (e.g. openai-mcp,
+// claude-ai). Set per CallTool when the call is remote; null for local calls.
+// Mirrors currentCallIsRemote so telemetry attributes remote events to the
+// actual remote client instead of the device's own currentClient (which stays
+// LOCAL and must not be polluted by remote callers).
+let currentRemoteClient: { name?: string; version?: string } | null = null;
+
+/**
+ * Set the remote caller's client for the current tool call (null when local).
+ * Called once per tool call by the CallTool handler.
+ */
+function setCurrentRemoteClient(clientInfo: { name?: string; version?: string } | null) {
+    currentRemoteClient = clientInfo;
+}
+
 /**
  * Unified way to update client information
  */
@@ -223,7 +238,7 @@ server.setRequestHandler(InitializeRequestSchema, async (request: InitializeRequ
 });
 
 // Export current client info for access by other modules
-export { currentClient, currentCallIsRemote };
+export { currentClient, currentCallIsRemote, currentRemoteClient };
 
 deferLog('info', 'Setting up request handlers...');
 
@@ -1212,18 +1227,27 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
         // this call carries the remote marker in _meta.
         const isRemoteCall = !!(metadata && typeof metadata === 'object' && metadata.remote);
         setCurrentCallIsRemote(isRemoteCall);
-        if (metadata && typeof metadata === 'object') {
-            // add remote flag if present (convert to string for telemetry)
-            if (metadata.remote) {
-                telemetryData.remote = String(metadata.remote);
-            }
-            // Dynamically update client info if provided in _meta
-            // To use in capture later
-            if (metadata.clientInfo) {
-                await updateCurrentClient(metadata.clientInfo);
-                telemetryData.client_name = metadata.clientInfo.name;
-                telemetryData.client_version = metadata.clientInfo.version;
-            }
+        if (isRemoteCall) {
+            // add remote flag (convert to string for telemetry)
+            telemetryData.remote = String(metadata.remote);
+            // Remote calls carry the originating MCP client (e.g. openai-mcp,
+            // claude-ai) in _meta.clientInfo. Attribute this call to that remote
+            // client — NOT the device's own currentClient. Fall back to a sentinel
+            // when it's absent so the call is visibly remote-but-unattributed
+            // rather than masquerading as the local device client. We deliberately
+            // do NOT call updateCurrentClient here: currentClient tracks the LOCAL
+            // client and must not be polluted (nor its transport reconfigured) by
+            // remote callers.
+            const remoteClient =
+                metadata.clientInfo && (metadata.clientInfo.name || metadata.clientInfo.version)
+                    ? metadata.clientInfo
+                    : { name: 'remote-unknown', version: 'unknown' };
+            setCurrentRemoteClient(remoteClient);
+            telemetryData.client_name = remoteClient.name;
+            telemetryData.client_version = remoteClient.version;
+        } else {
+            // Local call — clear any remote attribution left by a prior call.
+            setCurrentRemoteClient(null);
         }
 
         if (name === 'set_config_value' && args && typeof args === 'object' && 'key' in args) {

--- a/src/utils/capture.ts
+++ b/src/utils/capture.ts
@@ -1,7 +1,7 @@
 import { platform } from 'os';
 import * as https from 'https';
 import { configManager, isTelemetryDisabledValue } from '../config-manager.js';
-import { currentClient, currentCallIsRemote } from '../server.js';
+import { currentClient, currentCallIsRemote, currentRemoteClient } from '../server.js';
 
 let VERSION = 'unknown';
 try {
@@ -100,11 +100,15 @@ export const captureBase = async (captureURL: string, event: string, properties?
         }
 
         // Get current client information for all events
+        // For remote calls, attribute to the originating remote client (carried on
+        // the tool call) instead of the device's local currentClient.
+        const effectiveClient =
+            currentCallIsRemote && currentRemoteClient ? currentRemoteClient : currentClient;
         let clientContext = {};
-        if (currentClient) {
+        if (effectiveClient) {
             clientContext = {
-                client_name: currentClient.name,
-                client_version: currentClient.version,
+                client_name: effectiveClient.name,
+                client_version: effectiveClient.version,
             };
         }
 
@@ -294,11 +298,15 @@ const buildEventProperties = async (properties?: any) => {
         uniqueUserId = await configManager.getOrCreateClientId();
     }
 
+    // For remote calls, attribute to the originating remote client (carried on
+    // the tool call) instead of the device's local currentClient.
+    const effectiveClient =
+        currentCallIsRemote && currentRemoteClient ? currentRemoteClient : currentClient;
     let clientContext: any = {};
-    if (currentClient) {
+    if (effectiveClient) {
         clientContext = {
-            client_name: currentClient.name,
-            client_version: currentClient.version,
+            client_name: effectiveClient.name,
+            client_version: effectiveClient.version,
         };
     }
 


### PR DESCRIPTION
Remote tool calls carry the upstream client (openai-mcp, Anthropic/ClaudeAI, ...) in _meta.clientInfo. Previously the device passed this through updateCurrentClient(), which overwrote the device's own local currentClient (desktop-commander-client) and reconfigured the transport for the remote caller -- leaking the remote identity into subsequent calls.

Track the remote caller in a separate, per-call currentRemoteClient instead:
- server.ts: set currentRemoteClient from _meta.clientInfo on remote calls (falling back to a remote-unknown sentinel), clear to null on local calls; never touch currentClient or the transport.
- capture.ts: emit telemetry with effectiveClient = currentCallIsRemote && currentRemoteClient ? currentRemoteClient : currentClient, so ALL events (server_call_tool and the deeper server_read_file / server_start_process / ...) attribute to the right client without polluting the local identity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Telemetry now better distinguishes between local and remote tool calls, improving client attribution in event data.
  * Remote-call context is now tracked separately, helping preserve the correct app/client details during remote actions.

* **Bug Fixes**
  * Fixed cases where telemetry could reflect the wrong client information during remote tool usage.
  * Local calls now correctly clear remote attribution so subsequent events stay accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->