### PR TITLE
Link skill reference files from SKILL.md to satisfy vally orphan-file…

### DIFF
--- a/plugins/claude/skills/ai-tools-setup/SKILL.md
+++ b/plugins/claude/skills/ai-tools-setup/SKILL.md
@@ -63,18 +63,18 @@ known failure modes.
   servers, and inspecting / validating / repairing MCP config files
   (`claude_desktop_config.json`, `.claude/mcp.json`, `~/.lmstudio/mcp.json`,
   and similar). Also connection health checks.
-  → Read `references/claude-desktop-mcp.md`
+  → Read [`references/claude-desktop-mcp.md`](references/claude-desktop-mcp.md)
 
 - **OpenClaw** — a self-hosted multi-channel gateway for AI agents. Install,
   onboard, wire a model/provider, connect channels (Telegram, Slack, iMessage,
   etc.), diagnose the gateway, and uninstall.
-  → Read `references/openclaw.md`
+  → Read [`references/openclaw.md`](references/openclaw.md)
 
 - **Hermes** — disambiguate first: **Hermes Agent** (the Nous Research
   self-improving agent framework) vs. **Hermes 3** (just a local LLM you run via
   Ollama). Install, run `hermes setup --portal`, configure providers, personality
   (`SOUL.md`), memory/skills, MCP, and messaging.
-  → Read `references/hermes.md`
+  → Read [`references/hermes.md`](references/hermes.md)
 
 When in doubt about a tool's current behavior, fetch the official docs:
 OpenClaw — https://docs.openclaw.ai/ ·

--- a/plugins/claude/skills/computer-health-check/SKILL.md
+++ b/plugins/claude/skills/computer-health-check/SKILL.md
@@ -58,9 +58,9 @@ Determine the platform before doing anything else, because the commands differ.
 
 Then open the matching reference file and use its command set:
 
-- macOS → `references/macos.md`
-- Windows → `references/windows.md`
-- Linux → `references/linux.md`
+- macOS → [`references/macos.md`](references/macos.md)
+- Windows → [`references/windows.md`](references/windows.md)
+- Linux → [`references/linux.md`](references/linux.md)
 
 Read **only** the one that matches. Each file contains a single batched collection script
 plus interpretation notes and cleanup commands.

--- a/skills/ai-tools-setup/SKILL.md
+++ b/skills/ai-tools-setup/SKILL.md
@@ -63,18 +63,18 @@ known failure modes.
   servers, and inspecting / validating / repairing MCP config files
   (`claude_desktop_config.json`, `.claude/mcp.json`, `~/.lmstudio/mcp.json`,
   and similar). Also connection health checks.
-  → Read `references/claude-desktop-mcp.md`
+  → Read [`references/claude-desktop-mcp.md`](references/claude-desktop-mcp.md)
 
 - **OpenClaw** — a self-hosted multi-channel gateway for AI agents. Install,
   onboard, wire a model/provider, connect channels (Telegram, Slack, iMessage,
   etc.), diagnose the gateway, and uninstall.
-  → Read `references/openclaw.md`
+  → Read [`references/openclaw.md`](references/openclaw.md)
 
 - **Hermes** — disambiguate first: **Hermes Agent** (the Nous Research
   self-improving agent framework) vs. **Hermes 3** (just a local LLM you run via
   Ollama). Install, run `hermes setup --portal`, configure providers, personality
   (`SOUL.md`), memory/skills, MCP, and messaging.
-  → Read `references/hermes.md`
+  → Read [`references/hermes.md`](references/hermes.md)
 
 When in doubt about a tool's current behavior, fetch the official docs:
 OpenClaw — https://docs.openclaw.ai/ ·

--- a/skills/computer-health-check/SKILL.md
+++ b/skills/computer-health-check/SKILL.md
@@ -58,9 +58,9 @@ Determine the platform before doing anything else, because the commands differ.
 
 Then open the matching reference file and use its command set:
 
-- macOS → `references/macos.md`
-- Windows → `references/windows.md`
-- Linux → `references/linux.md`
+- macOS → [`references/macos.md`](references/macos.md)
+- Windows → [`references/windows.md`](references/windows.md)
+- Linux → [`references/linux.md`](references/linux.md)
 
 Read **only** the one that matches. Each file contains a single batched collection script
 plus interpretation notes and cleanup commands.


### PR DESCRIPTION

The ai-tools-setup and computer-health-check skills mentioned their references/*.md files as inline code, which vally's orphan-files gate does not count as reachable. Convert them to markdown links so every reference file is reachable from SKILL.md. Applied to both the root skills/ copy (submitted as the VS Code agent plugin) and the plugins/claude/skills/ mirror.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved readability and navigation by converting referenced setup, operating system, and troubleshooting documents into consistent Markdown links.
  - Cleaned up bullet and line-break formatting across the related guidance sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->