### PR TITLE
Show welcome page for all clients except DC app and remote contexts

### DIFF
--- a/src/remote-device/desktop-commander-integration.ts
+++ b/src/remote-device/desktop-commander-integration.ts
@@ -2,7 +2,7 @@ import { spawn } from 'child_process';
 import path from 'path';
 import fs from 'fs/promises';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { StdioClientTransport, getDefaultEnvironment } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { fileURLToPath } from 'url';
 import { captureRemote } from '../utils/capture.js';
 
@@ -35,7 +35,13 @@ export class DesktopCommanderIntegration {
 
         try {
             console.debug('[DEBUG] Creating StdioClientTransport');
-            this.mcpTransport = new StdioClientTransport(config);
+            // DC_REMOTE_DEVICE tells the spawned server it is serving remote
+            // services, so it suppresses local-only behavior like opening the
+            // welcome page in a browser the remote user would never see.
+            this.mcpTransport = new StdioClientTransport({
+                ...config,
+                env: { ...getDefaultEnvironment(), ...config.env, DC_REMOTE_DEVICE: 'true' }
+            });
 
             // Create MCP client
             console.debug('[DEBUG] Creating MCP Client');

--- a/src/server.ts
+++ b/src/server.ts
@@ -217,6 +217,7 @@ server.setRequestHandler(InitializeRequestSchema, async (request: InitializeRequ
             // spawned by the remote-device wrapper and a locally opened browser
             // would never reach the remote user.
             if (currentClient.name !== 'desktop-commander-app'
+                && currentClient.name !== 'desktop-commander'
                 && !isRemoteClientContext(currentClient.name)
                 && !(global as any).disableOnboarding) {
                 await handleWelcomePageOnboarding(currentClient.name);

--- a/src/server.ts
+++ b/src/server.ts
@@ -170,6 +170,16 @@ function setCurrentRemoteClient(clientInfo: { name?: string; version?: string } 
 }
 
 /**
+ * True when this server instance is serving remote services rather than a
+ * local MCP client. The remote-device wrapper marks the server it spawns with
+ * DC_REMOTE_DEVICE=true (see remote-device/desktop-commander-integration.ts);
+ * the client-name check covers older wrappers that predate the env marker.
+ */
+function isRemoteClientContext(clientName?: string): boolean {
+    return process.env.DC_REMOTE_DEVICE === 'true' || clientName === 'desktop-commander-client';
+}
+
+/**
  * Unified way to update client information
  */
 async function updateCurrentClient(clientInfo: { name?: string, version?: string }) {
@@ -202,11 +212,14 @@ server.setRequestHandler(InitializeRequestSchema, async (request: InitializeRequ
         if (clientInfo) {
             await updateCurrentClient(clientInfo);
 
-            // Welcome page for new claude-ai users (A/B test controlled)
-            // Also matches 'local-agent-mode-*' which is how Claude.ai connectors report themselves
-            // and 'claude-code' (the Claude Code CLI)
-            if ((currentClient.name === 'claude-ai' || currentClient.name === 'claude-code' || currentClient.name?.startsWith('local-agent-mode')) && !(global as any).disableOnboarding) {
-                await handleWelcomePageOnboarding();
+            // Welcome page for new users (A/B test controlled) — all clients except
+            // the Desktop Commander app and remote contexts, where the server is
+            // spawned by the remote-device wrapper and a locally opened browser
+            // would never reach the remote user.
+            if (currentClient.name !== 'desktop-commander-app'
+                && !isRemoteClientContext(currentClient.name)
+                && !(global as any).disableOnboarding) {
+                await handleWelcomePageOnboarding(currentClient.name);
             }
         }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -204,7 +204,8 @@ server.setRequestHandler(InitializeRequestSchema, async (request: InitializeRequ
 
             // Welcome page for new claude-ai users (A/B test controlled)
             // Also matches 'local-agent-mode-*' which is how Claude.ai connectors report themselves
-            if ((currentClient.name === 'claude-ai' || currentClient.name?.startsWith('local-agent-mode')) && !(global as any).disableOnboarding) {
+            // and 'claude-code' (the Claude Code CLI)
+            if ((currentClient.name === 'claude-ai' || currentClient.name === 'claude-code' || currentClient.name?.startsWith('local-agent-mode')) && !(global as any).disableOnboarding) {
                 await handleWelcomePageOnboarding();
             }
         }

--- a/src/utils/open-browser.ts
+++ b/src/utils/open-browser.ts
@@ -40,7 +40,10 @@ export async function openBrowser(url: string): Promise<void> {
 /**
  * Open the Desktop Commander welcome page
  */
-export async function openWelcomePage(): Promise<void> {
-  const url = 'https://desktopcommander.app/welcome/';
+export async function openWelcomePage(clientName?: string): Promise<void> {
+  // utm_source is auto-captured by the welcome page's PostHog (and GA4), so
+  // web analytics can segment by MCP client without any web-side changes.
+  const url = 'https://desktopcommander.app/welcome/'
+    + (clientName ? `?utm_source=${encodeURIComponent(clientName)}` : '');
   await openBrowser(url);
 }

--- a/src/utils/welcome-onboarding.ts
+++ b/src/utils/welcome-onboarding.ts
@@ -13,7 +13,7 @@ import { capture } from './capture.js';
  * 2. Users in the 'showOnboardingPage' A/B variant
  * 3. Haven't seen it yet
  */
-export async function handleWelcomePageOnboarding(): Promise<void> {
+export async function handleWelcomePageOnboarding(clientName?: string): Promise<void> {
   // Check if this is a new install pending A/B decision
   // This flag is set when config is first created and survives process restarts
   const pending = await configManager.getValue('pendingWelcomeOnboarding');
@@ -56,7 +56,7 @@ export async function handleWelcomePageOnboarding(): Promise<void> {
   }
 
   try {
-    await openWelcomePage();
+    await openWelcomePage(clientName);
     await configManager.setValue('sawOnboardingPage', true);
     await configManager.setValue('pendingWelcomeOnboarding', false);
     capture('server_welcome_page_opened', { success: true });


### PR DESCRIPTION
## Summary

Widens the welcome-page onboarding from an allow-list (`claude-ai`, `claude-code`, `local-agent-mode-*`) to **all MCP clients**, excluding only:

- `desktop-commander-app` (the DC desktop app has its own onboarding)
- **remote contexts** — the server spawned by the remote-device wrapper, where opening a local browser would never reach the actual (remote) user

Remote detection is belt-and-suspenders: the wrapper now sets `DC_REMOTE_DEVICE=true` when spawning the local server (covers any remote service regardless of client name), with the wrapper's hardcoded `desktop-commander-client` client name as fallback for already-deployed wrappers that predate the env marker.

## Client attribution

The redirect now appends a single query param — `https://desktopcommander.app/welcome/?utm_source=<client-name>`. The site's PostHog auto-captures `utm_source`, so welcome pageviews are segmentable by MCP client with **zero web-side changes**. Server telemetry (`server_welcome_page_ab_decision` / `server_welcome_page_opened`) already carries `client_name` via `capture()`.

## Testing

Verified with a stdio harness simulating fresh installs (throwaway `$HOME`, real flag fetch, real A/B assignment):

- ✅ new client (`cursor`, `harness-test`) → browser opens with `?utm_source=<name>`, config flags flip
- ✅ `desktop-commander-app` → skipped, no browser
- ✅ `desktop-commander-client` (old-wrapper fallback) → skipped
- ✅ any client + `DC_REMOTE_DEVICE=true` → skipped
- ✅ end-to-end: test pageview with `utm_source=harness-test` arrived in the PostHog insight above
- ✅ compiled `dist/` contains the env marker in both wrapper and server

Existing gates unchanged: `pendingWelcomeOnboarding` (new installs only), `OnboardingPreTool` A/B flag (currently 100% show), `--no-onboarding` flag.

Note: this widens the funnel to clients like Cursor/Windsurf/VS Code — `utm_source` will show exactly what mix we get.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted welcome/onboarding display so it only triggers in the intended client contexts, reducing unexpected prompts.
  * The welcome page now includes source-specific tracking when a client name is available, while preserving the default behavior when it isn’t.
  * Remote desktop sessions now receive the correct environment settings (including remote context), improving recognition of remote execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->