### PR TITLE
docs: clarify process timeout limits

### DIFF
--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -26,7 +26,9 @@ export const ListProcessesArgsSchema = z.object({});
 // Terminal tools schemas
 export const StartProcessArgsSchema = z.object({
   command: z.string(),
-  timeout_ms: z.number(),
+  timeout_ms: z.number().describe(
+    'Maximum time to wait for initial process state, in milliseconds. Some MCP clients impose their own shorter per-tool-call limits. For long-running work, start the process with a small timeout and poll read_process_output rather than relying on a large timeout.'
+  ),
   shell: z.string().optional(),
   verbose_timing: z.boolean().optional(),
   // 'ui' marks widget-fired calls (e.g. open-in-folder/editor buttons);


### PR DESCRIPTION
## Summary
- clarify that `start_process.timeout_ms` controls the initial process-state wait
- note that MCP clients may impose stricter per-call limits
- point long-running work to a short startup wait plus `read_process_output`

## Why
A client-specific cap can make a large `timeout_ms` appear ineffective. The parameter schema did not explain this or provide a reliable polling workflow.

## Validation
- `npm.cmd run build`
- verified the compiled Zod schema exposes the new description

Fixes #447

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the process startup timeout represents the maximum wait for the initial state.
  * Added guidance to poll for long-running processes instead of using extended startup timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->