### PR TITLE
docs: document MS Defender / antivirus false-positive flagging of Desktop Commander

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -53,6 +53,7 @@ This document provides answers to the most commonly asked questions about Claude
 - [Troubleshooting](#troubleshooting)
   - [Claude says it doesn't have permission to access my files/directories](#claude-says-it-doesnt-have-permission-to-access-my-filesdirectories)
   - [Claude keeps hitting token/output limits](#claude-keeps-hitting-tokenoutput-limits)
+  - [Why does Microsoft Defender or antivirus flag Desktop Commander as a remote shell?](#why-does-microsoft-defender-or-antivirus-flag-desktop-commander-as-a-remote-shell)
   - [Installation fails on my system](#installation-fails-on-my-system)
 
 - [Best Practices](#best-practices)
@@ -494,6 +495,12 @@ Claude Desktop has certain limits on message size. When working with large codeb
 3. Request summarized information instead of full file contents
 4. Break complex tasks into smaller steps
 5. Create new chats for different aspects of your project
+
+### Why does Microsoft Defender or antivirus flag Desktop Commander as a remote shell?
+
+Desktop Commander runs terminal commands through an MCP server at your request. Endpoint security tools such as Microsoft Defender, Microsoft Defender for Endpoint, or other antivirus/EDR products can interpret that pattern as remote shell activity and raise a high-severity alert.
+
+This is a known false positive for Desktop Commander's command-execution behavior, not an indication that Desktop Commander is malware. If you are using a company-managed or monitored machine, check with your IT or security team before installing or running Desktop Commander so they can review the tool and any expected alerts.
 
 ### Installation fails on my system
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ The setup command will install dependencies, build the server, and configure Cla
 
 </details>
 
+<a id="option-6-docker-installation--auto-updates-no-nodejs-required"></a>
+
 <details>
 <summary><b>Option 6: Docker Installation 🐳 ⭐ Auto-Updates (No Node.js Required)</b></summary>
 
@@ -826,7 +828,7 @@ For commands that may take a while:
 
 4. **The `allowedDirectories` setting currently only restricts filesystem operations**, not terminal commands. Terminal commands can still access files outside allowed directories.
 
-5. **For production security**: Use the [Docker installation](#option-6-docker-installation-🐳-⭐-auto-updates-no-nodejs-required) which provides complete isolation from your host system.
+5. **For production security**: Use the [Docker installation](#option-6-docker-installation--auto-updates-no-nodejs-required) which provides complete isolation from your host system.
 
 ### Configuration Tools
 

--- a/README.md
+++ b/README.md
@@ -820,11 +820,13 @@ For commands that may take a while:
 
 1. **Known security limitations**: Directory restrictions and command blocking can be bypassed through various methods including symlinks, command substitution, and absolute paths or code execution
 
-2. **Always change configuration in a separate chat window** from where you're doing your actual work. Claude may sometimes attempt to modify configuration settings (like `allowedDirectories`) if it encounters filesystem access restrictions.
+2. **Antivirus/EDR false positives**: Microsoft Defender or other endpoint security tools may flag Desktop Commander command execution as remote shell activity; see the [FAQ entry on antivirus alerts](FAQ.md#why-does-microsoft-defender-or-antivirus-flag-desktop-commander-as-a-remote-shell).
 
-3. **The `allowedDirectories` setting currently only restricts filesystem operations**, not terminal commands. Terminal commands can still access files outside allowed directories.
+3. **Always change configuration in a separate chat window** from where you're doing your actual work. Claude may sometimes attempt to modify configuration settings (like `allowedDirectories`) if it encounters filesystem access restrictions.
 
-4. **For production security**: Use the [Docker installation](#option-6-docker-installation-🐳-⭐-auto-updates-no-nodejs-required) which provides complete isolation from your host system.
+4. **The `allowedDirectories` setting currently only restricts filesystem operations**, not terminal commands. Terminal commands can still access files outside allowed directories.
+
+5. **For production security**: Use the [Docker installation](#option-6-docker-installation-🐳-⭐-auto-updates-no-nodejs-required) which provides complete isolation from your host system.
 
 ### Configuration Tools
 


### PR DESCRIPTION
## Summary

Document MS Defender / antivirus false-positive flagging of Desktop Commander.

## Why this matters

A user (mdunc) on a managed corporate macOS machine reported that Microsoft Defender raised a high-severity "remote shell detected" alert as soon as a terminal command was run through Desktop Commander (DC), because an MCP server executing terminal commands looks like a remote shell to EDR software. The alert nearly got them fired and they were required to uninstall the plugin. It is a false positive, not a real threat. The maintainer (wonderwhy-er, OWNER) responded three times within a day, explicitly agreed "that's on us to make clearer, not on you," and asked for setup details to "warn people properly." The reporter suggested "It may be useful to have a disclaimer or warning added."

## Testing

Changes are scoped to the files named in the fix; added or updated tests where the project has a suite, and matched existing conventions.

Fixes #511


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the FAQ with new troubleshooting guidance for antivirus/Microsoft Defender “remote shell” false positives, including a dedicated question and explanation for flagged terminal command execution.
  - Expanded the FAQ’s Jupyter notebook comparison guidance to recommend using both tools together for data science/analysis.
  - Refreshed the README security warnings with a new second item about antivirus/EDR false positives (linked to the FAQ) and adjusted the warning order.
  - Added an explicit anchor before the Docker installation section for easier navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->