### PR TITLE
feat(telemetry): attribute file-tool calls to ui vs llm via call_origin

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1230,6 +1230,17 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
             telemetryData.set_config_value_key_name = (args as any).key;
             telemetryData.call_origin = (args as any).origin === 'ui' ? 'ui' : 'llm';
         }
+        // Attribute file-surface tool calls to the file-preview UI vs the LLM.
+        // The UI passes origin:'ui' when it fires these tools to refresh/navigate
+        // (pagination, folder expansion, link resolution, in-preview edits); the
+        // first read_file that opens a file comes from the LLM and is recorded as
+        // 'llm'. Lets us separate UI-refresh churn from genuine model-driven reads.
+        if (
+            (name === 'read_file' || name === 'write_file' || name === 'edit_block' || name === 'list_directory') &&
+            args && typeof args === 'object'
+        ) {
+            telemetryData.call_origin = (args as any).origin === 'ui' ? 'ui' : 'llm';
+        }
         if (name === 'get_prompts' && args && typeof args === 'object') {
             const promptArgs = args as any;
             telemetryData.action = promptArgs.action;

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -52,7 +52,10 @@ export const ReadFileArgsSchema = z.object({
   length: z.number().optional().default(1000),
   sheet: z.string().optional(),  // String only for MCP client compatibility (Cursor doesn't support union types in JSON Schema)
   range: z.string().optional(),
-  options: z.record(z.any()).optional()
+  options: z.record(z.any()).optional(),
+  // Whether the call came from the file-preview UI (refresh/navigation) or the
+  // LLM. Used only for telemetry attribution; see call_origin in server.ts.
+  origin: z.enum(['ui', 'llm']).optional(),
 });
 
 export const ReadMultipleFilesArgsSchema = z.object({
@@ -63,6 +66,8 @@ export const WriteFileArgsSchema = z.object({
   path: z.string(),
   content: z.string(),
   mode: z.enum(['rewrite', 'append']).default('rewrite'),
+  // Telemetry attribution: 'ui' when fired by the file-preview UI, else 'llm'.
+  origin: z.enum(['ui', 'llm']).optional(),
 });
 
 // PDF modification schemas - exported for reuse
@@ -111,6 +116,8 @@ export const CreateDirectoryArgsSchema = z.object({
 export const ListDirectoryArgsSchema = z.object({
   path: z.string(),
   depth: z.number().optional().default(2),
+  // Telemetry attribution: 'ui' when fired by the file-preview UI, else 'llm'.
+  origin: z.enum(['ui', 'llm']).optional(),
 });
 
 export const MoveFileArgsSchema = z.object({
@@ -136,7 +143,9 @@ export const EditBlockArgsSchema = z.object({
   // Structured file range rewrite (Excel, etc.)
   range: z.string().optional(),
   content: z.any().optional(),
-  options: z.record(z.any()).optional()
+  options: z.record(z.any()).optional(),
+  // Telemetry attribution: 'ui' when fired by the file-preview UI, else 'llm'.
+  origin: z.enum(['ui', 'llm']).optional(),
 }).refine(
   data => {
     // Helper to check if value is actually provided (not undefined, not empty string)

--- a/src/ui/file-preview/src/directory-controller.ts
+++ b/src/ui/file-preview/src/directory-controller.ts
@@ -189,7 +189,7 @@ export function attachDirectoryHandlers(options: {
             loadMoreBtn.querySelector('.dir-warning-text')!.textContent = 'Loading…';
             (loadMoreBtn as HTMLButtonElement).disabled = true;
             try {
-                const result = await options.callTool?.('list_directory', { path: loadPath, depth: 1 });
+                const result = await options.callTool?.('list_directory', { path: loadPath, depth: 1, origin: 'ui' });
                 const text = extractToolText(result) ?? '';
                 if (text) {
                     const parsed = parseDirectoryEntries(text);
@@ -238,7 +238,7 @@ export function attachDirectoryHandlers(options: {
             }
             if (chevron) chevron.textContent = '⏳';
             try {
-                const result = await options.callTool?.('list_directory', { path: fullPath, depth: 2 });
+                const result = await options.callTool?.('list_directory', { path: fullPath, depth: 2, origin: 'ui' });
                 const text = extractToolText(result) ?? '';
                 if (text) {
                     target.dataset.loaded = 'true';
@@ -264,7 +264,7 @@ export function attachDirectoryHandlers(options: {
         if (target.classList.contains('dir-row-file')) {
             target.classList.add('dir-loading');
             try {
-                const result = await options.callTool?.('read_file', { path: fullPath });
+                const result = await options.callTool?.('read_file', { path: fullPath, origin: 'ui' });
                 if (!result || typeof result !== 'object' || result === null) {
                     return;
                 }

--- a/src/ui/file-preview/src/markdown/controller.ts
+++ b/src/ui/file-preview/src/markdown/controller.ts
@@ -373,6 +373,7 @@ export function createMarkdownController(dependencies: MarkdownControllerDepende
         const rawResult = await dependencies.callTool?.('read_file', {
             path: filePath,
             ...(typeof length === 'number' ? { offset: offset ?? 0, length } : {}),
+            origin: 'ui',
         });
         return { rawResult, payload: extractRenderPayload(rawResult) ?? null };
     }
@@ -466,7 +467,7 @@ export function createMarkdownController(dependencies: MarkdownControllerDepende
 
         for (const ancestor of ancestors) {
             try {
-                const result = await dependencies.callTool?.('list_directory', { path: ancestor, depth: 1 });
+                const result = await dependencies.callTool?.('list_directory', { path: ancestor, depth: 1, origin: 'ui' });
                 const text = extractToolText(result) ?? '';
                 const entries = splitListingLines(text);
                 if (entries.some((entry) => markers.has(entry))) {
@@ -827,6 +828,7 @@ export function createMarkdownController(dependencies: MarkdownControllerDepende
                         old_string: block.old_string,
                         new_string: block.new_string,
                         expected_replacements: 1,
+                        origin: 'ui',
                     });
                     assertSuccessfulEditBlockResult(editResult);
                     appliedCount++;

--- a/src/ui/file-preview/src/panel-actions.ts
+++ b/src/ui/file-preview/src/panel-actions.ts
@@ -173,8 +173,8 @@ export function attachPanelActions(options: {
 
         try {
             const readArgs = direction === 'before'
-                ? { path: options.payload.filePath, offset: 0, length: range.fromLine - 1 }
-                : { path: options.payload.filePath, offset: range.toLine };
+                ? { path: options.payload.filePath, offset: 0, length: range.fromLine - 1, origin: 'ui' }
+                : { path: options.payload.filePath, offset: range.toLine, origin: 'ui' };
 
             const result = await options.callTool?.('read_file', readArgs);
             const newText = extractToolText(result);


### PR DESCRIPTION
Mirror the existing set_config_value call_origin pattern for read_file, write_file, edit_block, and list_directory. The file-preview UI passes origin:'ui' when it fires these tools to refresh/navigate (pagination, folder expansion, link resolution, in-preview edits); the LLM's calls default to 'llm'. server.ts records telemetryData.call_origin on the server_call_tool event so analytics can separate UI-refresh reads from genuine model-driven opens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracking for file browsing and editing actions so requests are now correctly attributed as coming from the app UI or other sources.
  * Added the same attribution to file reading, directory listing, and content editing actions used in previews and panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->