### PR TITLE
Fix typo in detectShell comment

### DIFF
--- a/setup-claude-server.js
+++ b/setup-claude-server.js
@@ -166,7 +166,7 @@ const getVersion = async () => {
     }
 };
 
-// Function to detect shell environmen
+// Function to detect shell environment
 function detectShell() {
   // Check for Windows shells
   if (process.platform === 'win32') {


### PR DESCRIPTION
Small fix: corrects a spelling error in a code comment.

`setup-claude-server.js` had `// Function to detect shell environmen` above the `detectShell()` function — `environmen` should be `environment`. Comment-only change, no behavior impact. Confirmed clean with codespell using the repo's `.codespellrc`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected and completed an inline comment describing shell environment detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->