### PR TITLE
fix(windows): restore shell environment variables

### DIFF
--- a/src/terminal-manager.ts
+++ b/src/terminal-manager.ts
@@ -35,6 +35,40 @@ function getRepairedPathExt(current = process.env.PATHEXT): string {
 }
 
 /**
+ * process.env is case-insensitive on Windows, but spreading it creates a
+ * regular object whose keys retain their original casing. Look up inherited
+ * values without depending on a particular spelling before normalizing them.
+ */
+function getEnvironmentValueIgnoringCase(
+  environment: NodeJS.ProcessEnv,
+  key: string
+): string | undefined {
+  const matchingEntries = Object.entries(environment).filter(
+    ([candidate]) => candidate.toUpperCase() === key.toUpperCase()
+  );
+
+  return matchingEntries.find(([candidate, value]) => candidate === key && value)?.[1]
+    || matchingEntries.find(([, value]) => value)?.[1];
+}
+
+/**
+ * Child process environments should contain one canonical spelling for each
+ * Windows variable. This prevents conflicting keys after a process.env spread.
+ */
+function setCanonicalWindowsEnvironmentValue(
+  environment: NodeJS.ProcessEnv,
+  key: string,
+  value: string
+): void {
+  for (const candidate of Object.keys(environment)) {
+    if (candidate !== key && candidate.toUpperCase() === key.toUpperCase()) {
+      delete environment[candidate];
+    }
+  }
+  environment[key] = value;
+}
+
+/**
  * Repair Windows variables required by child shells when an MSIX host has
  * stripped them from the inherited environment. PATHEXT repair is retained
  * from #481; WINDIR/SystemRoot repair covers the PowerShell module-loading
@@ -47,15 +81,23 @@ export function getRepairedWindowsShellEnvironment(
   if (!isWindows) return { ...environment };
 
   const repaired = { ...environment };
-  repaired.PATHEXT = getRepairedPathExt(environment.PATHEXT);
+  setCanonicalWindowsEnvironmentValue(
+    repaired,
+    'PATHEXT',
+    getRepairedPathExt(getEnvironmentValueIgnoringCase(environment, 'PATHEXT'))
+  );
 
-  const windowsDirectory = environment.WINDIR?.trim()
-    || environment.SystemRoot?.trim()
+  const inheritedWindir = getEnvironmentValueIgnoringCase(environment, 'WINDIR');
+  const inheritedSystemRoot = getEnvironmentValueIgnoringCase(environment, 'SystemRoot');
+  const windowsDirectory = inheritedWindir?.trim()
+    || inheritedSystemRoot?.trim()
     || 'C:\\Windows';
-  repaired.WINDIR = windowsDirectory;
-  if (!environment.SystemRoot?.trim()) {
-    repaired.SystemRoot = windowsDirectory;
-  }
+  setCanonicalWindowsEnvironmentValue(repaired, 'WINDIR', windowsDirectory);
+  setCanonicalWindowsEnvironmentValue(
+    repaired,
+    'SystemRoot',
+    inheritedSystemRoot?.trim() || windowsDirectory
+  );
 
   return repaired;
 }

--- a/src/terminal-manager.ts
+++ b/src/terminal-manager.ts
@@ -25,14 +25,39 @@ const STANDARD_PATHEXT = '.COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC'
  *                      present (preserves any extra extensions, order-stable).
  * - Otherwise       -> leave the inherited value untouched.
  */
