### PR TITLE
test: align file-preview tests with #524 and #526

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wonderwhy-er/desktop-commander",
-  "version": "0.2.42",
+  "version": "0.2.43",
   "description": "MCP server for terminal operations and file editing",
   "mcpName": "io.github.wonderwhy-er/desktop-commander",
   "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/wonderwhy-er/DesktopCommanderMCP",
     "source": "github"
   },
-  "version": "0.2.42",
+  "version": "0.2.43",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@wonderwhy-er/desktop-commander",
-      "version": "0.2.42",
+      "version": "0.2.43",
       "transport": {
         "type": "stdio"
       }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '0.2.42';
+export const VERSION = '0.2.43';

--- a/test/test-file-handlers.js
+++ b/test/test-file-handlers.js
@@ -333,9 +333,8 @@ async function testReadFilePreviewMetadata() {
   assert.ok(typeof imageContentItem.data === 'string' && imageContentItem.data.length > 0, 'Image content item should carry non-empty base64 data');
   assert.ok(imageResult.structuredContent, 'Image should include structuredContent');
   assert.strictEqual(imageResult.structuredContent.fileType, 'image', 'Image fileType should map to image preview state');
-  assert.strictEqual(typeof imageResult.structuredContent.imageData, 'string', 'Image structured payload should include imageData');
-  assert.ok(imageResult.structuredContent.imageData.length > 0, 'Image structured payload should include non-empty imageData');
-  assert.strictEqual(imageResult.structuredContent.content, imageResult.structuredContent.imageData, 'Image structuredContent should include file content');
+  assert.strictEqual(typeof imageResult.structuredContent.content, 'string', 'Image structured payload should carry base64 in content');
+  assert.ok(imageResult.structuredContent.content.length > 0, 'Image structured payload should include non-empty content');
   assert.strictEqual(imageResult.structuredContent.mimeType, 'image/png', 'Image structured payload should include mimeType');
   assert.strictEqual(imageResult.structuredContent.filePath, IMAGE_FILE, 'Image file path should be present');
   assert.strictEqual(imageResult.structuredContent.sourceTool, 'read_file', 'Image preview should preserve source tool');
@@ -349,8 +348,8 @@ async function testReadFilePreviewMetadata() {
   assert.ok(svgResult.structuredContent, 'SVG should include structuredContent');
   assert.strictEqual(svgResult.structuredContent.fileType, 'image', 'SVG should map to image preview state');
   assert.strictEqual(svgResult.structuredContent.mimeType, 'image/svg+xml', 'SVG structured payload should include SVG mimeType');
-  assert.strictEqual(typeof svgResult.structuredContent.imageData, 'string', 'SVG structured payload should include imageData');
-  assert.ok(svgResult.structuredContent.imageData.length > 0, 'SVG structured payload should include non-empty imageData');
+  assert.strictEqual(typeof svgResult.structuredContent.content, 'string', 'SVG structured payload should carry base64 in content');
+  assert.ok(svgResult.structuredContent.content.length > 0, 'SVG structured payload should include non-empty content');
   assert.strictEqual(svgResult.structuredContent.sourceTool, 'read_file', 'SVG preview should preserve source tool');
 
   const writeResult = await handleWriteFile({ path: TEXT_FILE, content: 'written through handler' });

--- a/test/test-markdown-preview.js
+++ b/test/test-markdown-preview.js
@@ -219,7 +219,7 @@ async function testFailedSaveResyncsEditBaseline() {
         }
 
         if (name === 'read_file') {
-          assert.deepStrictEqual(args, { path: payload.filePath });
+          assert.deepStrictEqual(args, { path: payload.filePath, origin: 'ui' });
           return {
             structuredContent: {
               fileName: payload.fileName,
@@ -444,7 +444,7 @@ async function testPartialDocumentBecomesNewEditBaseline() {
   const controller = createMarkdownController({
     callTool: async (name, args) => {
       assert.strictEqual(name, 'read_file');
-      assert.deepStrictEqual(args, { path: partialPayload.filePath, offset: 0, length: 3 });
+      assert.deepStrictEqual(args, { path: partialPayload.filePath, offset: 0, length: 3, origin: 'ui' });
       return {
         structuredContent: {
           fileName: partialPayload.fileName,


### PR DESCRIPTION
## What

Fixes the two failing tests in the suite (`test-file-handlers.js`, `test-markdown-preview.js`). Both were stale tests trailing the two most recent merges — not MCP regressions.

## Why they failed

**`test-file-handlers.js` (Test 9)** — #526 (`refactor(read_file): carry image base64 once`) deliberately removed `structuredContent.imageData` and now carries the image base64 only in `structuredContent.content`. The test still asserted `imageData` was a string, so it got `undefined`.

**`test-markdown-preview.js` (Test 9)** — #524 (`feat(telemetry): call_origin ui vs llm`) appends `origin: 'ui'` to the controller's `read_file` call. The mock asserted exact args via `deepStrictEqual({ path, offset, length })`; the extra key made it throw, `loadFullDocument`'s `catch` swallowed it, and the full-document reload silently aborted — leaving the baseline at the truncated `# Intro`. The same staleness was hiding behind it in Test 11 (`testFailedSaveResyncsEditBaseline`, the runner stops at the first failure).

## Changes

- Image/SVG assertions now read `structuredContent.content` instead of the removed `imageData`.
- Added `origin: 'ui'` to the expected `read_file` args in Test 9 and Test 11.

No source changes.

## Verification

Full suite green locally: **42/42 passed**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated preview-related tests to match the latest file-handling and markdown preview behavior.
  * Updated structured preview assertions for images and SVGs, ensuring the returned content payload includes a non-empty base64 string.
  * Adjusted file-reading call expectations in markdown preview tests to include the new request parameter format.
* **Release / Versioning**
  * Bumped version to **0.2.43** across the app configuration and source version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->