### PR TITLE
Codex/exclude claude welcome page

### DIFF
--- a/src/config-manager.ts
+++ b/src/config-manager.ts
@@ -83,6 +83,16 @@ class ConfigManager {
         const configData = await fs.readFile(this.configPath, 'utf8');
         this.config = JSON.parse(configData);
         this._isFirstRun = false;
+
+        // Configs created before this marker existed must not receive the
+        // welcome page retroactively when client eligibility changes later.
+        // New configs get this field from getDefaultConfig() and remain
+        // eligible across restarts until their first initialization.
+        if (this.config['welcomeOnboardingEligible'] === undefined) {
+          this.config['welcomeOnboardingEligible'] = false;
+          this.config['pendingWelcomeOnboarding'] = false;
+          await this.saveConfig();
+        }
       } catch (error) {
         // Config file doesn't exist, create default
         this.config = this.getDefaultConfig();
@@ -173,7 +183,8 @@ class ConfigManager {
       telemetryEnabled: true, // Default to opt-out approach (telemetry on by default)
       fileWriteLineLimit: 50,  // Default line limit for file write operations (changed from 100)
       fileReadLineLimit: 1000,  // Default line limit for file read operations (changed from character-based)
-      pendingWelcomeOnboarding: true  // New install flag - triggers A/B test for welcome page
+      pendingWelcomeOnboarding: true, // New install flag - triggers A/B test for welcome page
+      welcomeOnboardingEligible: true // Distinguishes new installs from migrated legacy configs
     };
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -214,12 +214,13 @@ server.setRequestHandler(InitializeRequestSchema, async (request: InitializeRequ
             await updateCurrentClient(clientInfo);
 
             // Welcome page for new users (A/B test controlled) — all clients except
-            // the Desktop Commander app and remote contexts, where the server is
-            // spawned by the remote-device wrapper and a locally opened browser
-            // would never reach the remote user.
+            // the Desktop Commander app, remote contexts, and `claude-code`.
+            // Claude Code and Claude Cowork plugin sessions both identify as
+            // `claude-code` and provide their own onboarding surface.
             if (currentClient.name !== 'desktop-commander-app'
                 && currentClient.name !== 'desktop-commander'
                 && !isRemoteClientContext(currentClient.name)
+                && currentClient.name !== 'claude-code'
                 && !(global as any).disableOnboarding) {
                 await handleWelcomePageOnboarding(currentClient.name);
             }

--- a/src/server.ts
+++ b/src/server.ts
@@ -66,7 +66,7 @@ import { trackToolCall } from './utils/trackTools.js';
 import { usageTracker } from './utils/usageTracker.js';
 import { processDockerPrompt } from './utils/dockerPrompt.js';
 import { toolHistory } from './utils/toolHistory.js';
-import { handleWelcomePageOnboarding } from './utils/welcome-onboarding.js';
+import { handleWelcomePageOnboarding, skipWelcomePageOnboarding } from './utils/welcome-onboarding.js';
 
 import { VERSION } from './version.js';
 import { capture, capture_call_tool, runInUiOriginCallContext } from "./utils/capture.js";
@@ -214,15 +214,18 @@ server.setRequestHandler(InitializeRequestSchema, async (request: InitializeRequ
             await updateCurrentClient(clientInfo);
 
             // Welcome page for new users (A/B test controlled) — all clients except
-            // the Desktop Commander app, remote contexts, and `claude-code`.
-            // Claude Code and Claude Cowork plugin sessions both identify as
-            // `claude-code` and provide their own onboarding surface.
-            if (currentClient.name !== 'desktop-commander-app'
+            // the Desktop Commander app and remote contexts.
+            const isWelcomePageEligibleClient = currentClient.name !== 'desktop-commander-app'
                 && currentClient.name !== 'desktop-commander'
                 && !isRemoteClientContext(currentClient.name)
-                && currentClient.name !== 'claude-code'
-                && !(global as any).disableOnboarding) {
+                && !(global as any).disableOnboarding;
+
+            if (isWelcomePageEligibleClient) {
                 await handleWelcomePageOnboarding(currentClient.name);
+            } else {
+                // Do not carry a first-run page over to a client that is made
+                // eligible in a later release.
+                await skipWelcomePageOnboarding();
             }
         }
 

--- a/src/utils/welcome-onboarding.ts
+++ b/src/utils/welcome-onboarding.ts
@@ -5,6 +5,17 @@ import { openWelcomePage } from './open-browser.js';
 import { logToStderr } from './logger.js';
 import { capture } from './capture.js';
 
+/** Consume a pending welcome page when this client must never receive it. */
+export async function skipWelcomePageOnboarding(): Promise<void> {
+  const pending = await configManager.getValue('pendingWelcomeOnboarding');
+  if (!pending) {
+    return;
+  }
+
+  await configManager.setValue('pendingWelcomeOnboarding', false);
+  logToStderr('debug', 'Welcome page skipped for ineligible client');
+}
+
 /**
  * Handle welcome page display for new users (A/B test controlled)
  * 
@@ -14,6 +25,13 @@ import { capture } from './capture.js';
  * 3. Haven't seen it yet
  */
 export async function handleWelcomePageOnboarding(clientName?: string): Promise<void> {
+  // Existing configs are migrated to false. Only configs created with the
+  // eligibility marker may receive this welcome-page campaign.
+  const eligible = await configManager.getValue('welcomeOnboardingEligible');
+  if (!eligible) {
+    return;
+  }
+
   // Check if this is a new install pending A/B decision
   // This flag is set when config is first created and survives process restarts
   const pending = await configManager.getValue('pendingWelcomeOnboarding');

--- a/src/utils/welcome-onboarding.ts
+++ b/src/utils/welcome-onboarding.ts
@@ -13,7 +13,20 @@ export async function skipWelcomePageOnboarding(): Promise<void> {
   }
 
   await configManager.setValue('pendingWelcomeOnboarding', false);
-  logToStderr('debug', 'Welcome page skipped for ineligible client');
+  logToStderr('debug', 'Welcome page skipped');
+}
+
+function isWelcomePageClientExcluded(clientName?: string): boolean {
+  const configuredClients = featureFlagManager.get('welcome_page_excluded_clients', []);
+  if (!Array.isArray(configuredClients) || !clientName) {
+    return false;
+  }
+
+  const normalizedClientName = clientName.trim().toLowerCase();
+  return configuredClients.some(
+    (configuredClient) => typeof configuredClient === 'string'
+      && configuredClient.trim().toLowerCase() === normalizedClientName
+  );
 }
 
 /**
@@ -48,6 +61,20 @@ export async function handleWelcomePageOnboarding(clientName?: string): Promise<
   if (!loadedFromCache) {
     logToStderr('debug', 'Waiting for feature flags to load...');
     await featureFlagManager.waitForFreshFlags();
+  }
+
+  // Keep an MCP release compatible with an older flag document: only an
+  // explicit false disables. Absent or malformed values fail open so a flag
+  // file typo cannot permanently consume pending onboarding for new installs.
+  const enabled = featureFlagManager.get('welcome_page_enabled', true) !== false;
+  if (!enabled) {
+    await skipWelcomePageOnboarding();
+    return;
+  }
+
+  if (isWelcomePageClientExcluded(clientName)) {
+    await skipWelcomePageOnboarding();
+    return;
   }
 
   // Check A/B test assignment

--- a/test/test-welcome-onboarding-legacy-config.js
+++ b/test/test-welcome-onboarding-legacy-config.js
@@ -24,18 +24,26 @@ class ExistingConfigClaudeCodeMigrationTest {
     this.configPath = path.join(this.home, '.claude-server-commander', 'config.json');
   }
 
-  seedLegacyConfig() {
+  seedConfig(config, featureFlags) {
     mkdirSync(path.dirname(this.configPath), { recursive: true });
-    writeFileSync(this.configPath, JSON.stringify({
-      telemetryEnabled: false,
-      pendingWelcomeOnboarding: true,
-    }));
+    writeFileSync(this.configPath, JSON.stringify(config));
+    if (featureFlags) {
+      writeFileSync(
+        path.join(path.dirname(this.configPath), 'feature-flags.json'),
+        JSON.stringify({ version: 'test', flags: featureFlags })
+      );
+    }
   }
 
   async initializeAsClaudeCode() {
     await new Promise((resolve, reject) => {
       const child = spawn('node', [DIST_INDEX], {
-        env: { ...process.env, HOME: this.home, USERPROFILE: this.home },
+        env: {
+          ...process.env,
+          HOME: this.home,
+          USERPROFILE: this.home,
+          DC_FLAG_URL: 'http://127.0.0.1:9/',
+        },
         stdio: ['pipe', 'pipe', 'pipe'],
       });
       let stdout = '';
@@ -84,17 +92,41 @@ class ExistingConfigClaudeCodeMigrationTest {
   }
 }
 
-const test = new ExistingConfigClaudeCodeMigrationTest();
-try {
-  test.seedLegacyConfig();
-  await test.initializeAsClaudeCode();
-  const config = test.readConfig();
-  assert.equal(
-    config.pendingWelcomeOnboarding,
-    false,
-    'legacy Claude Code configs must consume pending welcome onboarding'
-  );
-  console.log('✓ Legacy Claude Code config does not retain pending welcome onboarding');
-} finally {
-  test.cleanup();
+async function runScenario(name, config, featureFlags) {
+  const test = new ExistingConfigClaudeCodeMigrationTest();
+  try {
+    test.seedConfig(config, featureFlags);
+    await test.initializeAsClaudeCode();
+    const resultConfig = test.readConfig();
+    assert.equal(
+      resultConfig.pendingWelcomeOnboarding,
+      false,
+      `${name} must consume pending welcome onboarding`
+    );
+    // The A/B control path also consumes pending but records sawOnboardingPage:
+    // false. Skip paths must resolve before the A/B decision and never touch it.
+    assert.equal(
+      resultConfig.sawOnboardingPage,
+      undefined,
+      `${name} must skip before the A/B decision, not via control assignment`
+    );
+    console.log(`✓ ${name}`);
+  } finally {
+    test.cleanup();
+  }
 }
+
+await runScenario(
+  'Legacy Claude Code config does not retain pending welcome onboarding',
+  { telemetryEnabled: false, pendingWelcomeOnboarding: true },
+);
+await runScenario(
+  'Disabled welcome-page feature flag consumes pending onboarding',
+  { telemetryEnabled: false, welcomeOnboardingEligible: true, pendingWelcomeOnboarding: true },
+  { welcome_page_enabled: false },
+);
+await runScenario(
+  'Configured Claude Code exclusion matches case-insensitively',
+  { telemetryEnabled: false, welcomeOnboardingEligible: true, pendingWelcomeOnboarding: true },
+  { welcome_page_enabled: true, welcome_page_excluded_clients: ['CLAUDE-CODE'] },
+);

--- a/test/test-welcome-onboarding-legacy-config.js
+++ b/test/test-welcome-onboarding-legacy-config.js
@@ -1,0 +1,100 @@
+/**
+ * Regression test for legacy pending welcome onboarding.
+ *
+ * A config created before welcome onboarding was enabled for Claude Code can
+ * still contain pendingWelcomeOnboarding: true. When the server is later
+ * initialized by Claude Code, that pending state must be consumed rather than
+ * causing a retroactive welcome page when eligibility changes in a release.
+ */
+
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DIST_INDEX = path.join(__dirname, '..', 'dist', 'index.js');
+const TIMEOUT_MS = 10_000;
+
+class ExistingConfigClaudeCodeMigrationTest {
+  constructor() {
+    this.home = mkdtempSync(path.join(os.tmpdir(), 'dc-welcome-legacy-'));
+    this.configPath = path.join(this.home, '.claude-server-commander', 'config.json');
+  }
+
+  seedLegacyConfig() {
+    mkdirSync(path.dirname(this.configPath), { recursive: true });
+    writeFileSync(this.configPath, JSON.stringify({
+      telemetryEnabled: false,
+      pendingWelcomeOnboarding: true,
+    }));
+  }
+
+  async initializeAsClaudeCode() {
+    await new Promise((resolve, reject) => {
+      const child = spawn('node', [DIST_INDEX], {
+        env: { ...process.env, HOME: this.home, USERPROFILE: this.home },
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      let stdout = '';
+      const timeout = setTimeout(() => finish(new Error('Timed out waiting for initialize response')), TIMEOUT_MS);
+
+      const finish = (error) => {
+        clearTimeout(timeout);
+        child.kill('SIGTERM');
+        error ? reject(error) : resolve();
+      };
+
+      child.stdout.on('data', (chunk) => {
+        stdout += chunk.toString();
+        let newline;
+        while ((newline = stdout.indexOf('\n')) >= 0) {
+          const line = stdout.slice(0, newline);
+          stdout = stdout.slice(newline + 1);
+          try {
+            const message = JSON.parse(line);
+            if (message.id === 1) finish();
+          } catch {
+            // Ignore non-protocol output.
+          }
+        }
+      });
+      child.on('error', finish);
+      child.stdin.write(`${JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'claude-code', version: 'test' },
+        },
+      })}\n`);
+    });
+  }
+
+  readConfig() {
+    return JSON.parse(readFileSync(this.configPath, 'utf8'));
+  }
+
+  cleanup() {
+    rmSync(this.home, { recursive: true, force: true });
+  }
+}
+
+const test = new ExistingConfigClaudeCodeMigrationTest();
+try {
+  test.seedLegacyConfig();
+  await test.initializeAsClaudeCode();
+  const config = test.readConfig();
+  assert.equal(
+    config.pendingWelcomeOnboarding,
+    false,
+    'legacy Claude Code configs must consume pending welcome onboarding'
+  );
+  console.log('✓ Legacy Claude Code config does not retain pending welcome onboarding');
+} finally {
+  test.cleanup();
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New installs are now eligible for the welcome onboarding A/B flow after first creation.
* **Bug Fixes**
  * Legacy configs are migrated to include the required onboarding fields.
  * Pending welcome onboarding state is now consistently consumed/cleared whenever onboarding is skipped (including for ineligible clients, when onboarding is disabled via feature flags, or for excluded clients).
  * Eligibility logic was adjusted to better handle client cases and feature-flag gating.
* **Tests**
  * Expanded regression coverage to verify pending state is cleared after initialization via the built server entrypoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->