### PR TITLE
fix: redact sensitive tool-call log values

### DIFF
--- a/src/utils/trackTools.ts
+++ b/src/utils/trackTools.ts
@@ -6,6 +6,99 @@ import { TOOL_CALL_FILE, TOOL_CALL_FILE_MAX_SIZE } from '../config.js';
 const logDir = path.dirname(TOOL_CALL_FILE);
 await fs.promises.mkdir(logDir, { recursive: true });
 
+const LOG_FILE_MODE = 0o600;
+
+const REDACTED_KEY_FRAGMENTS = [
+  'command',
+  'cmd',
+  'args',
+  'arguments',
+  'content',
+  'filetext',
+  'text',
+  'body',
+  'input',
+  'markdown',
+  'message',
+  'value',
+  'val',
+  'newstring',
+  'oldstring',
+  'env',
+  'environment',
+  'password',
+  'passwd',
+  'secret',
+  'token',
+  'credential',
+  'key',
+  'apikey',
+  'privatekey',
+  'authorization',
+  'cookie',
+];
+
+function normalizeArgumentKey(key: string): string {
+  return key.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+function shouldRedactArgument(key: string): boolean {
+  const normalized = normalizeArgumentKey(key);
+  return REDACTED_KEY_FRAGMENTS.some(fragment => normalized.includes(fragment));
+}
+
+function redactionMarker(value: unknown): string {
+  let length = 0;
+  if (typeof value === 'string') {
+    length = value.length;
+  } else if (value !== null && value !== undefined) {
+    try {
+      length = JSON.stringify(value)?.length ?? 0;
+    } catch {
+      length = 0;
+    }
+  }
+  return `[REDACTED:${typeof value}:${length}chars]`;
+}
+
+/**
+ * Return a copy of tool arguments with command, content, and credential values
+ * replaced while retaining non-sensitive metadata for audit troubleshooting.
+ */
+export function sanitizeArgsForLog(args: unknown): unknown {
+  if (args === null || args === undefined || typeof args !== 'object') {
+    return args;
+  }
+  if (Array.isArray(args)) {
+    return args.map(sanitizeArgsForLog);
+  }
+
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(args as Record<string, unknown>)) {
+    if (shouldRedactArgument(key)) {
+      sanitized[key] = redactionMarker(value);
+    } else {
+      sanitized[key] = sanitizeArgsForLog(value);
+    }
+  }
+  return sanitized;
+}
+
+async function ensureLogFilePermissions(): Promise<void> {
+  const handle = await fs.promises.open(TOOL_CALL_FILE, 'a', LOG_FILE_MODE);
+  await handle.close();
+  await fs.promises.chmod(TOOL_CALL_FILE, LOG_FILE_MODE);
+}
+
+// Tighten permissions on an existing log before any new entries are written.
+// A failure here must not prevent the server from starting; each write retries
+// the check and is skipped by the existing error path if it still cannot be secured.
+try {
+  await ensureLogFilePermissions();
+} catch (error) {
+  console.error(`Error securing tool-call log: ${error instanceof Error ? error.message : String(error)}`);
+}
+
 /**
  * Track tool calls and save them to a log file
  * @param toolName Name of the tool being called
@@ -16,8 +109,11 @@ export async function trackToolCall(toolName: string, args?: unknown): Promise<v
     // Get current timestamp
     const timestamp = new Date().toISOString();
     
-    // Format the log entry
-    const logEntry = `${timestamp} | ${toolName.padEnd(20, ' ')}${args ? `\t| Arguments: ${JSON.stringify(args)}` : ''}\n`;
+    // Format the log entry without persisting command text, file contents, or credentials.
+    const safeArgs = args != null ? sanitizeArgsForLog(args) : null;
+    const logEntry = `${timestamp} | ${toolName.padEnd(20, ' ')}${safeArgs ? `\t| Arguments: ${JSON.stringify(safeArgs)}` : ''}\n`;
+
+    await ensureLogFilePermissions();
 
     // Check if file exists and get its size
     let fileSize = 0;
@@ -45,7 +141,10 @@ export async function trackToolCall(toolName: string, args?: unknown): Promise<v
     }
     
     // Append to log file (if file was renamed, this will create a new file)
-    await fs.promises.appendFile(TOOL_CALL_FILE, logEntry, 'utf8');
+    await fs.promises.appendFile(TOOL_CALL_FILE, logEntry, {
+      encoding: 'utf8',
+      mode: LOG_FILE_MODE,
+    });
     
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);

--- a/test/test-tool-call-log-security.js
+++ b/test/test-tool-call-log-security.js
@@ -1,0 +1,115 @@
+import assert from 'assert';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+async function runTests() {
+  const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'desktop-commander-log-test-'));
+  const previousHome = process.env.HOME;
+  const previousUserProfile = process.env.USERPROFILE;
+  const previousUmask = process.umask(0);
+
+  try {
+    process.env.HOME = tempHome;
+    process.env.USERPROFILE = tempHome;
+
+    const logDir = path.join(tempHome, '.claude-server-commander');
+    const logPath = path.join(logDir, 'claude_tool_call.log');
+    await fs.mkdir(logDir, { recursive: true });
+    await fs.writeFile(logPath, 'existing log\n', { mode: 0o644 });
+
+    const { sanitizeArgsForLog, trackToolCall } = await import('../dist/utils/trackTools.js');
+
+    if (process.platform !== 'win32') {
+      const existingMode = (await fs.stat(logPath)).mode & 0o777;
+      assert.equal(existingMode, 0o600, 'existing tool-call logs must be tightened to owner-only access');
+    }
+
+    const originalArgs = {
+      command: 'curl -H "Authorization: Bearer command-secret" https://example.test',
+      content: 'file-content-secret',
+      path: '/tmp/example.txt',
+      timeout_ms: 30000,
+      nested: {
+        apiKey: 'api-key-secret',
+        password: 'password-secret',
+        headers: { Authorization: 'Bearer authorization-secret' },
+        signing_key: 'signing-key-secret',
+        fileContent: 'nested-content-secret',
+        safe: 'visible',
+      },
+      env: { SERVICE_TOKEN: 'environment-secret' },
+      items: [{ refresh_token: 'refresh-token-secret', count: 2 }],
+    };
+
+    const sanitized = sanitizeArgsForLog(originalArgs);
+    const serialized = JSON.stringify(sanitized);
+
+    for (const secret of [
+      'command-secret',
+      'file-content-secret',
+      'api-key-secret',
+      'password-secret',
+      'authorization-secret',
+      'signing-key-secret',
+      'nested-content-secret',
+      'environment-secret',
+      'refresh-token-secret',
+    ]) {
+      assert(!serialized.includes(secret), `sanitized arguments must not contain ${secret}`);
+    }
+
+    assert.equal(sanitized.path, '/tmp/example.txt');
+    assert.equal(sanitized.timeout_ms, 30000);
+    assert.equal(sanitized.nested.safe, 'visible');
+    assert.equal(sanitized.items[0].count, 2);
+    assert.match(sanitized.command, /^\[REDACTED:string:\d+chars\]$/);
+    assert.match(sanitized.nested.apiKey, /^\[REDACTED:string:\d+chars\]$/);
+    assert.match(sanitized.nested.signing_key, /^\[REDACTED:string:\d+chars\]$/);
+    assert.match(sanitized.nested.fileContent, /^\[REDACTED:string:\d+chars\]$/);
+    assert.match(sanitized.env, /^\[REDACTED:object:\d+chars\]$/);
+    assert.equal(originalArgs.content, 'file-content-secret', 'sanitization must not mutate caller arguments');
+
+    await fs.rm(logPath);
+    await trackToolCall('write_file', originalArgs);
+
+    const log = await fs.readFile(logPath, 'utf8');
+    assert(log.includes('write_file'));
+    assert(log.includes('/tmp/example.txt'));
+    assert(log.includes('"timeout_ms":30000'));
+    assert(log.includes('[REDACTED:string:'));
+
+    for (const secret of [
+      'command-secret',
+      'file-content-secret',
+      'api-key-secret',
+      'password-secret',
+      'authorization-secret',
+      'signing-key-secret',
+      'nested-content-secret',
+      'environment-secret',
+      'refresh-token-secret',
+    ]) {
+      assert(!log.includes(secret), `tool-call log must not contain ${secret}`);
+    }
+
+    if (process.platform !== 'win32') {
+      const mode = (await fs.stat(logPath)).mode & 0o777;
+      assert.equal(mode, 0o600, 'new tool-call logs must be created with owner-only access');
+    }
+
+    console.log('Tool-call log security tests passed');
+  } finally {
+    process.umask(previousUmask);
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    if (previousUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = previousUserProfile;
+    await fs.rm(tempHome, { recursive: true, force: true });
+  }
+}
+
+runTests().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

- redact command, content, environment, and credential values before writing tool-call audit entries
- retain non-sensitive metadata such as paths, timeouts, and counters
- create new audit logs with owner-only permissions and tighten existing log permissions

## Root cause

Tool-call arguments were serialized directly into `claude_tool_call.log`, so command text, file contents, and nested credentials could be stored in plaintext. Log creation also relied on the process umask.

## Validation

- `npm run build`
- `npm test` — 45/45 passed
- `npm run test:integration` — 3/3 passed
- `node test/test-tool-call-log-security.js`

Fixes #506


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Sensitive tool-call arguments are now redacted in logs, including nested values.
  * Tool-call log files use owner-only permissions to help protect recorded data.
  * Non-sensitive metadata remains available for troubleshooting.

* **Bug Fixes**
  * Improved log writing reliability with explicit text encoding and permission settings.

* **Tests**
  * Added coverage verifying secret redaction, data preservation, immutability, and log-file permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->