### PR TITLE
Fix command blocklist bypasses and DoS in extractCommands

### DIFF
--- a/src/command-manager.ts
+++ b/src/command-manager.ts
@@ -2,13 +2,69 @@ import path from 'path';
 import {configManager} from './config-manager.js';
 import {capture} from "./utils/capture.js";
 
+// Thrown when nested $()/backtick/subshell parsing exceeds the depth limit.
+// Must propagate past extractCommands' own catch (rather than being swallowed
+// into a "no dangerous commands found" result) so validateCommand's fail-closed
+// handling denies the command instead of accidentally allowing it through.
+class CommandParsingLimitError extends Error {}
+
+const MAX_RECURSION_DEPTH = 20;
+
+// Matches a leading environment variable assignment, e.g. FOO=bar or FOO=
+const ENV_ASSIGNMENT_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*=/;
+
+// Splits a command string into whitespace-separated tokens, keeping quoted
+// segments (which may contain spaces, e.g. VAR="a b") intact as one token.
+function tokenizeRespectingQuotes(str: string): string[] {
+    const tokens: string[] = [];
+    let current = '';
+    let inQuote = false;
+    let quoteChar = '';
+    let escaped = false;
+
+    for (let i = 0; i < str.length; i++) {
+        const ch = str[i];
+
+        if (escaped) {
+            current += ch;
+            escaped = false;
+            continue;
+        }
+        if (ch === '\\') {
+            escaped = true;
+            current += ch;
+            continue;
+        }
+        if ((ch === '"' || ch === "'") && (!inQuote || ch === quoteChar)) {
+            inQuote = !inQuote;
+            quoteChar = inQuote ? ch : '';
+            current += ch;
+            continue;
+        }
+        if (!inQuote && /\s/.test(ch)) {
+            if (current) {
+                tokens.push(current);
+                current = '';
+            }
+            continue;
+        }
+        current += ch;
+    }
+    if (current) tokens.push(current);
+    return tokens;
+}
+
 class CommandManager {
 
     getBaseCommand(command: string) {
         return command.split(' ')[0].toLowerCase().trim();
     }
 
-    extractCommands(commandString: string): string[] {
+    extractCommands(commandString: string, depth: number = 0): string[] {
+        if (depth > MAX_RECURSION_DEPTH) {
+            capture('command_parser_depth_exceeded', { depth });
+            throw new CommandParsingLimitError('Command nesting depth exceeded maximum allowed limit');
+        }
         try {
             // Trim any leading/trailing whitespace
             commandString = commandString.trim();
@@ -60,14 +116,18 @@ class CommandManager {
                     const startIndex = i;
                     let openParens = 1;
                     let j = i + 2; // skip past $(
+                    let parenEscaped = false;
                     while (j < commandString.length && openParens > 0) {
-                        if (commandString[j] === '(') openParens++;
-                        if (commandString[j] === ')') openParens--;
+                        const pc = commandString[j];
+                        if (parenEscaped) { parenEscaped = false; j++; continue; }
+                        if (pc === '\\') { parenEscaped = true; j++; continue; }
+                        if (pc === '(') openParens++;
+                        if (pc === ')') openParens--;
                         j++;
                     }
                     if (j <= commandString.length && openParens === 0) {
                         const subContent = commandString.substring(i + 2, j - 1);
-                        const subCommands = this.extractCommands(subContent);
+                        const subCommands = this.extractCommands(subContent, depth + 1);
                         commands.push(...subCommands);
                         i = j - 1;
                         if (!inQuote) {
@@ -83,12 +143,17 @@ class CommandManager {
                 if (char === '`') {
                     const startIndex = i;
                     let j = i + 1;
-                    while (j < commandString.length && commandString[j] !== '`') {
+                    let backtickEscaped = false;
+                    while (j < commandString.length) {
+                        const bc = commandString[j];
+                        if (backtickEscaped) { backtickEscaped = false; j++; continue; }
+                        if (bc === '\\') { backtickEscaped = true; j++; continue; }
+                        if (bc === '`') break;
                         j++;
                     }
                     if (j < commandString.length) {
                         const subContent = commandString.substring(i + 1, j);
-                        const subCommands = this.extractCommands(subContent);
+                        const subCommands = this.extractCommands(subContent, depth + 1);
                         commands.push(...subCommands);
                         i = j;
                         if (!inQuote) {
@@ -111,9 +176,13 @@ class CommandManager {
                     // Find the matching closing parenthesis
                     let openParens = 1;
                     let j = i + 1;
+                    let subshellEscaped = false;
                     while (j < commandString.length && openParens > 0) {
-                        if (commandString[j] === '(') openParens++;
-                        if (commandString[j] === ')') openParens--;
+                        const sc = commandString[j];
+                        if (subshellEscaped) { subshellEscaped = false; j++; continue; }
+                        if (sc === '\\') { subshellEscaped = true; j++; continue; }
+                        if (sc === '(') openParens++;
+                        if (sc === ')') openParens--;
                         j++;
                     }
 
@@ -121,7 +190,7 @@ class CommandManager {
                     if (j <= commandString.length && openParens === 0) {
                         const subshellContent = commandString.substring(i + 1, j - 1);
                         // Recursively extract commands from the subshell
-                        const subCommands = this.extractCommands(subshellContent);
+                        const subCommands = this.extractCommands(subshellContent, depth + 1);
                         commands.push(...subCommands);
 
                         // Move position past the subshell
@@ -162,7 +231,13 @@ class CommandManager {
             // Remove duplicates and return
             return [...new Set(commands)];
         } catch (error) {
-            // If anything goes wrong, log the error but return the basic command to not break execution
+            // Depth-limit errors must propagate to validateCommand's fail-closed
+            // handling, not be swallowed into a seemingly-safe fallback result.
+            if (error instanceof CommandParsingLimitError) {
+                throw error;
+            }
+            // For genuine unexpected parse errors, log and fall back to the basic
+            // command so a malformed-but-benign input doesn't break execution.
             capture('server_request_error', {
                 error: 'Error extracting commands'
             });
@@ -174,30 +249,43 @@ class CommandManager {
     // This extracts the actual command name from a command string
     extractBaseCommand(commandStr: string): string | null {
         try {
-            // Remove environment variables (patterns like KEY=value)
-            const withoutEnvVars = commandStr.replace(/\w+=\S+\s*/g, '').trim();
+            // Strip leading environment variable assignments (KEY=value, including
+            // quoted values with spaces like KEY="a b") and 'export' prefixes, so
+            // e.g. "export PATH=/x rm -rf /" resolves to "rm", not "export".
+            const tokens = tokenizeRespectingQuotes(commandStr.trim());
+            let startIdx = 0;
+            while (startIdx < tokens.length) {
+                const token = tokens[startIdx];
+                if (token === 'export') {
+                    startIdx++;
+                    continue;
+                }
+                if (ENV_ASSIGNMENT_PATTERN.test(token)) {
+                    startIdx++;
+                    continue;
+                }
+                break;
+            }
 
             // If nothing remains after removing env vars, return null
-            if (!withoutEnvVars) return null;
+            if (startIdx >= tokens.length) return null;
 
-            // Get the first token (the command)
-            const tokens = withoutEnvVars.split(/\s+/);
             let firstToken = null;
 
             // Find the first valid token (skip variables)
-            for (let i = 0; i < tokens.length; i++) {
+            for (let i = startIdx; i < tokens.length; i++) {
                 const token = tokens[i];
-                
+
                 // Skip dollar-prefixed tokens (variables) but not $() command substitutions
                 if (token.startsWith('$') && !token.startsWith('$(')) {
                     continue;
                 }
-                
+
                 // Check if it starts with special characters like ( that might indicate it's not a regular command
                 if (token[0] === '(') {
                     continue;
                 }
-                
+
                 firstToken = token;
                 break;
             }

--- a/test/test-blocklist-bypass.js
+++ b/test/test-blocklist-bypass.js
@@ -54,6 +54,36 @@ async function runTests() {
         assert.ok(cmds8.includes('ls'), 'FAIL: should extract "ls" and ignore $MYVAR');
         assert.ok(!cmds8.includes('$MYVAR'), 'FAIL: should not include $MYVAR as a command');
 
+        // Test 9: 'export' prefix should not mask the real command
+        const cmds9 = commandManager.extractCommands('export PATH=/usr/bin rm -rf /');
+        console.log('  export PATH=/usr/bin rm -rf / =>', cmds9);
+        assert.ok(cmds9.includes('rm'), 'FAIL: should extract "rm" past an export prefix');
+        assert.ok(!cmds9.includes('export'), 'FAIL: should not extract "export" as the command');
+
+        // Test 10: quoted env var value (containing a space) should not desync tokenization
+        const cmds10 = commandManager.extractCommands('FOO="a b" rm -rf /');
+        console.log('  FOO="a b" rm -rf / =>', cmds10);
+        assert.ok(cmds10.includes('rm'), 'FAIL: should extract "rm" past a quoted env var value');
+
+        // Test 11: multiple leading env var assignments
+        const cmds11 = commandManager.extractCommands('A=1 B=2 rm -rf /');
+        console.log('  A=1 B=2 rm -rf / =>', cmds11);
+        assert.ok(cmds11.includes('rm'), 'FAIL: should extract "rm" past multiple env var assignments');
+
+        // Test 12: reasonable nesting still parses correctly (not affected by depth limit)
+        const cmds12 = commandManager.extractCommands('$($($(rm -rf /)))');
+        console.log('  $($($(rm -rf /))) =>', cmds12);
+        assert.ok(cmds12.includes('rm'), 'FAIL: should extract "rm" from reasonably nested $()');
+
+        // Test 13: excessive nesting depth must fail closed (throw) rather than
+        // silently returning an empty/incomplete result that could bypass validateCommand
+        const deeplyNested = '$('.repeat(25) + 'rm -rf /' + ')'.repeat(25);
+        assert.throws(
+            () => commandManager.extractCommands(deeplyNested),
+            'FAIL: should throw when nesting depth exceeds the limit, not fail open'
+        );
+        console.log('  25 levels of $() nesting => throws as expected (fail closed)');
+
         console.log('\nAll tests passed!');
     } catch (error) {
         console.error('Test failed:', error.message);


### PR DESCRIPTION
## Summary
- **Blocklist bypass (env-var/export prefix):** `export PATH=/x rm -rf /` and `FOO="a b" rm -rf /` previously resolved to a base command of `"export"` / garbage instead of `"rm"`, letting a blocked command straight through `validateCommand`. Fixed by rewriting the env-var stripping in `extractBaseCommand` to be prefix-only and quote-aware (handles `export`, and quoted values containing spaces), instead of a blanket regex over the whole string.
- **Blocklist bypass + DoS (unbounded recursion depth):** `extractCommands` recursed once per nesting level of `$()`/backticks/subshells with no depth limit. Sufficiently deep nesting (~10k+ levels, reachable with a plain unconstrained string, no size cap on the `command` field) exhausted the JS call stack; the resulting `RangeError` was silently swallowed by the catch block, which returned an empty command list that `validateCommand` treated as "nothing to check" — allowing a blocked command hidden inside the nesting through. It was also a straightforward CPU-exhaustion DoS (multi-second synchronous blocking on the single-threaded server) even without the bypass angle. Fixed by adding a max recursion depth (20) that throws instead of falling back silently — the error now propagates to `validateCommand`'s existing fail-closed handling (deny on error) rather than being absorbed into a fail-open result.
- **Parsing correctness (escape handling):** the `$()`/backtick/subshell delimiter scanners didn't account for escaped delimiters inside the scanned region, so an escaped backtick/paren could desync the parse boundary. Made all three scanners escape-aware.

## Test plan
- [x] Existing test suites (`test/test-blocklist-bypass.js`, `test/test-blocked-commands.js`) pass unchanged
- [x] Added regression tests to `test-blocklist-bypass.js` covering: `export` prefix, quoted env-var values, multiple assignments, reasonable nesting still works, and excessive nesting fails closed (throws) rather than silently bypassing
- [x] Manually verified via an isolated harness that both bypasses are closed and that deep-nesting cost dropped from multi-second CPU time to single-digit ms (fails fast now)
- [x] `tsc --noEmit` passes with no errors
- [x] Full `npm test` run: 42/44 passing; the 2 failures (`test-markdown-editor-edit-diff.js`, `test-markdown-editor-roundtrip.js`) are pre-existing and unrelated — confirmed they fail identically on unmodified `main` (missing `navigator` global for `prosemirror-view` in this Node environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved command parsing for quoted arguments, escaped characters, nested substitutions, and environment-variable assignments.
  - Enhanced handling of commands prefixed with `export` or multiple environment assignments.
  - Commands exceeding supported nesting limits now fail safely instead of being incorrectly accepted.
  - Preserved accurate extraction of commands from paths and nested substitutions.

- **Tests**
  - Added coverage for environment assignments, quoted values, nested substitutions, and excessive nesting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->