### PR TITLE
fix: release file handles after truncated reads

### DIFF
--- a/src/utils/files/text.ts
+++ b/src/utils/files/text.ts
@@ -330,13 +330,15 @@ export class TextFileHandler implements FileHandler {
         let bufferIndex = 0;
         let totalLines = 0;
 
-        for await (const line of rl) {
-            buffer[bufferIndex] = line;
-            bufferIndex = (bufferIndex + 1) % requestedLines;
-            totalLines++;
+        try {
+            for await (const line of rl) {
+                buffer[bufferIndex] = line;
+                bufferIndex = (bufferIndex + 1) % requestedLines;
+                totalLines++;
+            }
+        } finally {
+            await closeReadlineStream(rl, stream);
         }
-
-        rl.close();
 
         let result: string[];
         if (totalLines >= requestedLines) {

--- a/src/utils/files/text.ts
+++ b/src/utils/files/text.ts
@@ -39,6 +39,19 @@ const READ_PERFORMANCE_THRESHOLDS = {
     CHUNK_SIZE: 8192,             // 8KB chunks for reverse reading
 } as const;
 
+async function closeReadlineStream(
+    rl: ReturnType<typeof createInterface>,
+    stream: ReturnType<typeof createReadStream>
+): Promise<void> {
+    const closed = stream.closed
+        ? Promise.resolve()
+        : new Promise<void>(resolve => stream.once('close', resolve));
+
+    rl.close();
+    if (!stream.destroyed) stream.destroy();
+    await closed;
+}
+
 /**
  * Text file handler implementation
  * Binary detection is done at the factory level - this handler assumes file is text
@@ -307,8 +320,9 @@ export class TextFileHandler implements FileHandler {
         fileTotalLines?: number,
         signal?: AbortSignal
     ): Promise<FileResult> {
+        const stream = createReadStream(filePath, { signal });
         const rl = createInterface({
-            input: createReadStream(filePath, { signal }),
+            input: stream,
             crlfDelay: Infinity
         });
 
@@ -353,23 +367,26 @@ export class TextFileHandler implements FileHandler {
         fileTotalLines?: number,
         signal?: AbortSignal
     ): Promise<FileResult> {
+        const stream = createReadStream(filePath, { signal });
         const rl = createInterface({
-            input: createReadStream(filePath, { signal }),
+            input: stream,
             crlfDelay: Infinity
         });
 
         const result: string[] = [];
         let lineNumber = 0;
 
-        for await (const line of rl) {
-            if (lineNumber >= offset && result.length < length) {
-                result.push(line);
+        try {
+            for await (const line of rl) {
+                if (lineNumber >= offset && result.length < length) {
+                    result.push(line);
+                }
+                if (result.length >= length) break;
+                lineNumber++;
             }
-            if (result.length >= length) break;
-            lineNumber++;
+        } finally {
+            await closeReadlineStream(rl, stream);
         }
-
-        rl.close();
 
         if (includeStatusMessage) {
             const statusMessage = this.generateEnhancedStatusMessage(result.length, offset, fileTotalLines, false);
@@ -394,21 +411,24 @@ export class TextFileHandler implements FileHandler {
         signal?: AbortSignal
     ): Promise<FileResult> {
         // First, do a quick scan to estimate lines per byte
+        const sampleStream = createReadStream(filePath, { signal });
         const rl = createInterface({
-            input: createReadStream(filePath, { signal }),
+            input: sampleStream,
             crlfDelay: Infinity
         });
 
         let sampleLines = 0;
         let bytesRead = 0;
 
-        for await (const line of rl) {
-            bytesRead += Buffer.byteLength(line, 'utf-8') + 1;
-            sampleLines++;
-            if (bytesRead >= READ_PERFORMANCE_THRESHOLDS.SAMPLE_SIZE) break;
+        try {
+            for await (const line of rl) {
+                bytesRead += Buffer.byteLength(line, 'utf-8') + 1;
+                sampleLines++;
+                if (bytesRead >= READ_PERFORMANCE_THRESHOLDS.SAMPLE_SIZE) break;
+            }
+        } finally {
+            await closeReadlineStream(rl, sampleStream);
         }
-
-        rl.close();
 
         if (sampleLines === 0) {
             return await this.readFromStartWithReadline(filePath, offset, length, mimeType, includeStatusMessage, fileTotalLines, signal);
@@ -432,20 +452,22 @@ export class TextFileHandler implements FileHandler {
             const result: string[] = [];
             let firstLineSkipped = false;
 
-            for await (const line of rl2) {
-                if (!firstLineSkipped && startPosition > 0) {
-                    firstLineSkipped = true;
-                    continue;
-                }
+            try {
+                for await (const line of rl2) {
+                    if (!firstLineSkipped && startPosition > 0) {
+                        firstLineSkipped = true;
+                        continue;
+                    }
 
-                if (result.length < length) {
-                    result.push(line);
-                } else {
-                    break;
+                    if (result.length < length) {
+                        result.push(line);
+                    } else {
+                        break;
+                    }
                 }
+            } finally {
+                await closeReadlineStream(rl2, stream);
             }
-
-            rl2.close();
 
             const content = includeStatusMessage
                 ? `${this.generateEnhancedStatusMessage(result.length, offset, fileTotalLines, false)}\n\n${result.join('\n')}`

--- a/test/test-read-file-handle-release.js
+++ b/test/test-read-file-handle-release.js
@@ -11,11 +11,15 @@ async function run() {
   const tmpDir = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'dc-read-handle-')));
   const target = path.join(tmpDir, 'large.txt');
   const replacement = path.join(tmpDir, 'replacement.txt');
+  const endTarget = path.join(tmpDir, 'large-end.txt');
+  const endReplacement = path.join(tmpDir, 'end-replacement.txt');
   const content = Array.from({ length: 2000 }, (_, index) => `line ${index + 1}`).join('\n');
 
   try {
     await fs.writeFile(target, content);
     await fs.writeFile(replacement, 'replacement content\n');
+    await fs.writeFile(endTarget, content);
+    await fs.writeFile(endReplacement, 'end replacement content\n');
     await configManager.setValue('allowedDirectories', [tmpDir]);
 
     const result = await readFile(target, { offset: 0, length: 1000 });
@@ -23,7 +27,13 @@ async function run() {
 
     await fs.rename(replacement, target);
     assert.strictEqual(await fs.readFile(target, 'utf8'), 'replacement content\n');
-    console.log('PASS: truncated read releases the file before atomic replacement');
+
+    const endResult = await readFile(endTarget, { offset: -1000 });
+    assert.ok(endResult.content.includes('line 2000'), 'suffix read should include the final line');
+    await fs.rename(endReplacement, endTarget);
+    assert.strictEqual(await fs.readFile(endTarget, 'utf8'), 'end replacement content\n');
+
+    console.log('PASS: bounded reads release files before atomic replacement');
   } finally {
     await configManager.setValue('allowedDirectories', originalAllowed);
     await fs.rm(tmpDir, { recursive: true, force: true });

--- a/test/test-read-file-handle-release.js
+++ b/test/test-read-file-handle-release.js
@@ -1,0 +1,36 @@
+import assert from 'assert';
+import os from 'os';
+import path from 'path';
+import fs from 'fs/promises';
+import { readFile } from '../dist/tools/filesystem.js';
+import { configManager } from '../dist/config-manager.js';
+
+async function run() {
+  const original = await configManager.getConfig();
+  const originalAllowed = original.allowedDirectories;
+  const tmpDir = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'dc-read-handle-')));
+  const target = path.join(tmpDir, 'large.txt');
+  const replacement = path.join(tmpDir, 'replacement.txt');
+  const content = Array.from({ length: 2000 }, (_, index) => `line ${index + 1}`).join('\n');
+
+  try {
+    await fs.writeFile(target, content);
+    await fs.writeFile(replacement, 'replacement content\n');
+    await configManager.setValue('allowedDirectories', [tmpDir]);
+
+    const result = await readFile(target, { offset: 0, length: 1000 });
+    assert.ok(result.content.includes('line 1000'), 'truncated prefix should be returned');
+
+    await fs.rename(replacement, target);
+    assert.strictEqual(await fs.readFile(target, 'utf8'), 'replacement content\n');
+    console.log('PASS: truncated read releases the file before atomic replacement');
+  } finally {
+    await configManager.setValue('allowedDirectories', originalAllowed);
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+run().catch(error => {
+  console.error(`FAIL: ${error.stack || error.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- explicitly close and destroy readline-backed file streams when a bounded read stops before EOF
- wait for the underlying stream's `close` event before returning
- apply the same cleanup to the large-file sampling and estimated-position paths
- add a regression test that immediately replaces a file after a truncated read

## Root cause

The bounded text-read paths could break out of `for await` before reaching EOF. They closed the readline interface but did not explicitly destroy and await closure of the underlying `ReadStream`. On Windows, that stream could retain a file handle long enough to make an immediate atomic replacement fail with `WinError 5`.

## Impact

After `read_file` returns a prefix of a large text file, another process can immediately replace that path without being blocked by a handle retained by Desktop Commander.

Fixes #476.

## Validation

- `npm run build`
- `node test/test-read-file-handle-release.js`
- `node test/test-file-handlers.js`
- `node test/test-read-abort-timeout.js` (`4/4`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-reading cleanup to deterministically close readline and underlying streams, improving file-handle release after bounded/sliced reads.
  * Enhanced stability for reads from the beginning, end, and estimated positions, reducing cases where files could remain locked and block atomic replacement.

* **Tests**
  * Added an end-to-end test ensuring truncated reads correctly release handles by verifying atomic rename/replace succeeds for both prefix and suffix reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->