### PR TITLE
Resolve spawned system executables by absolute path (#509)

### DIFF
--- a/setup-claude-server.js
+++ b/setup-claude-server.js
@@ -533,6 +533,19 @@ function updateSetupStep(index, status, error = null) {
     }
 }
 
+// Resolve a system utility to an absolute path so it can't be shadowed by a
+// foreign entry prepended to PATH (shell rc files, direnv, tool shims, etc.).
+// Returns the first candidate that exists on disk, falling back to the bare
+// name if none are found (e.g. a distro that installs the tool elsewhere).
+function resolveSystemBinary(candidates, fallback) {
+    for (const candidate of candidates) {
+        if (existsSync(candidate)) {
+            return candidate;
+        }
+    }
+    return fallback;
+}
+
 async function execAsync(command) {
     const execStep = addSetupStep(`exec_${command.substring(0, 20)}...`);
     return new Promise((resolve, reject) => {
@@ -569,16 +582,20 @@ async function restartClaude() {
                         `taskkill /F /IM "Claude.exe"`,
                     );
                     break;
-                case "darwin":
+                case "darwin": {
+                    const killall = resolveSystemBinary(['/usr/bin/killall'], 'killall');
                     await execAsync(
-                        `killall "Claude"`,
+                        `"${killall}" "Claude"`,
                     );
                     break;
-                case "linux":
+                }
+                case "linux": {
+                    const pkill = resolveSystemBinary(['/usr/bin/pkill', '/bin/pkill'], 'pkill');
                     await execAsync(
-                        `pkill -f "claude"`,
+                        `"${pkill}" -f "claude"`,
                     );
                     break;
+                }
             }
             updateSetupStep(killStep, 'completed');
             await trackEvent('npx_setup_kill_claude_success', { platform });
@@ -600,7 +617,8 @@ async function restartClaude() {
                 updateSetupStep(startStep, 'skipped');
                 await trackEvent('npx_setup_start_claude_skipped', { platform });
             } else if (platform === "darwin") {
-                await execAsync(`open -a "Claude"`);
+                const open = resolveSystemBinary(['/usr/bin/open'], 'open');
+                await execAsync(`"${open}" -a "Claude"`);
                 updateSetupStep(startStep, 'completed');
                 logToFile("\n✅ Claude has been restarted automatically!");
                 await trackEvent('npx_setup_start_claude_success', { platform });

--- a/src/remote-device/remote-channel.ts
+++ b/src/remote-device/remote-channel.ts
@@ -542,7 +542,11 @@ export class RemoteChannel {
             console.debug('[DEBUG] Spawning blocking update script:', scriptPath);
             console.debug('[DEBUG] Using node executable:', process.execPath);
 
-            const result = spawnSync('node', [
+            // process.execPath is the exact Node binary currently running the
+            // server. Using it (instead of the bare name 'node') skips PATH
+            // resolution entirely, so the update script always runs on the same
+            // runtime and can't be shadowed by a different 'node' on PATH.
+            const result = spawnSync(process.execPath, [
                 scriptPath,
                 deviceId,
                 supabaseUrl,

--- a/uninstall-claude-server.js
+++ b/uninstall-claude-server.js
@@ -412,6 +412,15 @@ function updateUninstallStep(index, status, error = null) {
     }
 }
 
+function resolveSystemBinary(candidates, fallback) {
+    for (const candidate of candidates) {
+        if (existsSync(candidate)) {
+            return candidate;
+        }
+    }
+    return fallback;
+}
+
 async function execAsync(command) {
     const execStep = addUninstallStep(`exec_${command.substring(0, 20)}...`);
     return new Promise((resolve, reject) => {
@@ -489,12 +498,16 @@ async function restartClaude() {
                 case "win32":
                     await execAsync(`taskkill /F /IM "Claude.exe"`);
                     break;
-                case "darwin":
-                    await execAsync(`killall "Claude"`);
+                case "darwin": {
+                    const killall = resolveSystemBinary(['/usr/bin/killall'], 'killall');
+                    await execAsync(`"${killall}" "Claude"`);
                     break;
-                case "linux":
-                    await execAsync(`pkill -f "claude"`);
+                }
+                case "linux": {
+                    const pkill = resolveSystemBinary(['/usr/bin/pkill', '/bin/pkill'], 'pkill');
+                    await execAsync(`"${pkill}" -f "claude"`);
                     break;
+                }
             }
             updateUninstallStep(killStep, 'completed');
             logToFile("Claude process terminated successfully");

--- a/uninstall-claude-server.js
+++ b/uninstall-claude-server.js
@@ -529,7 +529,8 @@ async function restartClaude() {
                 updateUninstallStep(startStep, 'skipped');
                 await trackEvent('uninstall_start_claude_skipped');
             } else if (platform === "darwin") {
-                await execAsync(`open -a "Claude"`);
+                const open = resolveSystemBinary(['/usr/bin/open'], 'open');
+                await execAsync(`"${open}" -a "Claude"`);
                 updateUninstallStep(startStep, 'completed');
                 logToFile("✅ Claude has been restarted automatically!");
                 await trackEvent('uninstall_start_claude_success');


### PR DESCRIPTION
## Summary

Several `spawn`/`exec` calls resolved their executable through `PATH`, which is inherited from the parent process and can be reordered by shell startup files, `direnv`, or any tool that prepends a shims directory. This hardens the two spots called out in #509 to use fixed, unambiguous binaries.

## Changes

**`src/remote-device/remote-channel.ts`** — the blocking offline-update script was launched with `spawnSync('node', …)`. The code already logs `process.execPath` on the line above ("Using node executable:"), so this switches the spawn to `process.execPath`. That's the exact Node binary already running the server, so the child runs on the same runtime and can't be shadowed by a different `node` on `PATH`.

**`setup-claude-server.js`** — the macOS/Linux restart path shelled out to bare `killall`, `pkill`, and `open`. These now resolve through a small `resolveSystemBinary(candidates, fallback)` helper that returns the first absolute path that exists on disk (`/usr/bin/killall`, `/usr/bin/pkill` or `/bin/pkill`, `/usr/bin/open`) and falls back to the bare name if the tool is installed elsewhere, so uncommon distro layouts keep working. Paths are quoted to tolerate spaces.

Left as-is intentionally:
- Windows `taskkill` and the `cmd.exe` wrapper — resolved from the protected `System32` directory; out of scope for this issue.
- The Linux `claude` launch — that's the user's own CLI on `PATH`, not a fixed system utility, so it has no stable absolute location to prefer.

## Testing

- `npm run build` (tsc) passes; the compiled `dist/remote-device/remote-channel.js` shows `spawnSync(process.execPath, …)`.
- `node --check setup-claude-server.js` passes.
- Verified `resolveSystemBinary` returns the absolute path when present and falls back to the bare name otherwise.

Fixes #509


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Reliability**
  * Improved system utility launching by using trusted, absolute executable paths on macOS and Linux.
  * Updated Claude restart and shutdown actions to reliably locate required system commands.
  * Ensured offline update processes use the same Node.js runtime as the server for more consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->