### PR TITLE
docs: fix remote device script names

### DIFF
--- a/src/remote-device/README.md
+++ b/src/remote-device/README.md
@@ -97,7 +97,7 @@ desktop-commander-device --persist-session
 npm run device:start
 ```
 
-*(Or direct from `src/remote-device`: `npm run device`)*
+Use the root project script so the device runs with the repository's TypeScript tooling.
 
 ### 2. Authenticate
 
@@ -143,7 +143,7 @@ For developers contributing to the device or debugging issues:
 
 **Run with Debug Logging**:
 ```bash
-npm run device:dev
+npm run device:start:dev
 ```
 This enables verbose logging and ensures the device picks up usage of a local MCP server build if available.
 


### PR DESCRIPTION
## Summary
- update the remote-device README to reference the existing root `device:start:dev` script
- remove the stale direct `src/remote-device` `npm run device` instruction, since that folder has no package manifest

## Validation
- `npm run build`
- `node -e "const pkg=require('./package.json'); for (const name of ['device:start','device:start:dev']) { if (!pkg.scripts?.[name]) throw new Error('Missing script '+name); console.log(name+'='+pkg.scripts[name]); }"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated device startup instructions to use the repository’s TypeScript tooling.
  * Clarified the command for starting the device in development and debugging mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->