### PR TITLE
feat(telemetry): drop all telemetry for UI-origin tool calls

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -68,7 +68,7 @@ import { toolHistory } from './utils/toolHistory.js';
 import { handleWelcomePageOnboarding } from './utils/welcome-onboarding.js';
 
 import { VERSION } from './version.js';
-import { capture, capture_call_tool } from "./utils/capture.js";
+import { capture, capture_call_tool, runInUiOriginCallContext } from "./utils/capture.js";
 import { logToStderr, logger } from './utils/logger.js';
 import {
     buildUiToolMeta,
@@ -1211,6 +1211,21 @@ import * as handlers from './handlers/index.js';
 import { ServerResult } from './types.js';
 
 server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest): Promise<ServerResult> => {
+    const args = request.params.arguments;
+    // Calls fired programmatically by the widget UIs (file preview, config
+    // editor) carry origin:'ui'. They are real tool executions but not agent
+    // actions, so they must produce zero telemetry: running them inside the
+    // UI-origin capture context makes capture() drop every event they raise
+    // (server_call_tool, server_read_file, server_edit_block, ...). Deliberate
+    // UI interactions are tracked separately via mcp_ui_event.
+    const isUiOriginCall = !!(args && typeof args === 'object' && (args as any).origin === 'ui');
+    if (isUiOriginCall) {
+        return runInUiOriginCallContext(() => handleCallToolRequest(request));
+    }
+    return handleCallToolRequest(request);
+});
+
+async function handleCallToolRequest(request: CallToolRequest): Promise<ServerResult> {
     const { name, arguments: args } = request.params;
     const startTime = Date.now();
     // Hoisted above the try so the finally block can read them when emitting the
@@ -1252,18 +1267,6 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
 
         if (name === 'set_config_value' && args && typeof args === 'object' && 'key' in args) {
             telemetryData.set_config_value_key_name = (args as any).key;
-            telemetryData.call_origin = (args as any).origin === 'ui' ? 'ui' : 'llm';
-        }
-        // Attribute file-surface tool calls to the file-preview UI vs the LLM.
-        // The UI passes origin:'ui' when it fires these tools to refresh/navigate
-        // (pagination, folder expansion, link resolution, in-preview edits); the
-        // first read_file that opens a file comes from the LLM and is recorded as
-        // 'llm'. Lets us separate UI-refresh churn from genuine model-driven reads.
-        if (
-            (name === 'read_file' || name === 'write_file' || name === 'edit_block' || name === 'list_directory') &&
-            args && typeof args === 'object'
-        ) {
-            telemetryData.call_origin = (args as any).origin === 'ui' ? 'ui' : 'llm';
         }
         if (name === 'get_prompts' && args && typeof args === 'object') {
             const promptArgs = args as any;
@@ -1640,13 +1643,19 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
         // Single tool-call telemetry event, fired AFTER execution so it can carry
         // timing. In a finally so it still fires on the hard-crash path (the catch
         // above). Only missed if a tool never returns or throws (a true hang).
-        capture_call_tool('server_call_tool', {
-            ...telemetryData,
-            duration_ms: Date.now() - startTime,
-            is_error: String(isError),
-        });
+        // Not emitted for track_ui_event (it is just the transport for
+        // mcp_ui_event) — and UI-origin calls are dropped wholesale by the
+        // capture layer, so server_call_tool reflects only genuine
+        // agent-driven tool calls.
+        if (name !== 'track_ui_event') {
+            capture_call_tool('server_call_tool', {
+                ...telemetryData,
+                duration_ms: Date.now() - startTime,
+                is_error: String(isError),
+            });
+        }
     }
-});
+}
 
 // Add no-op handlers so Visual Studio initialization succeeds
 server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => ({ resourceTemplates: [] }));

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -1,7 +1,11 @@
 import { z } from "zod";
 
 // Config tools schemas
-export const GetConfigArgsSchema = z.object({});
+export const GetConfigArgsSchema = z.object({
+  // 'ui' marks calls the config-editor widget fires programmatically; they are
+  // excluded from tool-call telemetry (see isUiOriginCall in server.ts).
+  origin: z.enum(['ui', 'llm']).optional(),
+});
 
 export const SetConfigValueArgsSchema = z.object({
   key: z.string(),
@@ -12,6 +16,7 @@ export const SetConfigValueArgsSchema = z.object({
     z.array(z.string()),
     z.null(),
   ]),
+  // 'ui' marks widget-fired calls; excluded from tool-call telemetry.
   origin: z.enum(['ui', 'llm']).optional(),
 });
 
