### PR TITLE
fix: restrict markdown link navigation to safe URI schemes

### DIFF
--- a/src/ui/file-preview/src/markdown/linking.ts
+++ b/src/ui/file-preview/src/markdown/linking.ts
@@ -17,6 +17,7 @@ interface ParsedWikiLink {
 
 const WIKI_LINK_PATTERN = /\[\[([^\]|#]*)(?:#([^\]|]+))?(?:\|([^\]]+))?\]\]/g;
 const FENCE_PATTERN = /^(`{3,}|~{3,})/;
+const ALLOWED_EXTERNAL_SCHEMES = new Set(['http', 'https', 'mailto', 'ftp']);
 
 function encodeLinkPath(pathValue: string): string {
     return encodeURI(normalizePathSeparators(pathValue));
@@ -182,7 +183,16 @@ function fromFileUrl(url: URL): string {
 }
 
 function isExternalHref(rawHref: string): boolean {
-    return /^[A-Za-z][A-Za-z0-9+.-]*:/.test(rawHref) && !isWindowsAbsolutePath(rawHref);
+    if (isWindowsAbsolutePath(rawHref)) {
+        return false;
+    }
+
+    const match = rawHref.match(/^([A-Za-z][A-Za-z0-9+.-]*):/);
+    if (!match) {
+        return false;
+    }
+
+    return ALLOWED_EXTERNAL_SCHEMES.has(match[1].toLowerCase());
 }
 
 function resolveFileTargetPath(currentPath: string, rawPath: string): string {

--- a/test/test-markdown-preview.js
+++ b/test/test-markdown-preview.js
@@ -93,11 +93,32 @@ async function testLinkResolution() {
     anchor: 'Intro',
   });
 
+  assert.deepStrictEqual(resolveMarkdownLink(currentPath, '/relative/path'), {
+    kind: 'file',
+    href: '/relative/path',
+    targetPath: '/relative/path',
+  });
+
   assert.deepStrictEqual(resolveMarkdownLink(currentPath, 'https://example.com/docs'), {
     kind: 'external',
     href: 'https://example.com/docs',
     url: 'https://example.com/docs',
   });
+
+  for (const href of ['http://example.com/docs', 'HTTPS://example.com/docs', 'mailto:a@b.com', 'ftp://example.com/docs']) {
+    assert.deepStrictEqual(resolveMarkdownLink(currentPath, href), {
+      kind: 'external',
+      href,
+      url: href,
+    });
+  }
+
+  for (const href of ['javascript:alert(1)', 'data:text/html,<h1>x</h1>', 'vbscript:msgbox(1)', 'file:///etc/passwd', 'blob:https://x']) {
+    const resolved = resolveMarkdownLink(currentPath, href);
+    assert.strictEqual(resolved.kind, 'file', `${href} should not resolve as an external link`);
+    assert.strictEqual(resolved.href, href);
+    assert.strictEqual(resolved.url, undefined, `${href} should not expose an external URL`);
+  }
 
   assert.deepStrictEqual(resolveMarkdownLink(currentPath, '[[Meeting Notes#Action Items|Actions]]'), {
     kind: 'file',


### PR DESCRIPTION
## Summary

Restrict markdown link navigation to safe URI schemes.

## Why this matters

In `src/ui/file-preview/src/markdown/linking.ts`, `isExternalHref()` classifies any
href with a scheme-like prefix as external via `/^[A-Za-z][A-Za-z0-9+.-]*:/`. That regex
matches `javascript:`, `data:`, `vbscript:`, `file:`, and `blob:` just as readily as
`https:`. A link classified `kind: 'external'` is handed straight to the external-open
path in `controller.ts` (`resolveMarkdownLink` is called at controller.ts:704). The fix
relies on browsers blocking `javascript:` in `window.open()`, which is a downstream
assumption rather than an explicit guarantee. Replacing the open regex with an explicit
safe-scheme allowlist removes that dependency.

## Testing

Changes are scoped to the files named in the fix; added or updated tests where the project has a suite, and matched existing conventions.

Fixes #508


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link handling in markdown previews so only common external links are treated as external.
  * Non-web and potentially unsafe link formats are now handled as regular file links instead of being misclassified.
  * Relative paths in markdown links are now resolved more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->