### PR TITLE
Render file previews via widget-pulled reads; make structuredContent …

### DIFF
--- a/src/handlers/filesystem-handlers.ts
+++ b/src/handlers/filesystem-handlers.ts
@@ -134,29 +134,48 @@ export async function handleReadFile(args: unknown): Promise<ServerResult> {
                     },
                     ...pdfContent
                 ],
-                structuredContent: {
-                    fileName: path.basename(resolvedFilePath),
-                    filePath: resolvedFilePath,
-                    fileType: 'unsupported' as const,
-                    sourceTool: 'read_file',
-                    ...await getDefaultEditorMetadata(resolvedFilePath),
-                    content: pdfContent
-                        .filter((item): item is { type: "text"; text: string } => item.type === "text")
-                        .map((item) => item.text)
-                        .join("\n"),
-                },
+                ...(parsed.origin === 'ui' ? {
+                    structuredContent: {
+                        fileName: path.basename(resolvedFilePath),
+                        filePath: resolvedFilePath,
+                        fileType: 'unsupported' as const,
+                        ...await getDefaultEditorMetadata(resolvedFilePath),
+                    },
+                } : {}),
             };
         }
 
         // Handle image files
         if (fileResult.metadata?.isImage) {
             // Return the image bytes in the MCP content array so the host model can
-            // actually see the image. structuredContent additionally carries the bytes
-            // for the preview widget to render.
+            // actually see the image. The preview widget gets its copy from its own
+            // origin:'ui' read — structuredContent stays metadata-only.
             const imageData = typeof fileResult.content === 'string'
                 ? fileResult.content
                 : fileResult.content.toString('base64');
             const imageSummary = `Image file: ${parsed.path} (${fileResult.mimeType})\n`;
+            const imageStructuredContent = {
+                fileName: path.basename(resolvedFilePath),
+                filePath: resolvedFilePath,
+                fileType: 'image' as const,
+                ...await getDefaultEditorMetadata(resolvedFilePath),
+                mimeType: fileResult.mimeType,
+            };
+            // Widget pull (origin: 'ui'): return the base64 in a TEXT block, never
+            // an image block. An image content block makes the host inline-vision-
+            // render the result, which preempts delivery of this RPC response to
+            // the widget — leaving the preview stuck on "Preparing preview…" for
+            // exactly the host-rendered types (png/jpeg/gif/webp). Text-only lets
+            // the RPC response through so the widget can draw the <img>.
+            if (parsed.origin === 'ui') {
+                return {
+                    content: [{ type: "text", text: imageData }],
+                    structuredContent: imageStructuredContent,
+                };
+            }
+            // Model-facing read: keep the image block so the host/model sees it.
+            // No structuredContent — the widget renders from its own origin:'ui'
+            // read, and nothing else consumes it.
             return {
                 content: [
                     {
@@ -169,36 +188,31 @@ export async function handleReadFile(args: unknown): Promise<ServerResult> {
                         mimeType: fileResult.mimeType
                     }
                 ],
-                structuredContent: {
-                    fileName: path.basename(resolvedFilePath),
-                    filePath: resolvedFilePath,
-                    fileType: 'image',
-                    sourceTool: 'read_file',
-                    ...await getDefaultEditorMetadata(resolvedFilePath),
-                    // Image bytes for the preview widget, carried once. Deduped from the
-                    // old `content` + `imageData` pair down to this single `content` field.
-                    content: imageData,
-                    mimeType: fileResult.mimeType
-                }
             };
         } else {
             // For all other files, return as text.
             // structuredContent carries only file metadata (no content duplication);
-            // the widget reads text from the MCP content array.
-            const textContent = typeof fileResult.content === 'string'
+            // the widget reads text from the MCP content array (over the RPC read).
+            let textContent = typeof fileResult.content === 'string'
                 ? fileResult.content
                 : fileResult.content.toString('utf8');
             const fileType = fileResult.metadata?.isDirectory ? 'directory' as const : resolvePreviewFileType(resolvedFilePath);
+            // The directory fallback prefixes a "use list_directory instead" hint
+            // for the LLM. The widget's own read (a list_directory preview pulls
+            // read_file on the dir path) would render that hint as a notice — strip it.
+            if (parsed.origin === 'ui' && fileType === 'directory') {
+                textContent = textContent.replace(/^This is a directory, not a file\.[^\n]*\n+/, '');
+            }
             return {
                 content: [{ type: "text", text: textContent }],
-                structuredContent: {
-                    fileName: path.basename(resolvedFilePath),
-                    filePath: resolvedFilePath,
-                    fileType,
-                    sourceTool: 'read_file',
-                    ...await getDefaultEditorMetadata(resolvedFilePath),
-                    content: textContent,
-                },
+                ...(parsed.origin === 'ui' ? {
+                    structuredContent: {
+                        fileName: path.basename(resolvedFilePath),
+                        filePath: resolvedFilePath,
+                        fileType,
+                        ...await getDefaultEditorMetadata(resolvedFilePath),
+                    },
+                } : {}),
             };
         }
     };
@@ -306,20 +320,14 @@ export async function handleWriteFile(args: unknown): Promise<ServerResult> {
 
         // Provide more informative message based on mode
         const modeMessage = parsed.mode === 'append' ? 'appended to' : 'wrote to';
-        const resolvedWritePath = resolveAbsolutePath(parsed.path);
 
+        // No structuredContent: nothing in the UI calls write_file (the widget
+        // previews the write via its own read_file pull at tool-result time).
         return {
             content: [{
                 type: "text",
                 text: `Successfully ${modeMessage} ${parsed.path} (${lineCount} lines) ${errorMessage}`
             }],
-            structuredContent: {
-                fileName: path.basename(resolvedWritePath),
-                filePath: resolvedWritePath,
-                fileType: resolvePreviewFileType(resolvedWritePath),
-                sourceTool: 'write_file',
-                ...await getDefaultEditorMetadata(resolvedWritePath),
-            },
         };
     } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
@@ -358,16 +366,13 @@ export async function handleListDirectory(args: unknown): Promise<ServerResult> 
 
         return {
             content: [{ type: "text", text: resultText }],
-            structuredContent: {
-                fileName: path.basename(resolvedPath),
-                filePath: resolvedPath,
-                fileType: 'directory' as const,
-                sourceTool: 'list_directory',
-                // Carry the listing in structuredContent too. Chat reads the text
-                // content array, but structuredContent-only consumers (e.g. Cowork)
-                // render from here and would otherwise show an empty directory.
-                content: resultText,
-            },
+            ...(parsed.origin === 'ui' ? {
+                structuredContent: {
+                    fileName: path.basename(resolvedPath),
+                    filePath: resolvedPath,
+                    fileType: 'directory' as const,
+                },
+            } : {}),
         };
     } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);

--- a/src/server.ts
+++ b/src/server.ts
@@ -68,7 +68,7 @@ import { toolHistory } from './utils/toolHistory.js';
 import { handleWelcomePageOnboarding } from './utils/welcome-onboarding.js';
 
 import { VERSION } from './version.js';
