### PR TITLE
fix(pdf): make write_pdf Chrome acquisition self-healing and fail clearly

### DIFF
--- a/src/tools/pdf/markdown.ts
+++ b/src/tools/pdf/markdown.ts
@@ -12,6 +12,8 @@ const isUrl = (source: string): boolean =>
 // Cached Chrome path to avoid repeated lookups
 let cachedChromePath: string | undefined | null = null; // null = not checked yet
 let chromeCheckPromise: Promise<string | undefined> | null = null;
+// Last Chrome acquisition error, surfaced to the caller when PDF generation can't proceed.
+let lastChromeError: string | undefined;
 
 interface CachedPuppeteerChrome {
     executablePath: string;
@@ -174,7 +176,19 @@ async function installChrome(): Promise<CachedPuppeteerChrome> {
     
     const cacheDir = getPuppeteerCacheDir();
     const platform = detectBrowserPlatform()!;
-    const buildId = await resolveBuildId(Browser.CHROME, platform, 'stable');
+    // Prefer the exact Chrome build pinned by the bundled puppeteer-core so the
+    // downloaded browser is guaranteed compatible with the launcher md-to-pdf uses.
+    // Fall back to the current stable channel if the pin can't be read.
+    let buildId: string;
+    try {
+        const { PUPPETEER_REVISIONS } = await import('puppeteer-core/internal/revisions.js');
+        const pinned = PUPPETEER_REVISIONS?.chrome as string | undefined;
+        buildId = pinned && pinned !== 'latest'
+            ? pinned
+            : await resolveBuildId(Browser.CHROME, platform, 'stable');
+    } catch {
+        buildId = await resolveBuildId(Browser.CHROME, platform, 'stable');
+    }
     
     console.error('Downloading Chrome for PDF generation (this may take a few minutes)...');
     await fs.mkdir(cacheDir, { recursive: true });
@@ -234,10 +248,15 @@ async function getChromePath(): Promise<string | undefined> {
             const installedChrome = await installChrome();
             await pruneOldPuppeteerChromeBuilds(installedChrome.executablePath);
             cachedChromePath = installedChrome.executablePath;
+            lastChromeError = undefined;
             return installedChrome.executablePath;
         } catch (error) {
+            // Do NOT cache undefined here. A transient failure (offline, proxy, or a
+            // locked-down network) must not permanently disable PDF generation for the
+            // lifetime of the process. Leaving cachedChromePath as null lets the next
+            // write_pdf call retry the download instead of short-circuiting forever.
+            lastChromeError = error instanceof Error ? error.message : String(error);
             console.error('Failed to install Chrome:', error);
-            cachedChromePath = undefined;
             return undefined;
         }
     })();
@@ -289,15 +308,26 @@ export async function parseMarkdownToPdf(markdown: string, options: any = {}): P
         // Find Chrome: puppeteer cache -> system Chrome -> install
         const chromePath = await getChromePath();
         
-        if (chromePath) {
-            options = {
-                ...options,
-                launch_options: {
-                    ...options.launch_options,
-                    executablePath: chromePath,
-                }
-            };
+        if (!chromePath) {
+            // Do not silently fall through to md-to-pdf's bundled Puppeteer. It resolves
+            // a different (pinned) Chrome build in a different cache directory that
+            // Desktop Commander never populates, which surfaces to the user as an opaque
+            // "Failed to launch the browser process". Fail with an actionable message.
+            const detail = lastChromeError ? ` (last error: ${lastChromeError})` : '';
+            throw new Error(
+                'PDF generation requires Chrome, and Desktop Commander could not find or ' +
+                `download it${detail}. Install Google Chrome from ` +
+                'https://www.google.com/chrome/ and try again.'
+            );
         }
+
+        options = {
+            ...options,
+            launch_options: {
+                ...options.launch_options,
+                executablePath: chromePath,
+            }
+        };
         
         const pdf = await mdToPdf({ content: markdown }, options);
 


### PR DESCRIPTION
## Problem

`write_pdf` could fail with an opaque **"Failed to launch the browser process"** on machines without system Chrome — even though the codebase *does* have logic to download Chrome automatically. Investigation on a Windows box (with the Puppeteer-pinned Chrome build removed to simulate a fresh machine) traced it to three combining issues:

1. **Build/cache mismatch.** `installChrome()` downloaded the **`stable`** Chrome-for-Testing build into Desktop Commander's **private** cache, while `md-to-pdf`'s bundled Puppeteer looks for a **different, pinned** build in the **default** cache (`~/.cache/puppeteer`). The two resolution paths never aligned, so DC's own install could never satisfy the fallback.
2. **Sticky failure.** On any install failure, `getChromePath()` cached `undefined` for the entire process lifetime. A single transient failure (offline, proxy, locked-down network) **permanently disabled** PDF generation until restart — no retry.
3. **Silent broken fallback.** When `getChromePath()` returned `undefined`, `parseMarkdownToPdf` silently omitted `executablePath` and let `md-to-pdf` fall through to bundled Puppeteer, which hunts for the pinned build in a cache DC never populates → the opaque launch error the user actually sees.

The auto-fetch mechanism itself works (verified: downloads a working Chrome in ~19s). The failures came from these three gaps around it.

## Fixes (all in `src/tools/pdf/markdown.ts`)

- **Install the pinned build.** `installChrome()` now resolves the Chrome build **pinned by the co-bundled `puppeteer-core`** (via `PUPPETEER_REVISIONS`), falling back to the `stable` channel if the pin can't be read. The downloaded browser is now guaranteed compatible with the launcher and lives where it's expected.
- **Self-healing retry.** Stop caching `undefined` on install failure. Leaving the cache unset lets the next `write_pdf` retry the download instead of short-circuiting forever.
- **Actionable error.** Replace the silent bundled-Puppeteer fallback with a clear error that names the underlying install failure reason, instead of the opaque "Failed to launch the browser process".

## Verification

- Auto-fetch downloads a working Chrome (~19s) and now targets the **pinned** build (confirmed the resolver returns the co-bundled `puppeteer-core` pin rather than drifting `stable`).
- `npm run build` compiles clean (no TS errors).
- `read_file`/`write_file`/`edit_block`/`list_directory`/PDF read + write all continue to work on Windows.

## Notes

- No behavior change on the happy path (system Chrome present, or Chrome already cached): DC still passes an explicit `executablePath` and PDFs generate as before.
- This is independent of the v0.2.43 → next release content; it fixes a latent packaging/robustness issue in PDF creation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF export reliability when Chrome is unavailable.
  * PDF generation now returns a clearer error message with more detail about launch or install failures.
  * Browser detection can retry after a failed install instead of permanently treating Chrome as missing.
  * Chrome selection now more consistently uses the expected pinned version, with a fallback to the stable channel when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->