### PR TITLE
docs(security): clarify optional policy gateway boundary

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,6 +30,9 @@ policy gateway between the AI client and Desktop Commander. A gateway can
 normalize a tool call, apply file and command policy, request human approval,
 forward allowed calls, and write a redacted audit record.
 
+Gateway timeouts, errors, and missing policy decisions should fail closed: do
+not forward a call without an explicit allow decision or completed approval.
+
 This is an additional governance layer, not a sandbox. It can govern only calls
 that are routed through it; a client connected directly to Desktop Commander can
 bypass the gateway. Keep OS-level isolation in place when containment is required.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,6 +23,21 @@ If the AI client should never be able to reach the rest of your machine, that gu
 
 Terminal command execution is a first-class feature. Because it can launch arbitrary programs, path-based and command-based restrictions can be circumvented by design — for example via shell substitution, absolute paths, or invoking another interpreter. These controls are advisory: they make common mistakes less likely; they are not a boundary against a client that is actively trying to escape them.
 
+## Optional external policy gateway
+
+Deployments that need a policy decision for each operation can place an external
+policy gateway between the AI client and Desktop Commander. A gateway can
+normalize a tool call, apply file and command policy, request human approval,
+forward allowed calls, and write a redacted audit record.
+
+This is an additional governance layer, not a sandbox. It can govern only calls
+that are routed through it; a client connected directly to Desktop Commander can
+bypass the gateway. Keep OS-level isolation in place when containment is required.
+
+The gateway should be implementation-neutral. A local policy service or a tool
+such as PatchWarden can implement the pattern, but Desktop Commander does not
+require or imply support for any particular gateway.
+
 ## Recommended deployment for stronger isolation
 
 For any workload where the AI client must not access the wider machine, run Desktop Commander inside an isolated environment:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,9 +34,8 @@ This is an additional governance layer, not a sandbox. It can govern only calls
 that are routed through it; a client connected directly to Desktop Commander can
 bypass the gateway. Keep OS-level isolation in place when containment is required.
 
-The gateway should be implementation-neutral. A local policy service or a tool
-such as PatchWarden can implement the pattern, but Desktop Commander does not
-require or imply support for any particular gateway.
+Desktop Commander does not require or imply support for any particular gateway
+implementation.
 
 ## Recommended deployment for stronger isolation
 


### PR DESCRIPTION
## Summary

- document an optional external policy gateway between an AI client and Desktop Commander
- state that direct client connections bypass the gateway
- preserve Docker, VM, and OS isolation as the containment boundary

## Why

Desktop Commander's current security model correctly distinguishes safety
guardrails from sandboxing. Some deployments also need a deterministic policy
decision, human confirmation, and redacted audit record before a requested tool
call is forwarded.

This documentation describes that optional governance layer without treating it
as a replacement for Desktop Commander guardrails or OS-level isolation. It
also makes the enforcement boundary explicit: only calls routed through the
gateway are governed. Desktop Commander does not require or imply support for
any particular gateway implementation.

This is related to the policy-enforcement discussion in #431, but it does not
claim to implement or close that product-level request.

## Validation

- `git diff --check`
- manual Markdown heading and paragraph review
- verified that gateway, bypass, guardrail, and OS-isolation limitations appear together

Related: #431

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on using an optional external policy gateway for tool-call governance, approvals, forwarding, and redacted audit records.
  * Clarified that the gateway is not a sandbox and may be bypassed by direct connections.
  * Updated the documentation’s “Last updated” date to July 2026.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->