### PR TITLE
Capture host environment signals on MCP initialize

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import {
     CallToolRequestSchema,
@@ -209,7 +210,19 @@ server.setRequestHandler(InitializeRequestSchema, async (request: InitializeRequ
             }
         }
 
-        capture('run_server_mcp_initialized');
+        // Raw host environment signals (no PII, undefined when absent). Some
+        // hosts share a clientInfo name — Claude Code CLI, Claude Code inside
+        // the Claude Desktop app, and Cowork all report 'claude-code' — and
+        // these let analytics tell them apart without client-specific
+        // branching in code. Verified signatures: CLI → entrypoint 'cli';
+        // CC-in-desktop → entrypoint 'claude-desktop'; Cowork → no
+        // entrypoint/agent, plugin id 'desktop-commander-inline'.
+        capture('run_server_mcp_initialized', {
+            host_entrypoint: process.env.CLAUDE_CODE_ENTRYPOINT,
+            host_agent: process.env.AI_AGENT,
+            host_plugin_id: process.env.CLAUDE_PLUGIN_DATA
+                ? path.basename(process.env.CLAUDE_PLUGIN_DATA) : undefined
+        });
 
         // Negotiate protocol version with client
         const requestedVersion = request.params?.protocolVersion;

--- a/src/server.ts
+++ b/src/server.ts
@@ -217,11 +217,14 @@ server.setRequestHandler(InitializeRequestSchema, async (request: InitializeRequ
         // branching in code. Verified signatures: CLI → entrypoint 'cli';
         // CC-in-desktop → entrypoint 'claude-desktop'; Cowork → no
         // entrypoint/agent, plugin id 'desktop-commander-inline'.
+        // Values truncated to GA4's 100-char param limit (same convention as
+        // containerName/containerImage) so an oversized value can never get
+        // the whole event rejected.
         capture('run_server_mcp_initialized', {
-            host_entrypoint: process.env.CLAUDE_CODE_ENTRYPOINT,
-            host_agent: process.env.AI_AGENT,
+            host_entrypoint: process.env.CLAUDE_CODE_ENTRYPOINT?.substring(0, 100),
+            host_agent: process.env.AI_AGENT?.substring(0, 100),
             host_plugin_id: process.env.CLAUDE_PLUGIN_DATA
-                ? path.basename(process.env.CLAUDE_PLUGIN_DATA) : undefined
+                ? path.basename(process.env.CLAUDE_PLUGIN_DATA).substring(0, 100) : undefined
         });
 
         // Negotiate protocol version with client


### PR DESCRIPTION
## Summary

Telemetry-only change, no behavior impact. Claude Code CLI, Claude Code inside the Claude Desktop app, and Cowork **all report `clientInfo.name = 'claude-code'`**, so `client_name` alone cannot attribute initializes to the actual host.

Adds three raw, non-PII environment signals to the existing `run_server_mcp_initialized` event (no new event types):

| Property | Source env var | CC CLI | CC in Desktop app | Cowork | Other clients |
|---|---|---|---|---|---|
| `host_entrypoint` | `CLAUDE_CODE_ENTRYPOINT` | `cli` | `claude-desktop` | — | — |
| `host_agent` | `AI_AGENT` | `claude-code_<v>_harness` | `claude-code_<v>_harness` | — | — |
| `host_plugin_id` | basename of `CLAUDE_PLUGIN_DATA` | plugin id or — | `desktop-commander-inline` | `desktop-commander-inline` | — |

No client-specific branching in code — raw values are captured and segmentation happens in analytics:

```sql
CASE
  WHEN host_entrypoint = 'cli'            THEN 'claude-code-cli'
  WHEN host_entrypoint = 'claude-desktop' THEN 'claude-code-in-desktop-app'
  WHEN host_plugin_id  = 'desktop-commander-inline' THEN 'cowork'
  ELSE 'claude-code-other'
END
```

## Testing

Verified end-to-end against production BigQuery telemetry with one controlled initialize per host (fresh client id each): all three contexts produced distinct signatures; non-Claude clients (e.g. `codex-mcp-client`) send no extra fields. Only the basename of `CLAUDE_PLUGIN_DATA` is captured — no user paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved initialization reporting by enriching the telemetry event with contextual environment details (entrypoint, agent, and plugin identifier) and truncating values for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->