### PR TITLE
refactor(read_file): carry image base64 once in structuredContent

### DIFF
--- a/src/handlers/filesystem-handlers.ts
+++ b/src/handlers/filesystem-handlers.ts
@@ -175,8 +175,9 @@ export async function handleReadFile(args: unknown): Promise<ServerResult> {
                     fileType: 'image',
                     sourceTool: 'read_file',
                     ...await getDefaultEditorMetadata(resolvedFilePath),
+                    // Image bytes for the preview widget, carried once. Deduped from the
+                    // old `content` + `imageData` pair down to this single `content` field.
                     content: imageData,
-                    imageData,
                     mimeType: fileResult.mimeType
                 }
             };

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,8 +82,9 @@ export interface FilePreviewStructuredContent {
   sourceTool?: 'read_file' | 'write_file' | 'edit_block';
   defaultEditorName?: string;
   defaultEditorPath?: string;
+  // For text/markdown this is the file text; for images it is the base64 image
+  // payload (single source — the preview UI renders the <img> from this).
   content?: string;
-  imageData?: string;
   mimeType?: string;
 }
 

--- a/src/ui/file-preview/src/file-type-handlers.ts
+++ b/src/ui/file-preview/src/file-type-handlers.ts
@@ -22,14 +22,14 @@ function renderImageBody(payload: RenderPayload): RenderBodyResult {
         };
     }
 
-    if (!payload.imageData || payload.imageData.trim().length === 0) {
+    if (!payload.content || payload.content.trim().length === 0) {
         return {
             notice: 'Preview is unavailable because image data is missing.',
             html: '<div class="panel-content source-content"></div>',
         };
     }
 
-    const src = `data:${mimeType};base64,${payload.imageData}`;
+    const src = `data:${mimeType};base64,${payload.content}`;
     return {
         html: `<div class="panel-content image-content"><div class="image-preview"><img src="${escapeHtml(src)}" alt="${escapeHtml(payload.fileName)}" loading="eager" decoding="async"></div></div>`,
     };


### PR DESCRIPTION
The image read_file result duplicated the base64 in structuredContent as both `content` and `imageData`. Drop the `imageData` field and have the preview widget render from the single `content` field, halving the image structuredContent payload. No behavior change: the content[] image block (LLM vision) and the widget's data URI are both intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified file preview data handling so image previews now rely on a single content field.
  * Improved image preview validation to better detect missing or empty image data.
  * Kept preview output behavior the same while making image rendering more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->