### PR TITLE
fix: restrict HTML preview network access

### DIFF
--- a/src/ui/file-preview/src/components/html-renderer.ts
+++ b/src/ui/file-preview/src/components/html-renderer.ts
@@ -4,11 +4,22 @@
  *
  * The rendered preview runs inside a nested sandboxed iframe, which is itself inside
  * the MCP app's sandboxed iframe chain. Scripts and external resources (CDNs) are
- * allowed since the sandbox isolation prevents any escape.
+ * allowed for inline interactivity, while CSP blocks outbound requests.
  */
 import { renderCodeViewer } from './code-viewer.js';
 import { escapeHtml } from './highlighting.js';
 import type { HtmlPreviewMode } from '../types.js';
+
+const HTML_PREVIEW_CSP = [
+    "default-src 'none'",
+    "script-src 'unsafe-inline'",
+    "style-src 'unsafe-inline'",
+    'img-src data: blob:',
+    'media-src data: blob:',
+    "connect-src 'none'",
+    "form-action 'none'",
+    "base-uri 'none'",
+].join('; ');
 
 function resolveThemeFrameStyles(): { background: string; text: string; fontFamily: string } {
     if (typeof window === 'undefined' || typeof document === 'undefined') {
@@ -27,7 +38,7 @@ function resolveThemeFrameStyles(): { background: string; text: string; fontFami
 
 function renderSandboxedHtmlFrame(content: string): string {
     const palette = resolveThemeFrameStyles();
-    const frameDocument = `<!doctype html><html><head><meta charset="utf-8" /><style>html,body{margin:0;padding:0;background:${palette.background};color:${palette.text};}body{font-family:${palette.fontFamily};padding:16px;line-height:1.5;}img{max-width:100%;height:auto;}</style></head><body>${content}</body></html>`;
+    const frameDocument = `<!doctype html><html><head><meta charset="utf-8" /><meta http-equiv="Content-Security-Policy" content="${HTML_PREVIEW_CSP}" /><style>html,body{margin:0;padding:0;background:${palette.background};color:${palette.text};}body{font-family:${palette.fontFamily};padding:16px;line-height:1.5;}img{max-width:100%;height:auto;}</style></head><body>${content}</body></html>`;
     return `<iframe class="html-rendered-frame" title="Rendered HTML preview" sandbox="allow-scripts allow-forms allow-popups" referrerpolicy="no-referrer" srcdoc="${escapeHtml(frameDocument)}"></iframe>`;
 }
 

--- a/test/test-html-preview-csp.js
+++ b/test/test-html-preview-csp.js
@@ -1,0 +1,12 @@
+import assert from 'assert';
+import { renderHtmlPreview } from '../dist/ui/file-preview/src/components/html-renderer.js';
+
+const rendered = renderHtmlPreview('<script>fetch("https://example.com")</script>', 'rendered');
+
+assert.ok(rendered.html.includes('Content-Security-Policy'));
+assert.ok(rendered.html.includes('connect-src &#39;none&#39;'));
+assert.ok(rendered.html.includes('form-action &#39;none&#39;'));
+assert.ok(rendered.html.includes('sandbox="allow-scripts allow-forms allow-popups"'));
+assert.ok(rendered.html.includes('&lt;script&gt;fetch(&quot;https://example.com&quot;)&lt;/script&gt;'));
+
+console.log('PASS: rendered HTML previews carry a restrictive CSP');


### PR DESCRIPTION
## Summary

- inject a restrictive Content Security Policy into rendered HTML preview documents
- preserve inline scripts and styles used by interactive local previews
- block network connections, form submissions, external resources, and base-URL rewriting
- add a renderer-level regression for the escaped iframe `srcdoc`

## Security boundary

Preview content is attacker-controlled HTML. The iframe sandbox isolates its origin but does not prevent `fetch`, XHR, WebSocket, form, image, or script requests. The CSP now limits scripts and styles to inline preview content, images/media to `data:` and `blob:`, and denies outbound connections and form actions.

Fixes #507.

## Validation

- `npm run build`
- `node test/test-html-preview-csp.js`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Added a restrictive Content Security Policy to sandboxed HTML previews.
  * Prevented preview content from making network connections or submitting forms.

* **Bug Fixes**
  * Preserved existing fallback behavior, displaying source content if preview rendering fails.

* **Tests**
  * Added coverage to verify security restrictions are applied to rendered HTML previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->