### PR TITLE
fix: require explicit write_file mode when target file has content

### DIFF
--- a/src/handlers/filesystem-handlers.ts
+++ b/src/handlers/filesystem-handlers.ts
@@ -290,7 +290,32 @@ export async function handleReadMultipleFiles(args: unknown): Promise<ServerResu
  */
 export async function handleWriteFile(args: unknown): Promise<ServerResult> {
     try {
+        const modeProvided = !!(args && typeof args === 'object' && 'mode' in args);
         const parsed = WriteFileArgsSchema.parse(args);
+
+        // An omitted `mode` falls back to 'rewrite', which silently destroys
+        // the target's existing content. The common failure is an LLM caller
+        // intending to append but dropping the optional param (issue #541), so
+        // require explicit intent when the target already has content;
+        // new/empty files keep the zero-friction default.
+        if (!modeProvided) {
+            let existing: Record<string, any> | null = null;
+            try {
+                existing = await getFileInfo(parsed.path);
+            } catch {
+                // Missing file or invalid path — nothing to protect; the write
+                // itself will surface any real path error.
+            }
+            if (existing?.isFile && existing.size > 0) {
+                return createErrorResponse(
+                    `Write rejected to prevent accidental data loss: ${parsed.path} already exists ` +
+                    `with content (${existing.size} bytes), and no 'mode' was specified — the default ` +
+                    `mode 'rewrite' would REPLACE the entire file. Retry with an explicit mode: ` +
+                    `'append' to add your content to the end of the existing file, or 'rewrite' ` +
+                    `to replace all existing content.`
+                );
+            }
+        }
 
         // Get the line limit from configuration
         const config = await configManager.getConfig();


### PR DESCRIPTION
An omitted `mode` falls back to the schema default 'rewrite', which silently replaces the entire file. LLM callers might drop the optional param on an intended append, destroying existing content (reported in #541). Reject writes to existing non-empty files when `mode` is not explicitly provided, with an error that tells the model to retry with 'append' or 'rewrite'. Creating new or empty files keeps the zero-friction default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Writing to an existing file now requires an explicit overwrite choice, helping prevent accidental data loss.
  * If no write mode is provided and the file already contains content, the operation is blocked with an error instead of replacing the file automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->