-function getRepairedPathExt(): string {
-  const current = process.env.PATHEXT;
+function getRepairedPathExt(current = process.env.PATHEXT): string {
   if (!current) return STANDARD_PATHEXT;
   const exts = current.split(';').map(e => e.trim().toUpperCase()).filter(Boolean);
   if (!exts.includes('.EXE')) {
     return [...new Set([...STANDARD_PATHEXT.split(';'), ...exts])].join(';');
   }
   return current;
+}
+
+/**
+ * Repair Windows variables required by child shells when an MSIX host has
+ * stripped them from the inherited environment. PATHEXT repair is retained
+ * from #481; WINDIR/SystemRoot repair covers the PowerShell module-loading
+ * failures reported in #480.
+ */
+export function getRepairedWindowsShellEnvironment(
+  environment: NodeJS.ProcessEnv,
+  isWindows = process.platform === 'win32'
+): NodeJS.ProcessEnv {
+  if (!isWindows) return { ...environment };
+
+  const repaired = { ...environment };
+  repaired.PATHEXT = getRepairedPathExt(environment.PATHEXT);
+
+  const windowsDirectory = environment.WINDIR?.trim()
+    || environment.SystemRoot?.trim()
+    || 'C:\\Windows';
+  repaired.WINDIR = windowsDirectory;
+  if (!environment.SystemRoot?.trim()) {
+    repaired.SystemRoot = windowsDirectory;
+  }
+
+  return repaired;
 }
 
 interface CompletedSession {
@@ -205,10 +230,10 @@ export class TerminalManager {
       // Use shell-specific configuration with login flags where appropriate
       spawnConfig = getShellSpawnArgs(shellToUse, enhancedCommand);
       spawnOptions = {
-        env: {
+        env: getRepairedWindowsShellEnvironment({
           ...process.env,
           TERM: 'xterm-256color'  // Better terminal compatibility
-        },
+        }),
         windowsHide: true  // Prevent visible console windows on Windows
       };
 
@@ -225,20 +250,12 @@ export class TerminalManager {
       };
       spawnOptions = {
         shell: shellToUse,
-        env: {
+        env: getRepairedWindowsShellEnvironment({
           ...process.env,
           TERM: 'xterm-256color'
-        },
+        }),
         windowsHide: true  // Prevent visible console windows on Windows
       };
-    }
-
-    // Repair PATHEXT on Windows before spawning. On some Windows DXT launches
-    // the server process inherits a corrupted PATHEXT (e.g. ".CPL"), which we
-    // would otherwise propagate via { ...process.env } and break command
-    // resolution (git, node, python, rg, ...) in the spawned shell. See #481.
-    if (process.platform === 'win32' && spawnOptions.env) {
-      spawnOptions.env.PATHEXT = getRepairedPathExt();
     }
 
     // On Windows, when we invoke cmd.exe directly and pass the user's command as a

--- a/test/test-windows-shell-environment.js
+++ b/test/test-windows-shell-environment.js
@@ -17,6 +17,23 @@ assert.equal(repaired.SystemRoot, 'D:\\Windows');
 assert.equal(repaired.KEEP_ME, 'present');
 assert.equal(brokenMsixEnvironment.WINDIR, '');
 
+const mixedCaseEnvironment = {
+  pathext: '.CPL',
+  PATHEXT: '.EXE',
+  windir: 'E:\\Windows',
+  WINDIR: '',
+  systemroot: 'F:\\Windows',
+};
+
+const normalized = getRepairedWindowsShellEnvironment(mixedCaseEnvironment, true);
+
+assert.equal(normalized.PATHEXT, '.EXE');
+assert.equal(normalized.WINDIR, 'E:\\Windows');
+assert.equal(normalized.SystemRoot, 'F:\\Windows');
+assert.equal(normalized.pathext, undefined);
+assert.equal(normalized.windir, undefined);
+assert.equal(normalized.systemroot, undefined);
+
 const fallback = getRepairedWindowsShellEnvironment({ PATHEXT: '.EXE' }, true);
 assert.equal(fallback.WINDIR, 'C:\\Windows');
 assert.equal(fallback.SystemRoot, 'C:\\Windows');

--- a/test/test-windows-shell-environment.js
+++ b/test/test-windows-shell-environment.js
@@ -1,0 +1,28 @@
+import assert from 'assert';
+import { getRepairedWindowsShellEnvironment } from '../dist/terminal-manager.js';
+
+const brokenMsixEnvironment = {
+  PATHEXT: '.CPL',
+  WINDIR: '',
+  SystemRoot: 'D:\\Windows',
+  KEEP_ME: 'present',
+};
+
+const repaired = getRepairedWindowsShellEnvironment(brokenMsixEnvironment, true);
+
+assert.match(repaired.PATHEXT, /\.EXE/i);
+assert.match(repaired.PATHEXT, /\.CPL/i);
+assert.equal(repaired.WINDIR, 'D:\\Windows');
+assert.equal(repaired.SystemRoot, 'D:\\Windows');
+assert.equal(repaired.KEEP_ME, 'present');
+assert.equal(brokenMsixEnvironment.WINDIR, '');
+
+const fallback = getRepairedWindowsShellEnvironment({ PATHEXT: '.EXE' }, true);
+assert.equal(fallback.WINDIR, 'C:\\Windows');
+assert.equal(fallback.SystemRoot, 'C:\\Windows');
+
+const nonWindows = getRepairedWindowsShellEnvironment({ PATHEXT: '.CPL' }, false);
+assert.equal(nonWindows.PATHEXT, '.CPL');
+assert.equal(nonWindows.WINDIR, undefined);
+
+console.log('Windows shell environment repair tests passed.');


### PR DESCRIPTION
## Summary
- repair `WINDIR` and `SystemRoot` for Windows child shells when the host process supplies an empty or missing value
- keep the existing PATHEXT repair on the same child-environment path
- add a focused regression test for the MSIX-like environment

Fixes #480

## Root cause
`TerminalManager.executeCommand()` copied the inherited process environment directly into every child shell. Under the MSIX-packaged Claude Desktop, `WINDIR` can be empty, which prevents PowerShell from loading CIM/CDXML modules even after PATHEXT has been repaired.

## Validation
- `npm run build`
- `node test/test-windows-shell-environment.js`
- `git diff --check`

## Scope
This does not alter command policy or process execution. On Windows it preserves a non-empty configured `WINDIR`, otherwise falls back to `SystemRoot` and only then `C:\Windows`; non-Windows environments are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows shell startup reliability by repairing critical environment variables before running commands.
  * Automatically normalizes and completes command extension settings, and sets canonical `WINDIR`/`SystemRoot` with sensible defaults.
  * Avoids mutating the original environment and preserves unrelated environment values.
  * Keeps `PATHEXT` behavior unchanged on non-Windows systems.
* **Tests**
  * Added automated coverage for Windows and non-Windows environment repair and defaulting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->