-import { capture, capture_call_tool } from "./utils/capture.js";
+import { capture, capture_call_tool, runInUiOriginCallContext } from "./utils/capture.js";
 import { logToStderr, logger } from './utils/logger.js';
 import {
     buildUiToolMeta,
@@ -1211,6 +1211,21 @@ import * as handlers from './handlers/index.js';
 import { ServerResult } from './types.js';
 
 server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest): Promise<ServerResult> => {
+    const args = request.params.arguments;
+    // Calls fired programmatically by the widget UIs (file preview, config
+    // editor) carry origin:'ui'. They are real tool executions but not agent
+    // actions, so they must produce zero telemetry: running them inside the
+    // UI-origin capture context makes capture() drop every event they raise
+    // (server_call_tool, server_read_file, server_edit_block, ...). Deliberate
+    // UI interactions are tracked separately via mcp_ui_event.
+    const isUiOriginCall = !!(args && typeof args === 'object' && (args as any).origin === 'ui');
+    if (isUiOriginCall) {
+        return runInUiOriginCallContext(() => handleCallToolRequest(request));
+    }
+    return handleCallToolRequest(request);
+});
+
+async function handleCallToolRequest(request: CallToolRequest): Promise<ServerResult> {
     const { name, arguments: args } = request.params;
     const startTime = Date.now();
     // Hoisted above the try so the finally block can read them when emitting the
@@ -1252,18 +1267,6 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
 
         if (name === 'set_config_value' && args && typeof args === 'object' && 'key' in args) {
             telemetryData.set_config_value_key_name = (args as any).key;
-            telemetryData.call_origin = (args as any).origin === 'ui' ? 'ui' : 'llm';
-        }
-        // Attribute file-surface tool calls to the file-preview UI vs the LLM.
-        // The UI passes origin:'ui' when it fires these tools to refresh/navigate
-        // (pagination, folder expansion, link resolution, in-preview edits); the
-        // first read_file that opens a file comes from the LLM and is recorded as
-        // 'llm'. Lets us separate UI-refresh churn from genuine model-driven reads.
-        if (
-            (name === 'read_file' || name === 'write_file' || name === 'edit_block' || name === 'list_directory') &&
-            args && typeof args === 'object'
-        ) {
-            telemetryData.call_origin = (args as any).origin === 'ui' ? 'ui' : 'llm';
         }
         if (name === 'get_prompts' && args && typeof args === 'object') {
             const promptArgs = args as any;
@@ -1640,13 +1643,19 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
         // Single tool-call telemetry event, fired AFTER execution so it can carry
         // timing. In a finally so it still fires on the hard-crash path (the catch
         // above). Only missed if a tool never returns or throws (a true hang).
-        capture_call_tool('server_call_tool', {
-            ...telemetryData,
-            duration_ms: Date.now() - startTime,
-            is_error: String(isError),
-        });
+        // Not emitted for track_ui_event (it is just the transport for
+        // mcp_ui_event) — and UI-origin calls are dropped wholesale by the
+        // capture layer, so server_call_tool reflects only genuine
+        // agent-driven tool calls.
+        if (name !== 'track_ui_event') {
+            capture_call_tool('server_call_tool', {
+                ...telemetryData,
+                duration_ms: Date.now() - startTime,
+                is_error: String(isError),
+            });
+        }
     }
-});
+}
 
 // Add no-op handlers so Visual Studio initialization succeeds
 server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => ({ resourceTemplates: [] }));

--- a/src/tools/edit.ts
+++ b/src/tools/edit.ts
@@ -113,7 +113,7 @@ function getCharacterCodeData(expected: string, actual: string): {
     };
 }
 
-export async function performSearchReplace(filePath: string, block: SearchReplace, expectedReplacements: number = 1): Promise<ServerResult> {
+export async function performSearchReplace(filePath: string, block: SearchReplace, expectedReplacements: number = 1, origin?: 'ui' | 'llm'): Promise<ServerResult> {
     // Get file extension for telemetry using path module
     const fileExtension = path.extname(filePath).toLowerCase();
     
@@ -223,13 +223,18 @@ RECOMMENDATION: For large search/replace operations, consider breaking them into
                 type: "text",
                 text: `${statusLine}${previewContent}`
             }],
-            structuredContent: {
-                fileName: path.basename(resolvedEditPath),
-                filePath: resolvedEditPath,
-                fileType: resolvePreviewFileType(resolvedEditPath),
-                sourceTool: 'edit_block',
-                ...await getDefaultEditorMetadata(resolvedEditPath),
-            },
+            // structuredContent only travels on widget-initiated calls: it is the
+            // widget's save-success signal (assertSuccessfulEditBlockResult) and
+            // metadata source. LLM-facing responses don't need it — nothing there
+            // consumes it, and the widget re-reads by path instead.
+            ...(origin === 'ui' ? {
+                structuredContent: {
+                    fileName: path.basename(resolvedEditPath),
+                    filePath: resolvedEditPath,
+                    fileType: resolvePreviewFileType(resolvedEditPath),
+                    ...await getDefaultEditorMetadata(resolvedEditPath),
+                },
+            } : {}),
         };
     }
     
@@ -437,13 +442,14 @@ export async function handleEditBlock(args: unknown): Promise<ServerResult> {
                         type: "text",
                         text: `Successfully updated range ${parsed.range} in ${parsed.file_path}`
                     }],
-                    structuredContent: {
-                        fileName: path.basename(resolvedRangePath),
-                        filePath: resolvedRangePath,
-                        fileType: resolvePreviewFileType(resolvedRangePath),
-                        sourceTool: 'edit_block',
-                        ...await getDefaultEditorMetadata(resolvedRangePath),
-                    },
+                    ...(parsed.origin === 'ui' ? {
+                        structuredContent: {
+                            fileName: path.basename(resolvedRangePath),
+                            filePath: resolvedRangePath,
+                            fileType: resolvePreviewFileType(resolvedRangePath),
+                            ...await getDefaultEditorMetadata(resolvedRangePath),
+                        },
+                    } : {}),
                 };
             } catch (error) {
                 const errorMessage = error instanceof Error ? error.message : String(error);
@@ -477,13 +483,14 @@ export async function handleEditBlock(args: unknown): Promise<ServerResult> {
                         type: "text",
                         text: `Successfully applied ${result.editsApplied} edit(s) to ${parsed.file_path}`
                     }],
-                    structuredContent: {
-                        fileName: path.basename(resolvedEditRangePath),
-                        filePath: resolvedEditRangePath,
-                        fileType: resolvePreviewFileType(resolvedEditRangePath),
-                        sourceTool: 'edit_block',
-                        ...await getDefaultEditorMetadata(resolvedEditRangePath),
-                    },
+                    ...(parsed.origin === 'ui' ? {
+                        structuredContent: {
+                            fileName: path.basename(resolvedEditRangePath),
+                            filePath: resolvedEditRangePath,
+                            fileType: resolvePreviewFileType(resolvedEditRangePath),
+                            ...await getDefaultEditorMetadata(resolvedEditRangePath),
+                        },
+                    } : {}),
                 };
             }
 
@@ -498,5 +505,5 @@ export async function handleEditBlock(args: unknown): Promise<ServerResult> {
     return performSearchReplace(parsed.file_path, {
         search: parsed.old_string,
         replace: parsed.new_string
-    }, parsed.expected_replacements);
+    }, parsed.expected_replacements, parsed.origin);
 }

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -1,7 +1,11 @@
 import { z } from "zod";
 
 // Config tools schemas
-export const GetConfigArgsSchema = z.object({});
+export const GetConfigArgsSchema = z.object({
+  // 'ui' marks calls the config-editor widget fires programmatically; they are
+  // excluded from tool-call telemetry (see isUiOriginCall in server.ts).
+  origin: z.enum(['ui', 'llm']).optional(),
+});
 
 export const SetConfigValueArgsSchema = z.object({
   key: z.string(),
@@ -12,6 +16,7 @@ export const SetConfigValueArgsSchema = z.object({
     z.array(z.string()),
     z.null(),
   ]),
+  // 'ui' marks widget-fired calls; excluded from tool-call telemetry.
   origin: z.enum(['ui', 'llm']).optional(),
 });
 