@@ -24,6 +29,9 @@ export const StartProcessArgsSchema = z.object({
   timeout_ms: z.number(),
   shell: z.string().optional(),
   verbose_timing: z.boolean().optional(),
+  // 'ui' marks widget-fired calls (e.g. open-in-folder/editor buttons);
+  // excluded from tool-call telemetry (see isUiOriginCall in server.ts).
+  origin: z.enum(['ui', 'llm']).optional(),
 });
 
 export const ReadProcessOutputArgsSchema = z.object({
@@ -54,7 +62,8 @@ export const ReadFileArgsSchema = z.object({
   range: z.string().optional(),
   options: z.record(z.any()).optional(),
   // Whether the call came from the file-preview UI (refresh/navigation) or the
-  // LLM. Used only for telemetry attribution; see call_origin in server.ts.
+  // LLM. 'ui' calls are excluded from tool-call telemetry; see isUiOriginCall
+  // in server.ts.
   origin: z.enum(['ui', 'llm']).optional(),
 });
 
@@ -66,7 +75,8 @@ export const WriteFileArgsSchema = z.object({
   path: z.string(),
   content: z.string(),
   mode: z.enum(['rewrite', 'append']).default('rewrite'),
-  // Telemetry attribution: 'ui' when fired by the file-preview UI, else 'llm'.
+  // 'ui' when fired by the file-preview UI, else 'llm'. 'ui' calls are
+  // excluded from tool-call telemetry; see isUiOriginCall in server.ts.
   origin: z.enum(['ui', 'llm']).optional(),
 });
 
@@ -116,7 +126,8 @@ export const CreateDirectoryArgsSchema = z.object({
 export const ListDirectoryArgsSchema = z.object({
   path: z.string(),
   depth: z.number().optional().default(2),
-  // Telemetry attribution: 'ui' when fired by the file-preview UI, else 'llm'.
+  // 'ui' when fired by the file-preview UI, else 'llm'. 'ui' calls are
+  // excluded from tool-call telemetry; see isUiOriginCall in server.ts.
   origin: z.enum(['ui', 'llm']).optional(),
 });
 
@@ -144,7 +155,8 @@ export const EditBlockArgsSchema = z.object({
   range: z.string().optional(),
   content: z.any().optional(),
   options: z.record(z.any()).optional(),
-  // Telemetry attribution: 'ui' when fired by the file-preview UI, else 'llm'.
+  // 'ui' when fired by the file-preview UI, else 'llm'. 'ui' calls are
+  // excluded from tool-call telemetry; see isUiOriginCall in server.ts.
   origin: z.enum(['ui', 'llm']).optional(),
 }).refine(
   data => {
@@ -191,6 +203,9 @@ export const StartSearchArgsSchema = z.object({
   timeout_ms: z.number().optional(), // Match process naming convention
   earlyTermination: z.boolean().optional(), // Stop search early when exact filename match is found (default: true for files, false for content)
   literalSearch: z.boolean().optional().default(false), // Force literal string matching (-F flag) instead of regex
+  // 'ui' marks widget-fired calls (e.g. markdown link-target search);
+  // excluded from tool-call telemetry (see isUiOriginCall in server.ts).
+  origin: z.enum(['ui', 'llm']).optional(),
 });
 
 export const GetMoreSearchResultsArgsSchema = z.object({

--- a/src/ui/config-editor/src/app.ts
+++ b/src/ui/config-editor/src/app.ts
@@ -470,7 +470,7 @@ export function createConfigEditorController(callTool: ToolCall, trackConfigUiEv
                 }),
             });
 
-            const refreshed = await callTool('get_config', {});
+            const refreshed = await callTool('get_config', { origin: 'ui' });
             if (isToolErrorResult(refreshed)) {
                 const errorMessage = extractToolText(refreshed) ?? 'Value was updated but config refresh failed.';
                 return {
@@ -827,8 +827,6 @@ export function bootstrapConfigEditorApp(): void {
         expanded: true,
     };
 
-    let configEditorShownEventSent = false;
-
     let quietContextSupported = true;
     let tooltipHideTimer: number | null = null;
 
@@ -924,20 +922,11 @@ export function bootstrapConfigEditorApp(): void {
         controller.setPayload(payload);
         widgetState.write(payload);
         scheduleRender();
-
-        if (!configEditorShownEventSent) {
-            configEditorShownEventSent = true;
-            // One-shot impression event for get_config UI card visibility.
-            trackConfigUiEvent('config_editor_shown', {
-                tool_name: GET_CONFIG_TOOL_NAME,
-                entry_count: payload.entries.length,
-            });
-        }
     };
 
     const refreshConfigFromServer = async (): Promise<void> => {
         try {
-            const result = await bridge.callTool('get_config', {});
+            const result = await bridge.callTool('get_config', { origin: 'ui' });
             const payload = controller.extractPayload(result);
             if (payload) {
                 applyPayload(payload);

--- a/src/ui/file-preview/src/app.ts
+++ b/src/ui/file-preview/src/app.ts
@@ -26,7 +26,6 @@ import type { HtmlPreviewMode } from './types.js';
 
 let isExpanded = false;
 let hideSummaryRow = false;
-let previewShownFired = false;
 let onRender: (() => void) | undefined;
 let trackUiEvent: ((event: string, params?: Record<string, unknown>) => void) | undefined;
 let conflictDialogController: ConflictDialogController | undefined;
@@ -443,13 +442,6 @@ export function renderApp(
         onRender,
     });
     onRender?.();
-    if (!previewShownFired) {
-        previewShownFired = true;
-        trackUiEvent?.('preview_shown', {
-            file_type: payload.fileType,
-            file_extension: fileExtension,
-        });
-    }
 }
 
 export function bootstrapApp(): void {

--- a/src/ui/file-preview/src/directory-controller.ts
+++ b/src/ui/file-preview/src/directory-controller.ts
@@ -171,7 +171,7 @@ export function attachDirectoryHandlers(options: {
             const command = options.buildOpenInFolderCommand(openPath);
             if (command) {
                 try {
-                    await options.callTool?.('start_process', { command, timeout_ms: 12000 });
+                    await options.callTool?.('start_process', { command, timeout_ms: 12000, origin: 'ui' });
                 } catch {
                     // Keep UI stable if opening folder fails.
                 }

--- a/src/ui/file-preview/src/markdown/controller.ts
+++ b/src/ui/file-preview/src/markdown/controller.ts
@@ -496,6 +496,7 @@ export function createMarkdownController(dependencies: MarkdownControllerDepende
             maxResults: 20,
             earlyTermination: false,
             literalSearch: true,
+            origin: 'ui',
         });
         const text = extractToolText(result) ?? '';
         const filePaths = parseFileSearchResults(text);

--- a/src/ui/file-preview/src/panel-actions.ts
+++ b/src/ui/file-preview/src/panel-actions.ts
@@ -121,7 +121,7 @@ export function attachPanelActions(options: {
                     file_extension: fileExtension,
                 });
                 try {
-                    await options.callTool?.('start_process', { command, timeout_ms: 12000 });
+                    await options.callTool?.('start_process', { command, timeout_ms: 12000, origin: 'ui' });
                 } catch {
                     // Keep UI stable if opening folder fails.
                 }
@@ -141,7 +141,7 @@ export function attachPanelActions(options: {
                     file_extension: fileExtension,
                 });
                 try {
-                    await options.callTool?.('start_process', { command, timeout_ms: 12000 });
+                    await options.callTool?.('start_process', { command, timeout_ms: 12000, origin: 'ui' });
                 } catch {
                     // Keep UI stable if opening editor fails.
                 }

--- a/src/utils/capture.ts
+++ b/src/utils/capture.ts
@@ -1,7 +1,24 @@
 import { platform } from 'os';
 import * as https from 'https';
+import { AsyncLocalStorage } from 'async_hooks';
 import { configManager, isTelemetryDisabledValue } from '../config-manager.js';
 import { currentClient, currentCallIsRemote, currentRemoteClient } from '../server.js';
+
+// Execution context for tool calls fired programmatically by the widget UIs
+// (file preview, config editor), marked by args.origin === 'ui'. While code
+// runs inside this context, capture() drops every event, so UI refresh churn
+// (pull-by-path reads, in-preview saves, folder expansion, link search, ...)
+// produces zero telemetry. AsyncLocalStorage (rather than a module-level flag)
+// keeps attribution correct when a widget call interleaves with an agent call.
+const uiOriginCallContext = new AsyncLocalStorage<boolean>();
+
+export function runInUiOriginCallContext<T>(fn: () => T): T {
+    return uiOriginCallContext.run(true, fn);
+}
+
+export function isInsideUiOriginCall(): boolean {
+    return uiOriginCallContext.getStore() === true;
+}
 
 let VERSION = 'unknown';
 try {
@@ -463,6 +480,11 @@ const postTelemetryPayload = async (endpoint: string, payload: string): Promise<
 // can be silently dropped. If we need delivery guarantees on short-lived paths,
 // expose an awaitable variant or flush-before-exit hook.
 export const capture = async (event: string, properties?: any) => {
+    // Tool calls fired programmatically by the widget UIs must produce zero
+    // telemetry — drop every event raised while serving one.
+    if (isInsideUiOriginCall()) {
+        return;
+    }
     void (async () => {
         try {
             const eventProperties = await buildEventProperties(properties);

--- a/test/test-telemetry-handling.js
+++ b/test/test-telemetry-handling.js
@@ -5,6 +5,7 @@ import {
   isTelemetryDisabledValue,
   normalizeTelemetryEnabledValue,
 } from '../dist/config-manager.js';
+import { isInsideUiOriginCall, runInUiOriginCallContext } from '../dist/utils/capture.js';
 import { setConfigValue } from '../dist/tools/config.js';
 
 function testTelemetryHelpers() {
@@ -122,6 +123,44 @@ async function testCapturePathAllowsTrueValues() {
   console.log('ok: capture path allows true values');
 }
 
+/**
+ * Tool calls fired programmatically by the widget UIs (args.origin === 'ui')
+ * run inside runInUiOriginCallContext, and capture() drops every event raised
+ * while isInsideUiOriginCall() is true — so UI refresh churn (pull-by-path
+ * reads, in-preview saves, link search) produces zero telemetry. This verifies
+ * the AsyncLocalStorage mechanics that invariant depends on: the flag holds
+ * across awaits, does not leak out, and does not bleed into interleaved calls.
+ */
+async function testUiOriginCallContext() {
+  console.log('\n--- Test: UI-origin call context (zero telemetry for widget calls) ---');
+
+  assert.strictEqual(isInsideUiOriginCall(), false, 'context should be off outside runInUiOriginCallContext');
+
+  const observed = await runInUiOriginCallContext(async () => {
+    const beforeAwait = isInsideUiOriginCall();
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    return { beforeAwait, afterAwait: isInsideUiOriginCall() };
+  });
+  assert.strictEqual(observed.beforeAwait, true, 'context should be on inside runInUiOriginCallContext');
+  assert.strictEqual(observed.afterAwait, true, 'context should survive awaits');
+  assert.strictEqual(isInsideUiOriginCall(), false, 'context should not leak after the wrapped call returns');
+
+  // An agent call interleaving with an in-flight UI-origin call must not
+  // inherit the UI flag (this is why it is AsyncLocalStorage, not a global).
+  let releaseUiCall;
+  const uiGate = new Promise((resolve) => { releaseUiCall = resolve; });
+  const uiCall = runInUiOriginCallContext(async () => {
+    await uiGate;
+    return isInsideUiOriginCall();
+  });
+  const interleavedAgentFlag = isInsideUiOriginCall();
+  releaseUiCall();
+  assert.strictEqual(interleavedAgentFlag, false, 'concurrent non-UI code must not inherit the UI context');
+  assert.strictEqual(await uiCall, true, 'UI-origin call keeps its context across interleaving');
+
+  console.log('ok: UI-origin call context');
+}
+
 export default async function runTests() {
   const originalConfig = await configManager.getConfig();
 
@@ -133,6 +172,7 @@ export default async function runTests() {
     await testCapturePathRespectsStringFALSE();
     await testCapturePathRespectsBooleanFalse();
     await testCapturePathAllowsTrueValues();
+    await testUiOriginCallContext();
 
     console.log('\nTelemetry handling tests passed.');
     return true;


### PR DESCRIPTION
Tool calls fired programmatically by the widget UIs (file preview, config editor) carry origin:'ui'. They are real tool executions but not agent actions, so they now produce zero telemetry:

- capture.ts: run UI-origin calls inside an AsyncLocalStorage context; capture() drops every event raised inside it, including deep per-tool events (server_read_file, server_edit_block, server_search_files_*, server_start_process) without threading origin through signatures.
- server.ts: wrap the tool-call handler to enter that context, remove the now-dead call_origin attribution, and stop emitting server_call_tool for track_ui_event (it is just the transport for mcp_ui_event, which was double-counting every widget interaction).
- UI: remove the automatic preview_shown / config_editor_shown impression events; tag the previously unmarked widget calls (get_config refreshes, open-in-folder/editor start_process, markdown link-search start_search) with origin:'ui', declaring the field on those schemas so the unsupported-parameter warning does not fire.

User-interaction ui events (expand, copy_clicked, markdown_saved, ...) and local-only records (tool-call log, get_recent_tool_calls history, usage stats) are unchanged.