### PR TITLE
fix: strip leading whitespace from tool descriptions using dedent utility

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -70,6 +70,7 @@ import { handleWelcomePageOnboarding } from './utils/welcome-onboarding.js';
 
 import { VERSION } from './version.js';
 import { capture, capture_call_tool, runInUiOriginCallContext } from "./utils/capture.js";
+import { dedent } from './utils/dedent.js';
 import { logToStderr, logger } from './utils/logger.js';
 import {
     buildUiToolMeta,
@@ -301,7 +302,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             // Configuration tools
             {
                 name: "get_config",
-                description: `
+                description: dedent`
                         Get the complete server configuration as JSON. Config includes fields for:
                         - blockedCommands (array of blocked shell commands)
                         - defaultShell (shell to use for commands)
@@ -323,7 +324,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             {
                 name: "set_config_value",
-                description: `
+                description: dedent`
                         Set a specific configuration value by key.
                         
                         WARNING: Should be used in a separate chat from file operations and 
@@ -353,7 +354,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             // Filesystem tools
             {
                 name: "read_file",
-                description: `
+                description: dedent`
                         Read contents from files and URLs.
                         Read PDF files and extract content as markdown and images.
                         
@@ -418,7 +419,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             {
                 name: "read_multiple_files",
-                description: `
+                description: dedent`
                         Read the contents of multiple files simultaneously.
                         
                         Each file's content is returned with its path as a reference.
@@ -438,7 +439,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             {
                 name: "write_file",
-                description: `
+                description: dedent`
                         Write or append to file contents.
 
                         IMPORTANT: DO NOT use this tool to create PDF files. Use 'write_pdf' for all PDF creation tasks.
@@ -487,7 +488,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             {
                 name: "write_pdf",
-                description: `
+                description: dedent`
                         Create a new PDF file or modify an existing one.
 
                         THIS IS THE ONLY TOOL FOR CREATING AND MODIFYING PDF FILES.
@@ -549,7 +550,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             {
                 name: "create_directory",
-                description: `
+                description: dedent`
                         Create a new directory or ensure a directory exists.
                         
                         Can create multiple nested directories in one operation.
@@ -566,7 +567,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             {
                 name: "list_directory",
-                description: `
+                description: dedent`
                         Get a detailed listing of all files and directories in a specified path.
                         
                         Use this instead of 'execute_command' with ls/dir commands.
@@ -606,7 +607,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             {
                 name: "move_file",
-                description: `
+                description: dedent`
                         Move or rename files and directories.
                         
                         Can move files between directories and rename them in a single operation.
@@ -624,7 +625,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             {
                 name: "start_search",
-                description: `
+                description: dedent`
                         Start a streaming search that can return results progressively.
                         
                         SEARCH STRATEGY GUIDE:
@@ -711,7 +712,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             {
                 name: "get_more_search_results",
-                description: `
+                description: dedent`
                         Get more results from an active search with offset-based pagination.
                         
                         Supports partial result reading with:
@@ -741,7 +742,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             {
                 name: "stop_search",
-                description: `
+                description: dedent`
                         Stop an active search.
                         
                         Stops the background search process gracefully. Use this when you've found
@@ -761,7 +762,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             {
                 name: "list_searches",
-                description: `
+                description: dedent`
                         List all active searches.
                         
                         Shows search IDs, search types, patterns, status, and runtime.
@@ -777,7 +778,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             {
                 name: "get_file_info",
-                description: `
+                description: dedent`
                         Retrieve detailed metadata about a file or directory including:
                         - size
                         - creation time
@@ -804,7 +805,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             // Editing tools
             {
                 name: "edit_block",
-                description: `
+                description: dedent`
                         Apply surgical edits to files.
 
                         BEST PRACTICE: Make multiple small, focused edits rather than one large edit.
@@ -870,7 +871,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             // Terminal tools
             {
                 name: "start_process",
-                description: `
+                description: dedent`
                         Start a new terminal process with intelligent state detection.
                         
                         PRIMARY TOOL FOR FILE ANALYSIS AND DATA PROCESSING
@@ -943,7 +944,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             {
                 name: "read_process_output",
-                description: `
+                description: dedent`
                         Read output from a running process with file-like pagination support.
                         
                         Supports partial output reading with offset and length parameters (like read_file):
@@ -984,7 +985,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             {
                 name: "interact_with_process",
-                description: `
+                description: dedent`
                         Send input to a running process and automatically receive the response.
                         
                         CRITICAL: THIS IS THE PRIMARY TOOL FOR ALL LOCAL FILE ANALYSIS
@@ -1051,7 +1052,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             {
                 name: "force_terminate",
-                description: `
+                description: dedent`
                         Force terminate a running terminal session.
                         
                         ${CMD_PREFIX_DESCRIPTION}`,
@@ -1065,7 +1066,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             {
                 name: "list_sessions",
-                description: `
+                description: dedent`
                         List all active terminal sessions.
                         
                         Shows session status including:
@@ -1087,7 +1088,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             {
                 name: "list_processes",
-                description: `
+                description: dedent`
                         List all running processes.
                         
                         Returns process information including PID, command name, CPU usage, and memory usage.
@@ -1101,7 +1102,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             {
                 name: "kill_process",
-                description: `
+                description: dedent`
                         Terminate a running process by PID.
 
                         Use with caution as this will forcefully terminate the specified process.
@@ -1117,7 +1118,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             {
                 name: "get_usage_stats",
-                description: `
+                description: dedent`
                         Get usage statistics for debugging and analysis.
                         
                         Returns summary of tool usage, success/failure rates, and performance metrics.
@@ -1131,7 +1132,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             {
                 name: "get_recent_tool_calls",
-                description: `
+                description: dedent`
                         Get recent tool call history with their arguments and outputs.
                         Returns chronological list of tool calls made during this session.
                         
@@ -1152,7 +1153,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             {
                 name: "give_feedback_to_desktop_commander",
-                description: `
+                description: dedent`
                         Open feedback form in browser to provide feedback about Desktop Commander.
                         
                         IMPORTANT: This tool simply opens the feedback form - no pre-filling available.
@@ -1194,7 +1195,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             {
                 name: "get_prompts",
-                description: `
+                description: dedent`
                         Retrieve a specific Desktop Commander onboarding prompt by ID and execute it.
                         
                         SIMPLIFIED ONBOARDING V2: This tool only supports direct prompt retrieval.

--- a/src/utils/dedent.ts
+++ b/src/utils/dedent.ts
@@ -1,0 +1,45 @@
+/**
+ * Remove common leading whitespace from a template literal string.
+ * This allows template literals to be indented with the code
+ * without including that indentation in the output.
+ */
+export function dedent(strings: TemplateStringsArray, ...values: any[]): string {
+    // Combine the template literal parts with interpolated values
+    let result = '';
+    for (let i = 0; i < strings.length; i++) {
+        result += strings[i];
+        if (i < values.length) {
+            result += values[i];
+        }
+    }
+
+    // Split into lines and find common leading whitespace
+    const lines = result.split('\n');
+
+    // Find the first non-empty line to determine base indentation
+    let minIndent = Infinity;
+    for (const line of lines) {
+        if (line.trim().length === 0) continue;
+        const match = line.match(/^(\s*)/);
+        if (match) {
+            const indent = match[1].length;
+            if (indent < minIndent) {
+                minIndent = indent;
+            }
+        }
+    }
+
+    // If no indented lines found, return as-is
+    if (minIndent === Infinity || minIndent === 0) {
+        return result.trim();
+    }
+
+    // Remove common leading whitespace from each line
+    const dedented = lines.map(line => {
+        if (line.trim().length === 0) return '';
+        return line.slice(minIndent);
+    });
+
+    // Join and trim leading/trailing whitespace
+    return dedented.join('\n').trim();
+}


### PR DESCRIPTION
## Summary

Closes #200

All tool descriptions in `server.ts` had excessive leading whitespace due to template literal indentation matching the surrounding code. This caused poor formatting when descriptions are displayed in MCP clients (e.g., AIShell, Claude Desktop).

## Changes

- Added `src/utils/dedent.ts` - a utility function that strips common leading whitespace from template literal strings
- Wrapped all 25 tool description template literals with `dedent` in `server.ts`

## How it works

The `dedent` function:
1. Combines template literal parts with interpolated values
2. Finds the minimum indentation across all non-empty lines
3. Strips that common indentation from each line
4. Trims leading/trailing whitespace

This keeps the code well-indented (matching surrounding code style) while producing clean output without excessive whitespace.

## Before / After

**Before** (description displayed to user):
``
                        Get the complete server configuration as JSON. Config includes fields for:
                        - blockedCommands (array of blocked shell commands)
                        ...```

**After**:`
Get the complete server configuration as JSON. Config includes fields for:
- blockedCommands (array of blocked shell commands)
...```

## Testing

- `npx tsc --noEmit` passes (no new errors - all existing errors are pre-existing missing type declarations for external modules)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved formatting and readability of tool descriptions.
  * Removed unnecessary indentation and surrounding whitespace from displayed descriptions.
  * Preserved existing tool names, schemas, and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->