@@ -24,6 +29,9 @@ export const StartProcessArgsSchema = z.object({
   timeout_ms: z.number(),
   shell: z.string().optional(),
   verbose_timing: z.boolean().optional(),
+  // 'ui' marks widget-fired calls (e.g. open-in-folder/editor buttons);
+  // excluded from tool-call telemetry (see isUiOriginCall in server.ts).
+  origin: z.enum(['ui', 'llm']).optional(),
 });
 
 export const ReadProcessOutputArgsSchema = z.object({
@@ -54,7 +62,8 @@ export const ReadFileArgsSchema = z.object({
   range: z.string().optional(),
   options: z.record(z.any()).optional(),
   // Whether the call came from the file-preview UI (refresh/navigation) or the
-  // LLM. Used only for telemetry attribution; see call_origin in server.ts.
+  // LLM. 'ui' calls are excluded from tool-call telemetry; see isUiOriginCall
+  // in server.ts.
   origin: z.enum(['ui', 'llm']).optional(),
 });
 
@@ -66,7 +75,8 @@ export const WriteFileArgsSchema = z.object({
   path: z.string(),
   content: z.string(),
   mode: z.enum(['rewrite', 'append']).default('rewrite'),
-  // Telemetry attribution: 'ui' when fired by the file-preview UI, else 'llm'.
+  // 'ui' when fired by the file-preview UI, else 'llm'. 'ui' calls are
+  // excluded from tool-call telemetry; see isUiOriginCall in server.ts.
   origin: z.enum(['ui', 'llm']).optional(),
 });
 
@@ -116,7 +126,8 @@ export const CreateDirectoryArgsSchema = z.object({
 export const ListDirectoryArgsSchema = z.object({
   path: z.string(),
   depth: z.number().optional().default(2),
-  // Telemetry attribution: 'ui' when fired by the file-preview UI, else 'llm'.
+  // 'ui' when fired by the file-preview UI, else 'llm'. 'ui' calls are
+  // excluded from tool-call telemetry; see isUiOriginCall in server.ts.
   origin: z.enum(['ui', 'llm']).optional(),
 });
 
@@ -144,7 +155,8 @@ export const EditBlockArgsSchema = z.object({
   range: z.string().optional(),
   content: z.any().optional(),
   options: z.record(z.any()).optional(),
-  // Telemetry attribution: 'ui' when fired by the file-preview UI, else 'llm'.
+  // 'ui' when fired by the file-preview UI, else 'llm'. 'ui' calls are
+  // excluded from tool-call telemetry; see isUiOriginCall in server.ts.
   origin: z.enum(['ui', 'llm']).optional(),
 }).refine(
   data => {
@@ -191,6 +203,9 @@ export const StartSearchArgsSchema = z.object({
   timeout_ms: z.number().optional(), // Match process naming convention
   earlyTermination: z.boolean().optional(), // Stop search early when exact filename match is found (default: true for files, false for content)
   literalSearch: z.boolean().optional().default(false), // Force literal string matching (-F flag) instead of regex
+  // 'ui' marks widget-fired calls (e.g. markdown link-target search);
+  // excluded from tool-call telemetry (see isUiOriginCall in server.ts).
+  origin: z.enum(['ui', 'llm']).optional(),
 });
 
 export const GetMoreSearchResultsArgsSchema = z.object({

--- a/src/ui/config-editor/src/app.ts
+++ b/src/ui/config-editor/src/app.ts
@@ -470,7 +470,7 @@ export function createConfigEditorController(callTool: ToolCall, trackConfigUiEv
                 }),
             });
 
-            const refreshed = await callTool('get_config', {});
+            const refreshed = await callTool('get_config', { origin: 'ui' });
             if (isToolErrorResult(refreshed)) {
                 const errorMessage = extractToolText(refreshed) ?? 'Value was updated but config refresh failed.';
                 return {
@@ -827,8 +827,6 @@ export function bootstrapConfigEditorApp(): void {
         expanded: true,
     };
 
-    let configEditorShownEventSent = false;
-
     let quietContextSupported = true;
     let tooltipHideTimer: number | null = null;
 
@@ -924,20 +922,11 @@ export function bootstrapConfigEditorApp(): void {
         controller.setPayload(payload);
         widgetState.write(payload);
         scheduleRender();
-
-        if (!configEditorShownEventSent) {
-            configEditorShownEventSent = true;
-            // One-shot impression event for get_config UI card visibility.
-            trackConfigUiEvent('config_editor_shown', {
-                tool_name: GET_CONFIG_TOOL_NAME,
-                entry_count: payload.entries.length,
-            });
-        }
     };
 
     const refreshConfigFromServer = async (): Promise<void> => {
         try {
-            const result = await bridge.callTool('get_config', {});
+            const result = await bridge.callTool('get_config', { origin: 'ui' });
             const payload = controller.extractPayload(result);
             if (payload) {
                 applyPayload(payload);

--- a/src/ui/file-preview/src/app.ts
+++ b/src/ui/file-preview/src/app.ts
@@ -146,47 +146,126 @@ const markdownController = createMarkdownController({
     },
 });
 
-/**
- * Check if a payload needs its file content to be read.
- * Tool results from edit_block/write_file include structuredContent but
- * their text is a success message, not file content. Detect this by
- * checking for the absence of the read status line that read_file always includes.
- * URL payloads are fetched remotely by read_file(isUrl:true); we can't
- * re-fetch them from here (no isUrl flag on the refresh path), so skip.
- */
-function needsContentRead(payload: RenderPayload): boolean {
-    if (payload.fileType === 'directory' || payload.fileType === 'image' || payload.fileType === 'unsupported') {
-        return false;
+// Only read_file's own parameters may ride along on a re-read. Forwarding a
+// different tool's args (e.g. edit_block's old_string) makes the server prepend
+// an "unsupported params" warning that would pollute the pulled content.
+const READ_ARG_KEYS = ['path', 'offset', 'length', 'sheet', 'range', 'isUrl'] as const;
+
+function pickReadArgs(args: unknown): Record<string, unknown> | undefined {
+    if (!args || typeof args !== 'object') {
+        return undefined;
     }
-    if (/^https?:\/\//i.test(payload.filePath)) {
-        return false;
+    const src = args as Record<string, unknown>;
+    // edit_block calls the file "file_path"; read_file/write_file call it "path".
+    const path = typeof src.path === 'string'
+        ? src.path
+        : typeof src.file_path === 'string'
+            ? src.file_path
+            : undefined;
+    if (!path) {
+        return undefined;
     }
-    return !parseReadRange(payload.content);
+    const out: Record<string, unknown> = { path };
+    for (const key of READ_ARG_KEYS) {
+        if (key !== 'path' && src[key] !== undefined) {
+            out[key] = src[key];
+        }
+    }
+    return out;
 }
 
-async function readAndResolvePayload(
-    payload: RenderPayload,
-    onReady: (payload: RenderPayload) => void
+// The host doesn't send the tool name with tool-input, so infer mutations from
+// their arg shape: write_file carries `content`; edit_block `old_string`/
+// `new_string`. Drives two things: timing (a mutation's tool-input arrives
+// BEFORE the file changes, so those pull at tool-result time instead of input
+// time) and telemetry (the pulled payload's sourceTool is re-stamped with the
+// originating tool, since the pull itself is always a read_file).
+function inferMutationTool(args: unknown): 'write_file' | 'edit_block' | undefined {
+    if (!args || typeof args !== 'object') {
+        return undefined;
+    }
+    const src = args as Record<string, unknown>;
+    if (src.old_string !== undefined || src.new_string !== undefined) {
+        return 'edit_block';
+    }
+    if (src.content !== undefined) {
+        return 'write_file';
+    }
+    return undefined;
+}
+
+// Bound the RPC read so a stalled host response resolves to onFail instead of
+// hanging. Kept under the loading watchdog (PREVIEW_WATCHDOG_MS) so the pull
+// gets its chance to fail before the failure row appears.
+const PULL_TIMEOUT_MS = 8000;
+
+// One in-flight pull per path — the input-time pull and a tool-result-triggered
+// pull for the same call would otherwise read the file twice.
+let pullInFlightPath: string | undefined;
+
+/**
+ * The widget's render path: pull content + metadata over the RPC channel
+ * (`app.callServerTool` with origin:'ui'). The notification channel is not used
+ * for rendering — the host may strip structuredContent from it or swallow it
+ * entirely (images). `args` reproduces the original read exactly
+ * (offset/length/sheet/range/isUrl) so partial reads stay faithful.
+ */
+async function pullPayloadByArgs(
+    args: Record<string, unknown>,
+    onReady: (payload: RenderPayload) => void,
+    onFail: () => void
 ): Promise<void> {
+    const filePath = typeof args.path === 'string' ? args.path : undefined;
+    if (!filePath) {
+        onFail();
+        return;
+    }
+    if (pullInFlightPath === filePath) {
+        return;
+    }
+    pullInFlightPath = filePath;
     try {
-        const freshPayload = await markdownController.readPayload(payload.filePath);
-        if (freshPayload) {
-            onReady({
-                ...freshPayload,
-                sourceTool: payload.sourceTool ?? freshPayload.sourceTool,
-            });
-            if (freshPayload.fileType === 'markdown') {
-                void markdownController.refreshFromDisk(freshPayload);
-            }
+        // The host can hold the RPC response indefinitely (e.g. it preempts
+        // delivery to inline-render an image), so callServerTool would await
+        // forever with no throw. Race a timeout so the pull settles either way.
+        const raw = await Promise.race([
+            callToolIfReady('read_file', { ...args, origin: 'ui' }),
+            new Promise<never>((_resolve, reject) => {
+                setTimeout(
+                    () => reject(new Error(`RPC read_file did not respond within ${PULL_TIMEOUT_MS}ms`)),
+                    PULL_TIMEOUT_MS,
+                );
+            }),
+        ]);
+        const payload = extractRenderPayload(raw);
+        if (payload) {
+            onReady(payload);
             return;
         }
     } catch {
-        // Fall through to original payload.
+        // Timed out or rejected — fall through to the caller's fallback.
+    } finally {
+        pullInFlightPath = undefined;
     }
-    onReady(payload);
+    onFail();
+}
+
+// If a loading state hasn't resolved into a real render within this window, the
+// host most likely never delivered the tool result / RPC response (e.g. it
+// preempted delivery to inline-render an image). Rather than sit on "Preparing
+// preview…" forever, we surface a failure row.
+const PREVIEW_WATCHDOG_MS = 10000;
+let previewWatchdogId: ReturnType<typeof setTimeout> | undefined;
+
+function clearPreviewWatchdog(): void {
+    if (previewWatchdogId !== undefined) {
+        clearTimeout(previewWatchdogId);
+        previewWatchdogId = undefined;
+    }
 }
 
 function renderStatusState(container: HTMLElement, message: string): void {
+    clearPreviewWatchdog();
     container.innerHTML = `
       <main class="shell">
         ${renderCompactRow({ label: message, variant: 'status', interactive: false })}
@@ -202,6 +281,13 @@ function renderLoadingState(container: HTMLElement): void {
       </main>
     `;
     document.body.classList.add('dc-ready');
+    // Fall back to a failure row if nothing renders in time. Any successful
+    // render (renderApp) or explicit status clears this first.
+    clearPreviewWatchdog();
+    previewWatchdogId = setTimeout(() => {
+        previewWatchdogId = undefined;
+        renderStatusState(container, 'Unable to generate preview in this environment.');
+    }, PREVIEW_WATCHDOG_MS);
 }
 
 export function renderApp(
@@ -210,6 +296,7 @@ export function renderApp(
     htmlMode: HtmlPreviewMode = 'rendered',
     expandedState = false
 ): void {
+    clearPreviewWatchdog();
     isExpanded = expandedState;
     currentHtmlMode = htmlMode;
     shellController?.dispose();
@@ -436,6 +523,14 @@ export function bootstrapApp(): void {
     };
 
     let pendingCachedPayload: RenderPayload | undefined;
+    let lastToolInputArgs: Record<string, unknown> | undefined;
+    // The mutation tool that produced the current tool call, if any — stamped
+    // onto the pulled payload so telemetry attributes to write_file/edit_block
+    // rather than the read_file pull that rendered it.
+    let lastMutationTool: 'write_file' | 'edit_block' | undefined;
+    // True once the current tool call has been rendered (via the input-time pull),
+    // so a late tool-result notification doesn't trigger a redundant second pull.
+    let renderedForCurrentInput = false;
     let initialStateResolved = false;
     const resolveInitialState = (payload?: RenderPayload, message?: string): void => {
         if (initialStateResolved) {
@@ -491,6 +586,13 @@ export function bootstrapApp(): void {
 
     app.ontoolinput = (params) => {
         const requestedPath = typeof params.arguments?.path === 'string' ? params.arguments.path : undefined;
+        const readArgs = pickReadArgs(params.arguments);
+        lastMutationTool = inferMutationTool(params.arguments);
+        if (readArgs) {
+            // Retained so mutations (which pull at tool-result time) know what
+            // to re-read — faithfully reproducing offset/length/sheet/range.
+            lastToolInputArgs = readArgs;
+        }
         if (
             !initialStateResolved
             && pendingCachedPayload
@@ -505,38 +607,77 @@ export function bootstrapApp(): void {
 
         renderLoadingState(container);
         onRender?.();
+        renderedForCurrentInput = false;
+
+        // All previews render from the widget's own origin:'ui' RPC read — the
+        // notification channel is unreliable (the host strips structuredContent,
+        // and for images swallows the tool-result entirely to inline-render).
+        // tool-input always fires and carries the path + read args, so pull here.
+        // Exception: mutations (write_file/edit_block) — their tool-input arrives
+        // before the file changes, so they pull at tool-result time instead.
+        if (readArgs && !lastMutationTool) {
+            void pullPayloadByArgs(
+                readArgs,
+                (p) => {
+                    renderedForCurrentInput = true;
+                    if (initialStateResolved) {
+                        renderAndSync(getEffectiveIncomingPayload(p));
+                    } else {
+                        resolveInitialState(getEffectiveIncomingPayload(p));
+                    }
+                },
+                // Pull failed/timed out — the loading watchdog shows the failure row.
+                () => {},
+            );
+        }
     };
 
     app.ontoolresult = (result) => {
         pendingCachedPayload = undefined;
-        const payload = extractRenderPayload(result);
-        const message = extractToolText(result as unknown as Record<string, unknown>);
-        if (!initialStateResolved) {
-            if (payload) {
-                if (needsContentRead(payload)) {
-                    void readAndResolvePayload(payload, (p) => resolveInitialState(getEffectiveIncomingPayload(p)));
-                    return;
-                }
-                resolveInitialState(getEffectiveIncomingPayload(payload));
-                return;
-            }
-            if (message) {
-                resolveInitialState(undefined, message);
-            }
+
+        // Host-facing responses carry no structuredContent, so this notification
+        // only signals completion. Reads already rendered from their input-time
+        // pull; mutations (write_file/edit_block) pull now that the file changed.
+        if (renderedForCurrentInput) {
             return;
         }
 
-        if (payload) {
-            if (needsContentRead(payload)) {
-                renderLoadingState(container);
-                void readAndResolvePayload(payload, (p) => renderAndSync(getEffectiveIncomingPayload(p)));
+        const message = extractToolText(result as unknown as Record<string, unknown>);
+        const isError = (result as { isError?: boolean })?.isError === true;
+        const pullArgs = lastToolInputArgs
+            ?? (currentPayload?.filePath ? { path: currentPayload.filePath } : undefined);
+
+        const deliver = (pulled: RenderPayload): void => {
+            renderedForCurrentInput = true;
+            // The pull is always a read_file; re-stamp the originating mutation
+            // tool so telemetry attributes to write_file/edit_block.
+            const p = lastMutationTool ? { ...pulled, sourceTool: lastMutationTool } : pulled;
+            if (initialStateResolved) {
+                renderAndSync(getEffectiveIncomingPayload(p));
             } else {
-                renderAndSync(getEffectiveIncomingPayload(payload));
+                resolveInitialState(getEffectiveIncomingPayload(p));
             }
-        } else if (message) {
-            renderStatusState(container, message);
+        };
+        const renderMessageFallback = (): void => {
+            if (!message) {
+                return;
+            }
+            if (!initialStateResolved) {
+                resolveInitialState(undefined, message);
+            } else {
+                renderStatusState(container, message);
+                onRender?.();
+            }
+        };
+
+        // A failed tool call has nothing worth re-reading — show its message.
+        if (!isError && pullArgs) {
+            renderLoadingState(container);
             onRender?.();
+            void pullPayloadByArgs(pullArgs, deliver, renderMessageFallback);
+            return;
         }
+        renderMessageFallback();
     };
 
     app.ontoolcancelled = (params) => {
@@ -558,6 +699,7 @@ export function bootstrapApp(): void {
     };
 
     const teardown = (): void => {
+        clearPreviewWatchdog();
         shellController?.dispose();
         shellController = undefined;
         markdownController.disposeHandles();

--- a/src/ui/file-preview/src/app.ts
+++ b/src/ui/file-preview/src/app.ts
@@ -26,7 +26,6 @@ import type { HtmlPreviewMode } from './types.js';
 
 let isExpanded = false;
 let hideSummaryRow = false;
-let previewShownFired = false;
 let onRender: (() => void) | undefined;
 let trackUiEvent: ((event: string, params?: Record<string, unknown>) => void) | undefined;
 let conflictDialogController: ConflictDialogController | undefined;
@@ -443,13 +442,6 @@ export function renderApp(
         onRender,
     });
     onRender?.();
-    if (!previewShownFired) {
-        previewShownFired = true;
-        trackUiEvent?.('preview_shown', {
-            file_type: payload.fileType,
-            file_extension: fileExtension,
-        });
-    }
 }
 
 export function bootstrapApp(): void {

--- a/src/ui/file-preview/src/directory-controller.ts
+++ b/src/ui/file-preview/src/directory-controller.ts
@@ -171,7 +171,7 @@ export function attachDirectoryHandlers(options: {
             const command = options.buildOpenInFolderCommand(openPath);
             if (command) {
                 try {
-                    await options.callTool?.('start_process', { command, timeout_ms: 12000 });
+                    await options.callTool?.('start_process', { command, timeout_ms: 12000, origin: 'ui' });
                 } catch {
                     // Keep UI stable if opening folder fails.
                 }

--- a/src/ui/file-preview/src/markdown/controller.ts
+++ b/src/ui/file-preview/src/markdown/controller.ts
@@ -496,6 +496,7 @@ export function createMarkdownController(dependencies: MarkdownControllerDepende
             maxResults: 20,
             earlyTermination: false,
             literalSearch: true,
+            origin: 'ui',
         });
         const text = extractToolText(result) ?? '';
         const filePaths = parseFileSearchResults(text);

--- a/src/ui/file-preview/src/panel-actions.ts
+++ b/src/ui/file-preview/src/panel-actions.ts
@@ -121,7 +121,7 @@ export function attachPanelActions(options: {
                     file_extension: fileExtension,
                 });
                 try {
-                    await options.callTool?.('start_process', { command, timeout_ms: 12000 });
+                    await options.callTool?.('start_process', { command, timeout_ms: 12000, origin: 'ui' });
                 } catch {
                     // Keep UI stable if opening folder fails.
                 }
@@ -141,7 +141,7 @@ export function attachPanelActions(options: {
                     file_extension: fileExtension,
                 });
                 try {
-                    await options.callTool?.('start_process', { command, timeout_ms: 12000 });
+                    await options.callTool?.('start_process', { command, timeout_ms: 12000, origin: 'ui' });
                 } catch {
                     // Keep UI stable if opening editor fails.
                 }

--- a/src/ui/file-preview/src/payload-utils.ts
+++ b/src/ui/file-preview/src/payload-utils.ts
@@ -55,6 +55,31 @@ export function extractToolText(value: unknown): string | undefined {
     return undefined;
 }
 
+// Join ALL non-empty text blocks, not just the first. Most reads return a
+// single text block, but PDF reads return a summary block followed by
+// per-page text blocks — taking only the first would drop the page text.
+function extractJoinedToolText(value: unknown): string | undefined {
+    if (!isObjectRecord(value)) {
+        return undefined;
+    }
+    const content = value.content;
+    if (!Array.isArray(content)) {
+        return undefined;
+    }
+    const texts: string[] = [];
+    for (const item of content) {
+        if (
+            isObjectRecord(item)
+            && item.type === 'text'
+            && typeof item.text === 'string'
+            && item.text.trim().length > 0
+        ) {
+            texts.push(item.text);
+        }
+    }
+    return texts.length > 0 ? texts.join('\n') : undefined;
+}
+
 export function extractRenderPayload(value: unknown): RenderPayload | undefined {
     if (!isObjectRecord(value)) {
         return undefined;
@@ -69,7 +94,7 @@ export function extractRenderPayload(value: unknown): RenderPayload | undefined 
     // structuredContent alongside it is metadata-only. Images arrive as a base64
     // text block too (origin:'ui' reads carry no image block, so the host won't
     // inline-render and stall the RPC).
-    return buildRenderPayload(meta, extractToolText(value) ?? '');
+    return buildRenderPayload(meta, extractJoinedToolText(value) ?? '');
 }
 
 export function assertSuccessfulEditBlockResult(result: unknown): void {

--- a/src/ui/file-preview/src/payload-utils.ts
+++ b/src/ui/file-preview/src/payload-utils.ts
@@ -55,13 +55,6 @@ export function extractToolText(value: unknown): string | undefined {
     return undefined;
 }
 
-function extractStructuredContentText(value: unknown): string | undefined {
-    if (!isObjectRecord(value)) {
-        return undefined;
-    }
-    return typeof value.content === 'string' ? value.content : undefined;
-}
-
 export function extractRenderPayload(value: unknown): RenderPayload | undefined {
     if (!isObjectRecord(value)) {
         return undefined;
@@ -72,11 +65,11 @@ export function extractRenderPayload(value: unknown): RenderPayload | undefined 
             ? value
             : null;
     if (!meta) return undefined;
-    const text = extractStructuredContentText(value.structuredContent)
-        ?? extractToolText(value)
-        ?? extractToolText(value.structuredContent)
-        ?? '';
-    return buildRenderPayload(meta, text);
+    // Content always comes from the read output's content[] text blocks; the
+    // structuredContent alongside it is metadata-only. Images arrive as a base64
+    // text block too (origin:'ui' reads carry no image block, so the host won't
+    // inline-render and stall the RPC).
+    return buildRenderPayload(meta, extractToolText(value) ?? '');
 }
 
 export function assertSuccessfulEditBlockResult(result: unknown): void {

--- a/src/utils/capture.ts
+++ b/src/utils/capture.ts
@@ -1,7 +1,24 @@
 import { platform } from 'os';
 import * as https from 'https';
+import { AsyncLocalStorage } from 'async_hooks';
 import { configManager, isTelemetryDisabledValue } from '../config-manager.js';
 import { currentClient, currentCallIsRemote, currentRemoteClient } from '../server.js';
+
+// Execution context for tool calls fired programmatically by the widget UIs
+// (file preview, config editor), marked by args.origin === 'ui'. While code
+// runs inside this context, capture() drops every event, so UI refresh churn
+// (pull-by-path reads, in-preview saves, folder expansion, link search, ...)
+// produces zero telemetry. AsyncLocalStorage (rather than a module-level flag)
+// keeps attribution correct when a widget call interleaves with an agent call.
+const uiOriginCallContext = new AsyncLocalStorage<boolean>();
+
+export function runInUiOriginCallContext<T>(fn: () => T): T {
+    return uiOriginCallContext.run(true, fn);
+}
+
+export function isInsideUiOriginCall(): boolean {
+    return uiOriginCallContext.getStore() === true;
+}
 
 let VERSION = 'unknown';
 try {
@@ -463,6 +480,11 @@ const postTelemetryPayload = async (endpoint: string, payload: string): Promise<
 // can be silently dropped. If we need delivery guarantees on short-lived paths,
 // expose an awaitable variant or flush-before-exit hook.
 export const capture = async (event: string, properties?: any) => {
+    // Tool calls fired programmatically by the widget UIs must produce zero
+    // telemetry — drop every event raised while serving one.
+    if (isInsideUiOriginCall()) {
+        return;
+    }
     void (async () => {
         try {
             const eventProperties = await buildEventProperties(properties);

--- a/test/test-edit-block-line-endings.js
+++ b/test/test-edit-block-line-endings.js
@@ -33,18 +33,16 @@ const MIXED_FILE = path.join(TEST_DIR, 'file_with_mixed.txt');
  * Since the file-preview refactor (commit 8fd8f94), handleEditBlock's
  * exact-match path no longer returns a "Successfully applied N edit(s)"
  * text message — it returns a file preview (status line + snippet of
- * the edited region) plus structuredContent carrying fileName/filePath/
- * fileType for the preview UI.
+ * the edited region). Since the pull-by-path preview refactor,
+ * structuredContent is widget-only (returned solely on origin:'ui'
+ * calls), so LLM-shaped calls like these carry none.
  *
- * We assert the new contract: text response + structuredContent present
- * + preview status line shape, which together mean the edit was written
- * and a preview was produced. Callers additionally verify the edit
- * landed by reading the file back.
+ * We assert the preview status line shape, which means the edit was
+ * written and a preview was produced. Callers additionally verify the
+ * edit landed by reading the file back.
  */
 function assertEditBlockSuccess(result, message) {
   assert.strictEqual(result.content[0].type, 'text', `${message} (should return text content)`);
-  assert.ok(result.structuredContent, `${message} (should return structuredContent)`);
-  assert.ok(result.structuredContent.filePath, `${message} (structuredContent.filePath should be set)`);
   assert.ok(
     /\[Reading \d+ lines? from/.test(result.content[0].text),
     `${message} (text should contain file-preview status line)`

--- a/test/test-file-handlers.js
+++ b/test/test-file-handlers.js
@@ -284,7 +284,15 @@ async function testWriteModes() {
 }
 
 /**
- * Test 9: read_file handler returns preview structured content for markdown/text
+ * Test 9: read_file preview contract.
+ *
+ * Since the pull-by-path preview refactor, structuredContent is widget-only:
+ * it is returned ONLY on origin:'ui' calls (the preview widget's own RPC
+ * reads) and carries metadata only (no content duplication, no sourceTool —
+ * the widget stamps that client-side). LLM-facing calls carry the full
+ * content in content[] and no structuredContent at all. Image ui-reads
+ * return the base64 in a text block (an image block would make the host
+ * inline-render the RPC response and stall the widget).
  */
 async function testReadFilePreviewMetadata() {
   console.log('\n--- Test 9: read_file preview structured content ---');
@@ -300,61 +308,60 @@ async function testReadFilePreviewMetadata() {
   await fs.writeFile(IMAGE_FILE, Buffer.from(tinyPngBase64, 'base64'));
   await fs.writeFile(SVG_FILE, tinySvg);
 
+  // LLM-facing reads: full content in content[], no structuredContent.
   const markdownResult = await handleReadFile({ path: MD_FILE });
   assert.ok(Array.isArray(markdownResult.content), 'Result should include content array');
-  assert.ok(markdownResult.content[0].text.includes(markdownContent), 'Legacy content should still include markdown body');
-  assert.ok(markdownResult.structuredContent, 'Markdown should include structuredContent');
-  assert.strictEqual(markdownResult.structuredContent.fileType, 'markdown', 'Markdown fileType should be markdown');
-  assert.strictEqual(markdownResult.structuredContent.filePath, MD_FILE, 'Markdown file path should be present');
-  assert.strictEqual(markdownResult.structuredContent.sourceTool, 'read_file', 'Markdown preview should preserve source tool');
-  assert.strictEqual(markdownResult.structuredContent.content, markdownResult.content[0].text, 'Markdown structuredContent should include returned content');
+  assert.ok(markdownResult.content[0].text.includes(markdownContent), 'Content should include markdown body');
+  assert.strictEqual(markdownResult.structuredContent, undefined, 'LLM-facing read should carry no structuredContent');
 
   const textResult = await handleReadFile({ path: TEXT_FILE });
-  assert.ok(Array.isArray(textResult.content), 'Result should include content array');
-  assert.ok(textResult.content[0].text.includes(textContent), 'Legacy content should still include text body');
-  assert.ok(textResult.structuredContent, 'Text should include structuredContent');
-  assert.strictEqual(textResult.structuredContent.fileType, 'text', 'Text fileType should be text');
-  assert.strictEqual(textResult.structuredContent.sourceTool, 'read_file', 'Text preview should preserve source tool');
-  assert.strictEqual(textResult.structuredContent.content, textResult.content[0].text, 'Text structuredContent should include returned content');
+  assert.ok(textResult.content[0].text.includes(textContent), 'Content should include text body');
+  assert.strictEqual(textResult.structuredContent, undefined, 'LLM-facing read should carry no structuredContent');
 
-  const htmlResult = await handleReadFile({ path: HTML_FILE });
-  assert.ok(Array.isArray(htmlResult.content), 'Result should include content array');
-  assert.ok(htmlResult.content[0].text.includes('<h1>Preview</h1>'), 'Legacy content should still include html body');
-  assert.ok(htmlResult.structuredContent, 'HTML should include structuredContent');
-  assert.strictEqual(htmlResult.structuredContent.fileType, 'html', 'HTML fileType should be html');
-  assert.strictEqual(htmlResult.structuredContent.sourceTool, 'read_file', 'HTML preview should preserve source tool');
-  assert.strictEqual(htmlResult.structuredContent.content, htmlResult.content[0].text, 'HTML structuredContent should include returned content');
+  // Widget (origin:'ui') reads: same content plus metadata-only structuredContent.
+  const uiMarkdownResult = await handleReadFile({ path: MD_FILE, origin: 'ui' });
+  assert.ok(uiMarkdownResult.structuredContent, 'ui read should include structuredContent');
+  assert.strictEqual(uiMarkdownResult.structuredContent.fileType, 'markdown', 'Markdown fileType should be markdown');
+  assert.strictEqual(uiMarkdownResult.structuredContent.filePath, MD_FILE, 'Markdown file path should be present');
+  assert.strictEqual(uiMarkdownResult.structuredContent.content, undefined, 'structuredContent should be metadata-only (no content)');
+  assert.strictEqual(uiMarkdownResult.structuredContent.sourceTool, undefined, 'structuredContent should not carry sourceTool (widget stamps it)');
+  assert.ok(uiMarkdownResult.content[0].text.includes(markdownContent), 'ui read content[] should carry the markdown body');
 
+  const uiHtmlResult = await handleReadFile({ path: HTML_FILE, origin: 'ui' });
+  assert.strictEqual(uiHtmlResult.structuredContent.fileType, 'html', 'HTML fileType should be html');
+  assert.ok(uiHtmlResult.content[0].text.includes('<h1>Preview</h1>'), 'ui read content[] should carry the html body');
+
+  // LLM-facing image read: image block so the host model can see the image;
+  // no structuredContent.
   const imageResult = await handleReadFile({ path: IMAGE_FILE });
-  assert.ok(Array.isArray(imageResult.content), 'Image result should include content array');
   const imageContentItem = imageResult.content.find((item) => item.type === 'image');
   assert.ok(imageContentItem, 'Image result should include an image content item so the host model can see the image');
   assert.strictEqual(imageContentItem.mimeType, 'image/png', 'Image content item should carry the png mimeType');
   assert.ok(typeof imageContentItem.data === 'string' && imageContentItem.data.length > 0, 'Image content item should carry non-empty base64 data');
-  assert.ok(imageResult.structuredContent, 'Image should include structuredContent');
-  assert.strictEqual(imageResult.structuredContent.fileType, 'image', 'Image fileType should map to image preview state');
-  assert.strictEqual(typeof imageResult.structuredContent.content, 'string', 'Image structured payload should carry base64 in content');
-  assert.ok(imageResult.structuredContent.content.length > 0, 'Image structured payload should include non-empty content');
-  assert.strictEqual(imageResult.structuredContent.mimeType, 'image/png', 'Image structured payload should include mimeType');
-  assert.strictEqual(imageResult.structuredContent.filePath, IMAGE_FILE, 'Image file path should be present');
-  assert.strictEqual(imageResult.structuredContent.sourceTool, 'read_file', 'Image preview should preserve source tool');
+  assert.strictEqual(imageResult.structuredContent, undefined, 'LLM-facing image read should carry no structuredContent');
 
-  const svgResult = await handleReadFile({ path: SVG_FILE });
-  assert.ok(Array.isArray(svgResult.content), 'SVG result should include content array');
-  const svgContentItem = svgResult.content.find((item) => item.type === 'image');
-  assert.ok(svgContentItem, 'SVG result should include an image content item so the host model can see the image');
-  assert.strictEqual(svgContentItem.mimeType, 'image/svg+xml', 'SVG content item should carry the svg mimeType');
-  assert.ok(typeof svgContentItem.data === 'string' && svgContentItem.data.length > 0, 'SVG content item should carry non-empty base64 data');
-  assert.ok(svgResult.structuredContent, 'SVG should include structuredContent');
-  assert.strictEqual(svgResult.structuredContent.fileType, 'image', 'SVG should map to image preview state');
-  assert.strictEqual(svgResult.structuredContent.mimeType, 'image/svg+xml', 'SVG structured payload should include SVG mimeType');
-  assert.strictEqual(typeof svgResult.structuredContent.content, 'string', 'SVG structured payload should carry base64 in content');
-  assert.ok(svgResult.structuredContent.content.length > 0, 'SVG structured payload should include non-empty content');
-  assert.strictEqual(svgResult.structuredContent.sourceTool, 'read_file', 'SVG preview should preserve source tool');
+  // Widget image read: base64 rides in a TEXT block (no image block), plus
+  // metadata-only structuredContent with the mimeType the widget renders with.
+  const uiImageResult = await handleReadFile({ path: IMAGE_FILE, origin: 'ui' });
+  assert.ok(!uiImageResult.content.some((item) => item.type === 'image'), 'ui image read must not include an image block (host would inline-render and stall the RPC)');
+  assert.strictEqual(uiImageResult.content[0].type, 'text', 'ui image read should carry base64 in a text block');
+  assert.strictEqual(uiImageResult.content[0].text, tinyPngBase64, 'ui image read text block should be the base64 image data');
+  assert.ok(uiImageResult.structuredContent, 'ui image read should include structuredContent');
+  assert.strictEqual(uiImageResult.structuredContent.fileType, 'image', 'Image fileType should map to image preview state');
+  assert.strictEqual(uiImageResult.structuredContent.mimeType, 'image/png', 'Image structured payload should include mimeType');
+  assert.strictEqual(uiImageResult.structuredContent.content, undefined, 'Image structuredContent should be metadata-only');
 
+  const uiSvgResult = await handleReadFile({ path: SVG_FILE, origin: 'ui' });
+  assert.strictEqual(uiSvgResult.structuredContent.fileType, 'image', 'SVG should map to image preview state');
+  assert.strictEqual(uiSvgResult.structuredContent.mimeType, 'image/svg+xml', 'SVG structured payload should include SVG mimeType');
+  assert.ok(!uiSvgResult.content.some((item) => item.type === 'image'), 'ui SVG read must not include an image block');
+  assert.ok(uiSvgResult.content[0].text.length > 0, 'ui SVG read should carry base64 in a text block');
+
+  // write_file never returns structuredContent (nothing in the UI calls it;
+  // the widget previews writes via its own read_file pull).
   const writeResult = await handleWriteFile({ path: TEXT_FILE, content: 'written through handler' });
-  assert.ok(writeResult.structuredContent, 'write_file should include structuredContent');
-  assert.strictEqual(writeResult.structuredContent.sourceTool, 'write_file', 'write_file preview should preserve source tool');
+  assert.strictEqual(writeResult.structuredContent, undefined, 'write_file should carry no structuredContent');
+  assert.ok(writeResult.content[0].text.includes('Successfully'), 'write_file should confirm the write');
 
   const nullArgsResult = await handleReadFile(null);
   assert.ok(Array.isArray(nullArgsResult.content), 'Null-args result should include content array');
@@ -383,21 +390,31 @@ async function testMarkdownExactMatchSave() {
   });
 
   assert.ok(Array.isArray(result.content), 'edit_block result should include content array');
-  // After the file-preview refactor (commit 8fd8f94), edit_block's exact-match
-  // path returns a file preview + structuredContent instead of a
-  // "Successfully applied N edit(s)" message. Verify the new contract here.
   assert.strictEqual(result.content[0].type, 'text', 'edit_block result[0] should be text');
-  assert.ok(result.structuredContent, 'edit_block should return structuredContent');
-  assert.ok(result.structuredContent.filePath, 'edit_block structuredContent should include filePath');
-  assert.strictEqual(result.structuredContent.sourceTool, 'edit_block', 'edit_block preview should preserve source tool');
   assert.match(
     result.content[0].text,
     /\[Reading \d+ lines? from/,
     'edit_block should return a file-preview status line'
   );
+  // structuredContent is widget-only: LLM-facing edit_block calls omit it.
+  assert.strictEqual(result.structuredContent, undefined, 'LLM-facing edit_block should carry no structuredContent');
 
   const readBack = await fs.readFile(MD_FILE, 'utf8');
   assert.strictEqual(readBack, updatedContent, 'Markdown file should be rewritten with the updated content');
+
+  // Widget saves (origin:'ui') get metadata-only structuredContent — the save
+  // flow's success signal (assertSuccessfulEditBlockResult).
+  await fs.writeFile(MD_FILE, originalContent);
+  const uiResult = await handleEditBlock({
+    file_path: MD_FILE,
+    old_string: originalContent,
+    new_string: updatedContent,
+    expected_replacements: 1,
+    origin: 'ui',
+  });
+  assert.ok(uiResult.structuredContent, 'ui edit_block should return structuredContent');
+  assert.ok(uiResult.structuredContent.filePath, 'ui edit_block structuredContent should include filePath');
+  assert.strictEqual(uiResult.structuredContent.content, undefined, 'ui edit_block structuredContent should be metadata-only');
 
   console.log('✓ markdown exact-match save flow works');
 }

--- a/test/test-markdown-preview.js
+++ b/test/test-markdown-preview.js
@@ -540,9 +540,9 @@ async function testUnsupportedRawContentPreview() {
   assert.strictEqual(payload.content, '<!-- Page: 1 -->\nRaw PDF text', 'content[] text should be used as raw source');
 
   // A PDF ui-read returns multiple blocks: the summary text block first, then
-  // per-page image/text blocks. extractRenderPayload selects the first
-  // NON-EMPTY text block (whitespace-only blocks are skipped, image blocks
-  // are ignored) — so the summary line wins over later page text.
+  // per-page image/text blocks. extractRenderPayload joins ALL non-empty text
+  // blocks (whitespace-only blocks are skipped, image blocks are ignored) so
+  // the page text is preserved, not just the summary line.
   const multiBlockPayload = extractRenderPayload({
     content: [
       { type: 'text', text: '   ' },
@@ -561,8 +561,8 @@ async function testUnsupportedRawContentPreview() {
   assert.ok(multiBlockPayload, 'Multi-block payload should be extracted');
   assert.strictEqual(
     multiBlockPayload.content,
-    'PDF file: report.pdf (2 pages)\n',
-    'First non-empty text block (the summary) should be selected, skipping whitespace-only and image blocks'
+    'PDF file: report.pdf (2 pages)\n\n<!-- Page: 1 -->\nPage one text\n<!-- Page: 2 -->\nPage two text',
+    'All non-empty text blocks should be joined so PDF page text is preserved'
   );
 
   const capabilities = getFileTypeCapabilities(payload);

--- a/test/test-markdown-preview.js
+++ b/test/test-markdown-preview.js
@@ -539,6 +539,32 @@ async function testUnsupportedRawContentPreview() {
   assert.ok(payload, 'Unsupported payload should be extracted');
   assert.strictEqual(payload.content, '<!-- Page: 1 -->\nRaw PDF text', 'content[] text should be used as raw source');
 
+  // A PDF ui-read returns multiple blocks: the summary text block first, then
+  // per-page image/text blocks. extractRenderPayload selects the first
+  // NON-EMPTY text block (whitespace-only blocks are skipped, image blocks
+  // are ignored) — so the summary line wins over later page text.
+  const multiBlockPayload = extractRenderPayload({
+    content: [
+      { type: 'text', text: '   ' },
+      { type: 'image', data: 'aGVsbG8=', mimeType: 'image/png' },
+      { type: 'text', text: 'PDF file: report.pdf (2 pages)\n' },
+      { type: 'text', text: '<!-- Page: 1 -->\nPage one text' },
+      { type: 'text', text: '<!-- Page: 2 -->\nPage two text' },
+    ],
+    structuredContent: {
+      fileName: 'report.pdf',
+      filePath: '/tmp/report.pdf',
+      fileType: 'unsupported',
+    },
+  });
+
+  assert.ok(multiBlockPayload, 'Multi-block payload should be extracted');
+  assert.strictEqual(
+    multiBlockPayload.content,
+    'PDF file: report.pdf (2 pages)\n',
+    'First non-empty text block (the summary) should be selected, skipping whitespace-only and image blocks'
+  );
+
   const capabilities = getFileTypeCapabilities(payload);
   assert.strictEqual(capabilities.supportsPreview, true, 'Unsupported payload with raw content should be displayable');
   assert.strictEqual(capabilities.canCopy, true, 'Unsupported raw source should be copyable');

--- a/test/test-markdown-preview.js
+++ b/test/test-markdown-preview.js
@@ -523,20 +523,21 @@ async function testRefreshDoesNotMisclassifyMarkdownContentAsDeletion() {
 }
 
 async function testUnsupportedRawContentPreview() {
-  console.log('\n--- Test 11: unsupported files render raw structured content ---');
+  console.log('\n--- Test 11: unsupported files render raw content ---');
 
+  // structuredContent is metadata-only; the raw text rides in content[]
+  // (the shape of an origin:'ui' read the widget pulls).
   const payload = extractRenderPayload({
-    content: [{ type: 'text', text: 'PDF file: report.pdf (1 pages)\n' }],
+    content: [{ type: 'text', text: '<!-- Page: 1 -->\nRaw PDF text' }],
     structuredContent: {
       fileName: 'report.pdf',
       filePath: '/tmp/report.pdf',
       fileType: 'unsupported',
-      content: '<!-- Page: 1 -->\nRaw PDF text',
     },
   });
 
   assert.ok(payload, 'Unsupported payload should be extracted');
-  assert.strictEqual(payload.content, '<!-- Page: 1 -->\nRaw PDF text', 'Structured content text should be used as raw source');
+  assert.strictEqual(payload.content, '<!-- Page: 1 -->\nRaw PDF text', 'content[] text should be used as raw source');
 
   const capabilities = getFileTypeCapabilities(payload);
   assert.strictEqual(capabilities.supportsPreview, true, 'Unsupported payload with raw content should be displayable');

--- a/test/test-telemetry-handling.js
+++ b/test/test-telemetry-handling.js
@@ -5,6 +5,7 @@ import {
   isTelemetryDisabledValue,
   normalizeTelemetryEnabledValue,
 } from '../dist/config-manager.js';
+import { isInsideUiOriginCall, runInUiOriginCallContext } from '../dist/utils/capture.js';
 import { setConfigValue } from '../dist/tools/config.js';
 
 function testTelemetryHelpers() {
@@ -122,6 +123,44 @@ async function testCapturePathAllowsTrueValues() {
   console.log('ok: capture path allows true values');
 }
 
+/**
+ * Tool calls fired programmatically by the widget UIs (args.origin === 'ui')
+ * run inside runInUiOriginCallContext, and capture() drops every event raised
+ * while isInsideUiOriginCall() is true — so UI refresh churn (pull-by-path
+ * reads, in-preview saves, link search) produces zero telemetry. This verifies
+ * the AsyncLocalStorage mechanics that invariant depends on: the flag holds
+ * across awaits, does not leak out, and does not bleed into interleaved calls.
+ */
+async function testUiOriginCallContext() {
+  console.log('\n--- Test: UI-origin call context (zero telemetry for widget calls) ---');
+
+  assert.strictEqual(isInsideUiOriginCall(), false, 'context should be off outside runInUiOriginCallContext');
+
+  const observed = await runInUiOriginCallContext(async () => {
+    const beforeAwait = isInsideUiOriginCall();
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    return { beforeAwait, afterAwait: isInsideUiOriginCall() };
+  });
+  assert.strictEqual(observed.beforeAwait, true, 'context should be on inside runInUiOriginCallContext');
+  assert.strictEqual(observed.afterAwait, true, 'context should survive awaits');
+  assert.strictEqual(isInsideUiOriginCall(), false, 'context should not leak after the wrapped call returns');
+
+  // An agent call interleaving with an in-flight UI-origin call must not
+  // inherit the UI flag (this is why it is AsyncLocalStorage, not a global).
+  let releaseUiCall;
+  const uiGate = new Promise((resolve) => { releaseUiCall = resolve; });
+  const uiCall = runInUiOriginCallContext(async () => {
+    await uiGate;
+    return isInsideUiOriginCall();
+  });
+  const interleavedAgentFlag = isInsideUiOriginCall();
+  releaseUiCall();
+  assert.strictEqual(interleavedAgentFlag, false, 'concurrent non-UI code must not inherit the UI context');
+  assert.strictEqual(await uiCall, true, 'UI-origin call keeps its context across interleaving');
+
+  console.log('ok: UI-origin call context');
+}
+
 export default async function runTests() {
   const originalConfig = await configManager.getConfig();
 
@@ -133,6 +172,7 @@ export default async function runTests() {
     await testCapturePathRespectsStringFALSE();
     await testCapturePathRespectsBooleanFalse();
     await testCapturePathAllowsTrueValues();
+    await testUiOriginCallContext();
 
     console.log('\nTelemetry handling tests passed.');
     return true;


### PR DESCRIPTION
The preview widget now renders every file type from its own read_file RPC call (origin:'ui'), which the host passes through untouched:

- Reads pull at tool-input time (tool-result never arrives for images); mutations (write_file/edit_block, inferred from arg shape since the host doesn't send the tool name) pull at tool-result time, after the file changed.
- Image bytes return as a base64 text block on ui reads - an image content block would make the host inline-render the RPC response and stall it.
- structuredContent is returned only on origin:'ui' calls and is metadata-only (fileName/filePath/fileType/editor metadata/mimeType): no content duplication, no sourceTool (the widget stamps that client-side for telemetry). LLM-facing responses carry content[] only.
- An 8s timeout bounds the RPC pull and a 10s watchdog replaces a stuck "Preparing preview..." with a failure row instead of spinning forever.
- read_file directory listings drop the "use list_directory instead" hint on ui reads so it doesn't render as a notice in the directory preview.

Tests updated to the new contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File previews now adapt to request origin: the UI view receives metadata-only structured info (file type/name/path, image mimeType), while non-UI responses provide text/content payloads.
  * PDF/image/text preview formatting is more consistent, separating preview text from metadata across the read/edit flow.
* **Bug Fixes**
  * Improved preview rendering by pulling read results in a more reliable, pull-based way, with better timeout/watchdog recovery and fewer stale loading states.
* **Tests**
  * Updated read/edit preview tests to match the new origin-dependent structured/contents contract and payload extraction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->