### PR TITLE
fix(remote-device): recover from reconnect wedge when channel stalls …

### DIFF
--- a/src/remote-device/remote-channel.ts
+++ b/src/remote-device/remote-channel.ts
@@ -20,6 +20,14 @@ const HEARTBEAT_INTERVAL = 15000;
 // Cap a single channel recreate so a hung await can't pin the re-entrancy guard
 // true (which would silently disable the connection watchdog).
 const RECREATE_TIMEOUT_MS = 30000;
+// Max time the channel may sit CONTINUOUSLY in 'joining' before we force a recreate.
+// 'joining' is normally healthy (we let realtime-js's rejoin backoff converge), but on a
+// HALF-OPEN socket (readyState OPEN yet dead) realtime-js parks the channel in 'joining'
+// forever and never reconnects the socket — the device then wedges offline silently with
+// no recreate firing. realtime-js's join push times out in ~10s, so a genuine join
+// resolves/errors well within this window; 3 health ticks of unbroken 'joining' means the
+// state machine has stalled and only a fresh socket (via recreate) recovers it.
+const JOINING_WEDGE_TIMEOUT_MS = 30000;
 
 export class RemoteChannel {
     private client: SupabaseClient | null = null;
@@ -41,6 +49,7 @@ export class RemoteChannel {
     // Reconnect diagnostics + guard (see connState() / recreateChannel())
     private reconnectAttempt = 0;        // recreateChannel() attempts since last success
     private isRecreatingChannel = false; // a recreate is in flight (re-entrancy guard)
+    private joiningSince: number | null = null; // ts the channel entered an unbroken 'joining' run; null when not joining
 
     private _user: User | null = null;
     get user(): User | null { return this._user; }
@@ -279,12 +288,33 @@ export class RemoteChannel {
             this.lastChannelState = state;
         }
 
-        // 'joined' = healthy, 'joining' = transitional — let realtime-js's own rejoin
-        // backoff converge instead of tearing the channel down mid-join. (FIX: previously
-        // recreated on every non-joined state, which amputated that backoff.)
-        if (state === 'joined' || state === 'joining') return;
+        // 'joined' = healthy. Clear the joining-overstay timer.
+        if (state === 'joined') {
+            this.joiningSince = null;
+            return;
+        }
+
+        // 'joining' = transitional — normally let realtime-js's own rejoin backoff converge
+        // instead of tearing the channel down mid-join (recreating on every non-joined state
+        // amputates that backoff). BUT bound it: on a half-open socket realtime-js can park
+        // the channel in 'joining' indefinitely without ever reconnecting the socket, so the
+        // recreate below would never fire and the device wedges offline silently. If 'joining'
+        // overstays JOINING_WEDGE_TIMEOUT_MS unbroken, force a recreate — the only path that
+        // disconnect()s the dead socket. (connState() in the log shows the half-open socket.)
+        if (state === 'joining') {
+            const now = Date.now();
+            if (this.joiningSince === null) this.joiningSince = now;
+            const stuckMs = now - this.joiningSince;
+            if (stuckMs < JOINING_WEDGE_TIMEOUT_MS) return;
+            console.debug(`[DEBUG] ⚠️ Channel stuck 'joining' ${Math.round(stuckMs / 1000)}s - forcing recreate — ${this.connState()}`);
+            captureRemote('remote_channel_joining_wedge', { stuckMs, attempt: this.reconnectAttempt });
+            this.joiningSince = null;
+            this.recreateChannel();
+            return;
+        }
 
         // Unhealthy: closed, errored, leaving — recreate
+        this.joiningSince = null;
         captureRemote('remote_channel_state_health', { state, attempt: this.reconnectAttempt });
         console.debug(`[DEBUG] ⚠️ Channel in unhealthy state '${state}' - recreating... — ${this.connState()}`);
         this.recreateChannel();

--- a/test/test-remote-channel-reconnect.js
+++ b/test/test-remote-channel-reconnect.js
@@ -177,6 +177,45 @@ async function driveHealthChecks(rc, maxAttempts) {
   return !!(rc.channel && rc.channel.state === 'joined');
 }
 
+/**
+ * Model the WEDGE (open bug 2026-06-27): bring the channel up healthy, then make the
+ * socket half-open (readyState stays OPEN) AND leave the channel parked in 'joining' —
+ * which is what realtime-js does when it keeps re-attempting a join over a dead socket
+ * it never tears down. This is distinct from the 'errored' path the guard already
+ * handles: here the channel is stuck in a state the health-check treats as healthy.
+ */
+async function goHalfOpenStuckJoining(rc, client) {
+  await rc.createChannel(); // healthy subscribe -> 'joined'
+  assert.strictEqual(rc.channel.state, 'joined', 'precondition: channel should be joined');
+  client.realtime.socketDead = true; // dead peer, but readyState stays 1 (OPEN)
+  rc.channel.state = 'joining';      // realtime-js parks it rejoining on the dead socket
+  rc.lastChannelState = 'joining';
+}
+
+/**
+ * Drive the 10s health-check while the channel is stuck 'joining' on a half-open socket.
+ * Advances a SIMULATED clock 10s per tick (the real health-check interval) so a
+ * time-bounded guard can observe how long the channel has overstayed 'joining' without
+ * the test burning real wall-clock. Returns whether the channel recovered.
+ */
+async function driveHealthChecksStuckJoining(rc, maxTicks) {
+  const realNow = Date.now;
+  let simulated = realNow();
+  Date.now = () => simulated;
+  try {
+    for (let i = 0; i < maxTicks; i++) {
+      if (rc.channel && rc.channel.state === 'joined') return true;
+      rc.checkConnectionHealth(); // -> must eventually recreate once 'joining' overstays
+      await flush();
+      await flush();
+      simulated += 10_000; // advance one 10s health-check interval
+    }
+  } finally {
+    Date.now = realNow;
+  }
+  return !!(rc.channel && rc.channel.state === 'joined');
+}
+
 // Silence the (intentionally verbose) diagnostic logging during the drive so
 // the test output stays readable; we summarise via the fake's statusLog instead.
 // Must await so console is restored only after the async callbacks have fired.
@@ -262,6 +301,28 @@ async function main() {
       assert.strictEqual(rc.reconnectAttempt, attemptsBefore, 'joining must not trigger a recreate');
       assert.strictEqual(client.realtime.rebuilds, rebuildsBefore, 'joining must not rebuild the socket');
     });
+  });
+
+  // REGRESSION REPRO (open bug 2026-06-27): a half-open socket can leave the channel
+  // parked in 'joining' instead of 'errored'. The previous test proves single-tick
+  // 'joining' must NOT recreate; THIS test proves 'joining' must not be healthy
+  // *forever* — if it overstays while the socket reads OPEN(1) (the half-open tell),
+  // the guard must force a recreate (the same path that recovers the 'errored' case),
+  // or the device wedges offline until restart. EXPECTED TO FAIL until the
+  // time-bounded-'joining' fix lands in checkConnectionHealth().
+  await test('recovers when a half-open socket leaves the channel stuck in joining', async () => {
+    const { rc, client } = makeRemoteChannel();
+    const recovered = await withQuietLogs(async () => {
+      await goHalfOpenStuckJoining(rc, client);
+      return driveHealthChecksStuckJoining(rc, 8); // ~80s simulated; a 30s bound fires by tick ~4
+    });
+    assert.strictEqual(
+      recovered,
+      true,
+      `channel wedged in 'joining' on a half-open socket and never recovered.\n` +
+        `     attempts(recreate)=${rc.reconnectAttempt} rebuilds=${client.realtime.rebuilds}\n` +
+        `     channelState=${rc.channel && rc.channel.state} socketReadyState=${client.realtime.conn.readyState}`
+    );
   });
 
   console.log(


### PR DESCRIPTION
## Problem
Follow-up to #520. On a half-open socket (readyState OPEN but dead — e.g. after
sleep/wifi-loss), realtime-js SOMETIMES parks the channel in `joining` indefinitely and never
reconnects the socket. The health-check treated `joining` as unconditionally healthy,
so `recreateChannel()` (the only path that drops the dead socket) never fired — the
device wedged **offline forever** until restart.

Reproduced in prod: device offline 4+ min, logs frozen, zero recreate attempts, while
`last_seen` kept advancing via the separate HTTP heartbeat. 

## Fix
Bound time-in-`joining`: stay healthy only under `JOINING_WEDGE_TIMEOUT_MS` (30s = 3
health ticks; realtime-js's join push times out in ~10s). Past the bound → log, emit
`remote_channel_joining_wedge` telemetry, and force a recreate. `joiningSince` resets on
`joined` and every non-joining state, so normal rejoin oscillation never trips it.

## Test
Adds a deterministic repro to `test/test-remote-channel-reconnect.js` (red→green; uses a
simulated clock). All 4 cases pass, incl. the still-passing single-tick "joining is
healthy" guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when the realtime connection gets stuck while joining, helping the app reconnect automatically instead of remaining stuck.
  * Added protection against prolonged connection interruptions so the channel is refreshed sooner when it stops making progress.
  * Expanded automated coverage for the reconnect flow to verify recovery from this stuck joining state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->