### PR TITLE
fix(remote-device): correct clock skew and half-open socket wedges

### DIFF
--- a/src/remote-device/remote-channel.ts
+++ b/src/remote-device/remote-channel.ts
@@ -82,14 +82,16 @@ const SOCKET_SETTLE_POLL_MS = 20;
 
 // auth-js compares token expiry against this device's own Date.now(), with no
 // clock-skew tolerance — a fast clock treats every fresh token as expired and
-// refreshes forever (confirmed in prod: 9,300+ refreshes/24h on one device,
-// via at least 3 separate check sites, not all gated by autoRefreshToken).
+// refreshes forever (confirmed in prod on one device, via at least 3 separate
+// check sites, not all gated by autoRefreshToken).
 // Rather than chase each check, fix the shared input: every Supabase response
 // carries a `Date` header (RFC 7231, the server's own clock), so a fetch
 // wrapper passed via `global.fetch` corrects Date.now for this process off of
 // that, continuously — covers every current and future check without needing
-// to know where they live. Scoped to Date.now, not `new Date()`, so
-// last_seen/telemetry timestamps stay on the device's real clock.
+// to know where they live. Also shifts capture.ts telemetry timestamps
+// (Date.now-based) onto server time, which is desirable: GA4 drops
+// future-dated events, so a fast-clock device loses its telemetry otherwise.
+// `new Date()` is untouched.
 const rawDateNow = Date.now;
 let clockOffsetMs = 0;
 let clockPatched = false;

--- a/src/remote-device/remote-channel.ts
+++ b/src/remote-device/remote-channel.ts
@@ -165,8 +165,12 @@ export class RemoteChannel {
 
     private reconnectAttempt = 0;        // recreates since the last success
     private isRecreatingChannel = false; // re-entrancy guard
-    private joiningSince: number | null = null; // start of an unbroken 'joining' run
-    /** Last confirmed proof of life (SUBSCRIBED or heartbeat 'ok'); null until the first one lands. */
+    private joiningSince: number | null = null; // start of an unbroken 'joining' run (performance.now())
+    /** Last confirmed proof of life (SUBSCRIBED or heartbeat 'ok'); null until the
+     * first one lands. On performance.now(), not Date.now(): the clock-skew
+     * correction above can (un)patch Date.now mid-run, jumping wall-clock math by
+     * the whole offset — a backward jump would suppress stale detection for as
+     * long as the offset. Same for joiningSince. */
     private lastHeartbeatOkAt: number | null = null;
     private heartbeatListenerRegistered = false;
     /** Our own fixed-cadence auth refresh timer — see TOKEN_REFRESH_INTERVAL_MS. */
@@ -188,7 +192,7 @@ export class RemoteChannel {
             this.heartbeatListenerRegistered = true;
             try {
                 (this.client as any).realtime?.onHeartbeat?.((status: string) => {
-                    if (status === 'ok') this.lastHeartbeatOkAt = Date.now();
+                    if (status === 'ok') this.lastHeartbeatOkAt = performance.now();
                 });
             } catch { /* no onHeartbeat on this client version: staleness check stays inert */ }
         }
@@ -534,7 +538,7 @@ export class RemoteChannel {
                     if (status === 'SUBSCRIBED') {
                         const recovered = this.reconnectAttempt;
                         this.reconnectAttempt = 0;
-                        this.lastHeartbeatOkAt = Date.now(); // a fresh join is proof of life too
+                        this.lastHeartbeatOkAt = performance.now(); // a fresh join is proof of life too
                         console.log(`✅ Channel subscribed${recovered > 0 ? ` (recovered after ${recovered} attempt${recovered === 1 ? '' : 's'})` : ''}`);
                         // Update device status on successful connection (queued, so
                         // it can't be overtaken by a teardown's status write).
@@ -710,7 +714,7 @@ export class RemoteChannel {
             // 'joined' is a cached string, not proof of a live socket. Cross-check
             // against the last confirmed heartbeat reply.
             if (this.lastHeartbeatOkAt !== null) {
-                const staleMs = Date.now() - this.lastHeartbeatOkAt;
+                const staleMs = performance.now() - this.lastHeartbeatOkAt;
                 if (staleMs > HEARTBEAT_STALE_TIMEOUT_MS) {
                     console.debug(`[DEBUG] ⚠️ Channel reads 'joined' but no confirmed heartbeat in ${Math.round(staleMs / 1000)}s - forcing recreate — ${this.connState()}`);
                     captureRemote('remote_channel_heartbeat_stale', { staleMs, attempt: this.reconnectAttempt });
@@ -735,7 +739,7 @@ export class RemoteChannel {
         // JOINING_WEDGE_TIMEOUT_MS force a recreate, the only path that
         // disconnect()s the dead socket.
         if (state === 'joining') {
-            const now = Date.now();
+            const now = performance.now();
             if (this.joiningSince === null) this.joiningSince = now;
             const stuckMs = now - this.joiningSince;
             if (stuckMs < JOINING_WEDGE_TIMEOUT_MS) return;
@@ -833,7 +837,7 @@ export class RemoteChannel {
             // know the heartbeat is stale (this recreate may have been triggered
             // by exactly that).
             const heartbeatStale = this.lastHeartbeatOkAt !== null
-                && (Date.now() - this.lastHeartbeatOkAt) > HEARTBEAT_STALE_TIMEOUT_MS;
+                && (performance.now() - this.lastHeartbeatOkAt) > HEARTBEAT_STALE_TIMEOUT_MS;
             if (this.channel?.state === 'joined' && !heartbeatStale) {
                 console.log(`✅ Channel self-healed during backoff — skipping recreate — ${this.connState()}`);
                 return; // finally-block below clears the re-entrancy guard

--- a/src/remote-device/remote-channel.ts
+++ b/src/remote-device/remote-channel.ts
@@ -56,6 +56,14 @@ const RECREATE_TIMEOUT_MS = 45000;
 // Max continuous time in 'joining' before forcing a recreate — a half-open
 // socket parks the channel there forever, and a genuine join settles in ~10s.
 const JOINING_WEDGE_TIMEOUT_MS = 30000;
+// Backstop for a half-open socket where 'joined' never changes and realtime-js's
+// own heartbeat-close never completes. ~3x the 25s heartbeat interval.
+const HEARTBEAT_STALE_TIMEOUT_MS = 75000;
+// Fixed cadence for our own token refresh, independent of auth-js's internal
+// ticker (disabled in initialize()) — see the clock-skew comment below for why.
+const TOKEN_REFRESH_INTERVAL_MS = 45 * 60 * 1000;
+// Below this, skew is noise — leave Date.now untouched. Above it, correct.
+const CLOCK_SKEW_CORRECTION_THRESHOLD_MS = 5 * 60 * 1000;
 // Failed recreates before withdrawing transport_broadcast_v1 — keeping it while
 // unable to join makes the device undispatchable. Not lower than 3: ordinary
 // half-open recovery legitimately costs 2.
@@ -71,6 +79,49 @@ const OFFLINE_SESSION_TIMEOUT_MS = 500;
 // already covers.
 const SOCKET_SETTLE_MAX_MS = 300;
 const SOCKET_SETTLE_POLL_MS = 20;
+
+// auth-js compares token expiry against this device's own Date.now(), with no
+// clock-skew tolerance — a fast clock treats every fresh token as expired and
+// refreshes forever (confirmed in prod: 9,300+ refreshes/24h on one device,
+// via at least 3 separate check sites, not all gated by autoRefreshToken).
+// Rather than chase each check, fix the shared input: every Supabase response
+// carries a `Date` header (RFC 7231, the server's own clock), so a fetch
+// wrapper passed via `global.fetch` corrects Date.now for this process off of
+// that, continuously — covers every current and future check without needing
+// to know where they live. Scoped to Date.now, not `new Date()`, so
+// last_seen/telemetry timestamps stay on the device's real clock.
+const rawDateNow = Date.now;
+let clockOffsetMs = 0;
+let clockPatched = false;
+
+export function observeServerDate(dateHeader: string | null): void {
+    if (!dateHeader) return;
+    const serverMs = Date.parse(dateHeader);
+    if (Number.isNaN(serverMs)) return;
+
+    const offsetMs = serverMs - rawDateNow();
+    if (Math.abs(offsetMs) <= CLOCK_SKEW_CORRECTION_THRESHOLD_MS) {
+        if (clockPatched) {
+            Date.now = rawDateNow;
+            clockPatched = false;
+        }
+        return;
+    }
+
+    clockOffsetMs = offsetMs;
+    if (!clockPatched) {
+        Date.now = () => rawDateNow() + clockOffsetMs;
+        clockPatched = true;
+        console.warn(`⚠️ Device clock skewed ~${Math.round(offsetMs / 1000)}s from Supabase — correcting for this process`);
+        captureRemote('remote_channel_clock_skew_corrected', { offsetMs }).catch(() => { });
+    }
+}
+
+async function clockAwareFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+    const response = await fetch(input, init);
+    observeServerDate(response.headers.get('date'));
+    return response;
+}
 
 export class RemoteChannel {
     private client: SupabaseClient | null = null;
@@ -115,13 +166,32 @@ export class RemoteChannel {
     private reconnectAttempt = 0;        // recreates since the last success
     private isRecreatingChannel = false; // re-entrancy guard
     private joiningSince: number | null = null; // start of an unbroken 'joining' run
+    /** Last confirmed proof of life (SUBSCRIBED or heartbeat 'ok'); null until the first one lands. */
+    private lastHeartbeatOkAt: number | null = null;
+    private heartbeatListenerRegistered = false;
+    /** Our own fixed-cadence auth refresh timer — see TOKEN_REFRESH_INTERVAL_MS. */
+    private tokenRefreshInterval: NodeJS.Timeout | null = null;
 
     private _user: User | null = null;
     get user(): User | null { return this._user; }
 
 
     initialize(url: string, key: string): void {
-        this.client = createClient(url, key);
+        // autoRefreshToken:false — we drive refresh ourselves (startTokenRefresh(),
+        // see TOKEN_REFRESH_INTERVAL_MS) instead of auth-js's local-clock-driven
+        // ticker. clockAwareFetch — see the clock-skew correction block above.
+        this.client = createClient(url, key, {
+            auth: { autoRefreshToken: false },
+            global: { fetch: clockAwareFetch },
+        });
+        if (!this.heartbeatListenerRegistered) {
+            this.heartbeatListenerRegistered = true;
+            try {
+                (this.client as any).realtime?.onHeartbeat?.((status: string) => {
+                    if (status === 'ok') this.lastHeartbeatOkAt = Date.now();
+                });
+            } catch { /* no onHeartbeat on this client version: staleness check stays inert */ }
+        }
     }
 
     async setSession(session: AuthSession): Promise<{ error: any }> {
@@ -464,6 +534,7 @@ export class RemoteChannel {
                     if (status === 'SUBSCRIBED') {
                         const recovered = this.reconnectAttempt;
                         this.reconnectAttempt = 0;
+                        this.lastHeartbeatOkAt = Date.now(); // a fresh join is proof of life too
                         console.log(`✅ Channel subscribed${recovered > 0 ? ` (recovered after ${recovered} attempt${recovered === 1 ? '' : 's'})` : ''}`);
                         // Update device status on successful connection (queued, so
                         // it can't be overtaken by a teardown's status write).
@@ -635,6 +706,19 @@ export class RemoteChannel {
         // 'joined' = healthy. Clear the joining-overstay timer.
         if (state === 'joined') {
             this.joiningSince = null;
+
+            // 'joined' is a cached string, not proof of a live socket. Cross-check
+            // against the last confirmed heartbeat reply.
+            if (this.lastHeartbeatOkAt !== null) {
+                const staleMs = Date.now() - this.lastHeartbeatOkAt;
+                if (staleMs > HEARTBEAT_STALE_TIMEOUT_MS) {
+                    console.debug(`[DEBUG] ⚠️ Channel reads 'joined' but no confirmed heartbeat in ${Math.round(staleMs / 1000)}s - forcing recreate — ${this.connState()}`);
+                    captureRemote('remote_channel_heartbeat_stale', { staleMs, attempt: this.reconnectAttempt });
+                    this.recreateChannel();
+                    return;
+                }
+            }
+
             // Self-heal a failed presence publish: the channel is up, so nothing
             // else will ever retry (SUBSCRIBED won't fire again), and without
             // presence the server reports this healthy device as offline.
@@ -745,7 +829,12 @@ export class RemoteChannel {
             // it a window to win: the old channel can come back 'joined' while we
             // slept. Destroying a healthy channel would cause a pointless outage
             // cycle — bail out instead (observed live on staging, 2026-07-23).
-            if (this.channel?.state === 'joined') {
+            // 'joined' alone isn't proof — only bail out when we don't already
+            // know the heartbeat is stale (this recreate may have been triggered
+            // by exactly that).
+            const heartbeatStale = this.lastHeartbeatOkAt !== null
+                && (Date.now() - this.lastHeartbeatOkAt) > HEARTBEAT_STALE_TIMEOUT_MS;
+            if (this.channel?.state === 'joined' && !heartbeatStale) {
                 console.log(`✅ Channel self-healed during backoff — skipping recreate — ${this.connState()}`);
                 return; // finally-block below clears the re-entrancy guard
             }
@@ -1011,7 +1100,38 @@ export class RemoteChannel {
         // withdraws the capability flag must fall back to the fast legacy
         // cadence immediately, not 30 minutes later.
         this.scheduleHeartbeat();
-        console.debug(`[DEBUG] Heartbeat started - connectionCheck: 10s, last_seen: ${this.heartbeatIntervalMs()}ms`);
+        this.startTokenRefresh();
+        console.debug(`[DEBUG] Heartbeat started - connectionCheck: 10s, last_seen: ${this.heartbeatIntervalMs()}ms, tokenRefresh: ${TOKEN_REFRESH_INTERVAL_MS}ms`);
+    }
+
+    private async refreshTokenNow(): Promise<void> {
+        if (!this.client || this.shuttingDown) return;
+        try {
+            const { error } = await this.client.auth.refreshSession();
+            if (error) {
+                console.error('[DEBUG] Manual token refresh failed:', error.message);
+                await captureRemote('remote_channel_token_refresh_error', { error });
+            } else {
+                console.debug('[DEBUG] Manual token refresh ok');
+            }
+        } catch (error: any) {
+            console.error('[DEBUG] Manual token refresh threw:', error?.message);
+            await captureRemote('remote_channel_token_refresh_error', { error });
+        }
+    }
+
+    private startTokenRefresh(): void {
+        if (this.tokenRefreshInterval) return; // already running
+        this.tokenRefreshInterval = setInterval(() => {
+            this.refreshTokenNow().catch(() => { /* logged inside */ });
+        }, TOKEN_REFRESH_INTERVAL_MS);
+    }
+
+    private stopTokenRefresh(): void {
+        if (this.tokenRefreshInterval) {
+            clearInterval(this.tokenRefreshInterval);
+            this.tokenRefreshInterval = null;
+        }
     }
 
     /** Arm (or re-arm) the last_seen timer at the current tier's cadence. */
@@ -1039,6 +1159,7 @@ export class RemoteChannel {
             clearInterval(this.connectionCheckInterval);
             this.connectionCheckInterval = null;
         }
+        this.stopTokenRefresh();
     }
 
     async setOnlineStatus(deviceId: string, status: 'online' | 'offline') {

--- a/test/test-remote-channel-reconnect.js
+++ b/test/test-remote-channel-reconnect.js
@@ -24,7 +24,7 @@
  * or standalone: `node test/test-remote-channel-reconnect.js`.
  */
 import assert from 'node:assert';
-import { RemoteChannel } from '../dist/remote-device/remote-channel.js';
+import { RemoteChannel, observeServerDate } from '../dist/remote-device/remote-channel.js';
 
 // Keep telemetry from touching the network during the test.
 process.env.DESKTOP_COMMANDER_DISABLE_TELEMETRY = '1';
@@ -88,6 +88,10 @@ class FakeRealtime {
   accessTokenValue = null;
   rebuilds = 0;
 
+  onHeartbeat(cb) {
+    this._heartbeatCb = cb;
+  }
+
   connectionState() {
     return this.conn.readyState === 1 ? 'open' : 'closed';
   }
@@ -105,10 +109,120 @@ class FakeRealtime {
     this.rebuildSocket();
     return Promise.resolve();
   }
+  /** setSession()/the TOKEN_REFRESHED handler both call this to re-authorize
+   * the socket with the current access token. */
+  setAuth(token) {
+    this.accessTokenValue = token;
+  }
+}
+
+// Real, unskewed Date.now — captured at module load, before any test installs
+// a Date.now mock to simulate a skewed DEVICE clock. Used only to build
+// SERVER-side JWTs below: a real auth server's own clock is never the skewed
+// one, only the device reading its response is, so every token FakeAuth
+// "issues" must carry a genuinely true `iat`/`exp`, exactly like production.
+const trueNow = Date.now;
+
+/** Minimal base64url JWT encoder — no signature needed, FakeAuth just decodes
+ * the payload segment back out. */
+function makeJWT(payload) {
+  const b64url = (obj) => Buffer.from(JSON.stringify(obj)).toString('base64url');
+  return `${b64url({ alg: 'none', typ: 'JWT' })}.${b64url(payload)}.sig`;
+}
+
+function decodeJwtPayload(token) {
+  return JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString('utf8'));
+}
+
+/** A fresh, genuinely-valid token exactly as the SERVER would issue it: iat/exp
+ * from TRUE time, never the (possibly mocked/skewed) Date.now() the code under
+ * test sees. `n` disambiguates successive refreshes for debugging. */
+function freshServerToken(n = 0) {
+  const iat = Math.floor(trueNow() / 1000);
+  return makeJWT({ iat, exp: iat + 3600, sub: 'user-1', n });
+}
+
+/**
+ * Models the subset of supabase-js's `client.auth` that remote-channel.ts
+ * actually calls: setSession()/getUser()/getSession()/onAuthStateChange()
+ * from RemoteChannel.setSession(), and refreshSession() for the manual-refresh
+ * fix under test (see the clock-skew regression tests below).
+ *
+ * setSession() and getSession() mirror auth-js's OWN expiry decisions
+ * (GoTrueClient.js's _setSession() and __loadSession(), confirmed by direct
+ * source read) — both compare a token's claimed expiry against Date.now(),
+ * NEITHER gated by autoRefreshToken. That's the exact gap autoRefreshToken:
+ * false does not close, and the exact gap the clock-skew regression tests
+ * below need a faithful model of to prove closed — round 1's version of this
+ * fake didn't model either check, which is exactly how its test missed the
+ * gap. The internal autoRefreshToken ticker itself is deliberately still NOT
+ * modeled: it's disabled by the fix and orthogonal to what these two checks
+ * cover (confirmed by direct source read of _autoRefreshTokenTick()).
+ */
+class FakeAuth {
+  static EXPIRY_MARGIN_MS = 90 * 1000; // @supabase/auth-js's real EXPIRY_MARGIN_MS
+
+  session = null;
+  refreshCalls = 0;
+  listeners = [];
+
+  /** Mirrors GoTrueClient.js's _setSession() (~L1363): decides "expired" from
+   * the PASSED TOKEN's own `exp` claim vs Date.now(), regardless of
+   * autoRefreshToken, refreshing internally when so. */
+  async setSession({ access_token, refresh_token }) {
+    const { exp } = decodeJwtPayload(access_token);
+    const timeNow = Date.now() / 1000;
+    if (exp && exp <= timeNow) {
+      return this._refresh(refresh_token);
+    }
+    this.session = { access_token, refresh_token, expires_at: exp };
+    return { error: null };
+  }
+  async getUser() {
+    return { data: { user: { id: 'user-1', email: 'tester@example.com' } }, error: null };
+  }
+  /** Mirrors GoTrueClient.js's __loadSession() (~L1201), invoked by EVERY
+   * getSession() call — and so, via supabase-js's fetchWithAuth ->
+   * _getAccessToken(), by every outgoing REST request. NOT gated by
+   * autoRefreshToken (confirmed by direct source read) — this is the gap
+   * round 1's autoRefreshToken:false missed. */
+  async getSession() {
+    if (this.session) {
+      const hasExpired = this.session.expires_at * 1000 - Date.now() < FakeAuth.EXPIRY_MARGIN_MS;
+      if (hasExpired) await this._refresh(this.session.refresh_token);
+    }
+    return { data: { session: this.session }, error: null };
+  }
+  onAuthStateChange(cb) {
+    this.listeners.push(cb);
+    return { data: { subscription: { unsubscribe() {} } } };
+  }
+  /** What the fix's fixed-cadence timer calls directly. */
+  async refreshSession() {
+    return this._refresh(this.session?.refresh_token ?? 'rt-0');
+  }
+  /**
+   * Shared by every internal (setSession/getSession) and external
+   * (refreshSession) refresh trigger. Mirrors real auth-js's
+   * _callRefreshToken(), which notifies 'TOKEN_REFRESHED' subscribers
+   * unconditionally (verified by direct source read) — that's what keeps
+   * setSession()'s realtime.setAuth() re-authorization working regardless of
+   * what triggered the refresh. Always issues a token with TRUE-time
+   * iat/exp: a real server's clock is never the skewed one.
+   */
+  async _refresh(refreshToken) {
+    this.refreshCalls++;
+    const token = freshServerToken(this.refreshCalls);
+    const { exp } = decodeJwtPayload(token);
+    this.session = { access_token: token, refresh_token: refreshToken, expires_at: exp };
+    for (const cb of this.listeners) cb('TOKEN_REFRESHED', this.session);
+    return { data: { session: this.session }, error: null };
+  }
 }
 
 class FakeClient {
   realtime = new FakeRealtime();
+  auth = new FakeAuth();
   channels = [];
   statusLog = [];
 
@@ -239,6 +353,73 @@ async function driveHealthChecksStuckJoining(rc, maxTicks) {
   return !!(rc.channel && rc.channel.state === 'joined');
 }
 
+/**
+ * The gap neither of the above cover: a half-open socket where realtime-js's own
+ * heartbeat-timeout-then-close never completes (the close handshake waits on a
+ * peer ack that never comes), so `channel.state` stays 'joined' forever — never
+ * 'joining', never 'errored'. Nothing about this shape was previously visible to
+ * checkConnectionHealth(), which short-circuits as healthy on 'joined'.
+ */
+async function goHalfOpenStuckJoined(rc, client) {
+  await rc.createChannel(); // healthy subscribe -> 'joined', lastHeartbeatOkAt set
+  assert.strictEqual(rc.channel.state, 'joined', 'precondition: channel should be joined');
+  client.realtime.socketDead = true; // dead peer; channel.state is never told
+}
+
+/**
+ * Drive the 10s health-check while state stays 'joined' throughout, advancing a
+ * simulated clock past HEARTBEAT_STALE_TIMEOUT_MS (75s) without real delay.
+ * channel.state can't signal recovery here (it never left 'joined'), so recovery
+ * is judged by whether a fresh socket actually got forced.
+ */
+async function driveHealthChecksStuckJoined(rc, client, maxTicks) {
+  const realNow = Date.now;
+  let simulated = realNow();
+  Date.now = () => simulated;
+  try {
+    for (let i = 0; i < maxTicks; i++) {
+      if (client.realtime.rebuilds > 0) return true;
+      rc.checkConnectionHealth();
+      await flush();
+      await flush();
+      simulated += 10_000;
+    }
+  } finally {
+    Date.now = realNow;
+  }
+  return client.realtime.rebuilds > 0;
+}
+
+/**
+ * Intercept the real global setInterval/clearInterval so a test can (a) prove
+ * startHeartbeat() actually arms a timer at a given fixed cadence rather than
+ * something short/clock-driven, and (b) drive that timer by invoking the
+ * captured callback directly instead of waiting on real wall-clock time (the
+ * token-refresh cadence under test is 45 real minutes). Scoped to a single
+ * `fn` call and always restored, mirroring the Date.now() overrides above.
+ */
+async function withMockedIntervals(fn) {
+  const realSetInterval = global.setInterval;
+  const realClearInterval = global.clearInterval;
+  const registered = []; // { id, ms, cb, cleared }
+  let nextId = 1;
+  global.setInterval = (cb, ms) => {
+    const id = nextId++;
+    registered.push({ id, ms, cb, cleared: false });
+    return id;
+  };
+  global.clearInterval = (id) => {
+    const entry = registered.find((r) => r.id === id);
+    if (entry) entry.cleared = true;
+  };
+  try {
+    return await fn(registered);
+  } finally {
+    global.setInterval = realSetInterval;
+    global.clearInterval = realClearInterval;
+  }
+}
+
 // Silence the (intentionally verbose) diagnostic logging during the drive so
 // the test output stays readable; we summarise via the fake's statusLog instead.
 // Must await so console is restored only after the async callbacks have fired.
@@ -346,6 +527,137 @@ async function main() {
         `     attempts(recreate)=${rc.reconnectAttempt} rebuilds=${client.realtime.rebuilds}\n` +
         `     channelState=${rc.channel && rc.channel.state} socketReadyState=${client.realtime.conn.readyState}`
     );
+  });
+
+  // REGRESSION REPRO: a half-open socket where channel.state never leaves
+  // 'joined' at all — the shape the 'joining'-wedge fix above doesn't cover,
+  // since it never sees anything but 'joined'. Recovery here depends entirely
+  // on the heartbeat-staleness check.
+  await test('recovers when a half-open socket leaves the channel stuck at joined', async () => {
+    const { rc, client } = makeRemoteChannel();
+    const recovered = await withQuietLogs(async () => {
+      await goHalfOpenStuckJoined(rc, client);
+      return driveHealthChecksStuckJoined(rc, client, 10); // 100s simulated; 75s bound fires by tick ~8
+    });
+    assert.strictEqual(
+      recovered,
+      true,
+      `channel wedged at 'joined' on a half-open socket and never recovered.\n` +
+        `     attempts(recreate)=${rc.reconnectAttempt} rebuilds=${client.realtime.rebuilds}\n` +
+        `     channelState=${rc.channel && rc.channel.state} socketReadyState=${client.realtime.conn.readyState}`
+    );
+  });
+
+  // The fixed-cadence refresh timer (defense-in-depth alongside
+  // observeServerDate) must stay capped to one refreshSession() call per tick
+  // even under sustained clock skew, keep the realtime socket re-authorized,
+  // and tear down cleanly on shutdown.
+  await test('token refresh runs on a fixed cadence under simulated clock skew, and stops cleanly on shutdown', async () => {
+    const { rc, client } = makeRemoteChannel();
+    await withQuietLogs(async () => {
+      await withMockedIntervals(async (registered) => {
+        const realNow = Date.now;
+        const SKEW_MS = 3 * 60 * 60 * 1000; // 3h fast, matches the confirmed prod device
+        Date.now = () => realNow() + SKEW_MS;
+        try {
+          await rc.setSession({ access_token: freshServerToken(), refresh_token: 'seed-refresh' });
+          // setSession() itself can cost 1-2 refreshes under this much skew
+          // (its own internal _setSession() check, then the immediate
+          // getSession() call remote-channel.ts makes right after) — a
+          // bounded, one-time bootstrap cost, not what this test is about.
+          const afterSetSession = client.auth.refreshCalls;
+
+          rc.startHeartbeat('device-1');
+
+          const tokenTimer = registered.find((r) => r.ms === 45 * 60 * 1000); // TOKEN_REFRESH_INTERVAL_MS
+          assert.ok(
+            tokenTimer,
+            `expected startHeartbeat() to arm a fixed 45-minute refresh timer; registered intervals=${JSON.stringify(
+              registered.map((r) => r.ms)
+            )}`
+          );
+
+          // Fire it repeatedly, simulating hours of continued operation under
+          // the skewed clock. Capped-by-design: exactly one refreshSession()
+          // call per timer tick, never more — unlike the old ticker, which
+          // under this same skew would re-fire on every ~30s AUTO_REFRESH_TICK
+          // because it always finds the (skewed-relative) token "expired".
+          for (let i = 1; i <= 6; i++) {
+            tokenTimer.cb();
+            await flush();
+            await flush();
+            assert.strictEqual(
+              client.auth.refreshCalls,
+              afterSetSession + i,
+              `expected exactly ${i} refreshSession() call(s) after ${i} tick(s) on top of the ${afterSetSession} ` +
+              `bootstrap refresh(es), got ${client.auth.refreshCalls} total — refresh must stay capped to one per ` +
+              `fixed-interval tick, not fire unbounded`
+            );
+          }
+
+          // setSession()'s TOKEN_REFRESHED handler must still re-authorize the
+          // realtime socket, regardless of what triggered the refresh.
+          assert.strictEqual(
+            client.realtime.accessTokenValue,
+            client.auth.session.access_token,
+            'TOKEN_REFRESHED handler must still re-authorize the realtime socket when refresh is driven by our own timer'
+          );
+
+          rc.stopHeartbeat();
+          assert.strictEqual(
+            tokenTimer.cleared,
+            true,
+            'stopHeartbeat() must clear the token-refresh timer — a leaked timer would keep the process alive past shutdown'
+          );
+        } finally {
+          Date.now = realNow;
+        }
+      });
+    });
+  });
+
+  // observeServerDate reads the `Date` header every Supabase response carries
+  // (the server's real clock) instead of inferring skew from a token — see
+  // remote-channel.ts. A big disagreement must correct Date.now; a small one
+  // must not touch it; and a resolved skew must restore the original.
+  await test('observeServerDate corrects Date.now when the server disagrees by a lot', async () => {
+    await withQuietLogs(async () => {
+      const trueNow = Date.now;
+      try {
+        const serverDate = new Date(trueNow() - 3 * 60 * 60 * 1000).toUTCString(); // server 3h behind
+        observeServerDate(serverDate);
+        assert.notStrictEqual(Date.now, trueNow, 'expected Date.now to be patched');
+        assert.ok(
+          Math.abs(Date.now() - Date.parse(serverDate)) < 2000,
+          `expected corrected Date.now() to track the server's stated time, off by ${Date.now() - Date.parse(serverDate)}ms`
+        );
+      } finally {
+        observeServerDate(new Date().toUTCString()); // resolve skew -> restores Date.now
+      }
+    });
+  });
+
+  await test('observeServerDate leaves Date.now untouched for ordinary clock drift', () => {
+    const trueNow = Date.now;
+    observeServerDate(new Date(trueNow() + 30_000).toUTCString()); // 30s, well under the 5min threshold
+    assert.strictEqual(Date.now, trueNow, 'a small disagreement must not patch Date.now');
+  });
+
+  await test('observeServerDate restores Date.now once skew resolves', async () => {
+    await withQuietLogs(async () => {
+      const trueNow = Date.now;
+      observeServerDate(new Date(trueNow() - 3 * 60 * 60 * 1000).toUTCString());
+      assert.notStrictEqual(Date.now, trueNow, 'precondition: should be patched');
+      observeServerDate(new Date().toUTCString());
+      assert.strictEqual(Date.now, trueNow, 'expected Date.now restored once the server agrees again');
+    });
+  });
+
+  await test('observeServerDate ignores a missing or malformed Date header', () => {
+    const trueNow = Date.now;
+    observeServerDate(null);
+    observeServerDate('not a date');
+    assert.strictEqual(Date.now, trueNow, 'must not patch Date.now on unusable input');
   });
 
   // The jittered backoff exists so a fleet-wide event (server deploy, Supabase

--- a/test/test-remote-channel-reconnect.js
+++ b/test/test-remote-channel-reconnect.js
@@ -331,14 +331,15 @@ async function goHalfOpenStuckJoining(rc, client) {
 
 /**
  * Drive the 10s health-check while the channel is stuck 'joining' on a half-open socket.
- * Advances a SIMULATED clock 10s per tick (the real health-check interval) so a
- * time-bounded guard can observe how long the channel has overstayed 'joining' without
- * the test burning real wall-clock. Returns whether the channel recovered.
+ * Advances a SIMULATED monotonic clock (performance.now — what the liveness guards
+ * read) 10s per tick (the real health-check interval) so a time-bounded guard can
+ * observe how long the channel has overstayed 'joining' without the test burning
+ * real wall-clock. Returns whether the channel recovered.
  */
 async function driveHealthChecksStuckJoining(rc, maxTicks) {
-  const realNow = Date.now;
-  let simulated = realNow();
-  Date.now = () => simulated;
+  const realPerfNow = performance.now;
+  let simulated = realPerfNow.call(performance);
+  performance.now = () => simulated;
   try {
     for (let i = 0; i < maxTicks; i++) {
       if (rc.channel && rc.channel.state === 'joined') return true;
@@ -348,7 +349,7 @@ async function driveHealthChecksStuckJoining(rc, maxTicks) {
       simulated += 10_000; // advance one 10s health-check interval
     }
   } finally {
-    Date.now = realNow;
+    performance.now = realPerfNow;
   }
   return !!(rc.channel && rc.channel.state === 'joined');
 }
@@ -368,14 +369,23 @@ async function goHalfOpenStuckJoined(rc, client) {
 
 /**
  * Drive the 10s health-check while state stays 'joined' throughout, advancing a
- * simulated clock past HEARTBEAT_STALE_TIMEOUT_MS (75s) without real delay.
- * channel.state can't signal recovery here (it never left 'joined'), so recovery
- * is judged by whether a fresh socket actually got forced.
+ * simulated monotonic clock (performance.now — what the liveness guards read)
+ * past HEARTBEAT_STALE_TIMEOUT_MS (75s) without real delay. channel.state can't
+ * signal recovery here (it never left 'joined'), so recovery is judged by
+ * whether a fresh socket actually got forced.
+ *
+ * Regression guard baked in: Date.now() is pinned hours BACKWARD for the whole
+ * drive — the clock-skew correction can move Date.now by exactly such an offset
+ * mid-run, and staleness detection must not care (it reads performance.now).
+ * Against a Date.now-based implementation this skew makes staleMs negative and
+ * the recovery below never fires.
  */
 async function driveHealthChecksStuckJoined(rc, client, maxTicks) {
-  const realNow = Date.now;
-  let simulated = realNow();
-  Date.now = () => simulated;
+  const realPerfNow = performance.now;
+  const realDateNow = Date.now;
+  let simulated = realPerfNow.call(performance);
+  performance.now = () => simulated;
+  Date.now = () => realDateNow() - 6 * 3600_000;
   try {
     for (let i = 0; i < maxTicks; i++) {
       if (client.realtime.rebuilds > 0) return true;
@@ -385,7 +395,8 @@ async function driveHealthChecksStuckJoined(rc, client, maxTicks) {
       simulated += 10_000;
     }
   } finally {
-    Date.now = realNow;
+    performance.now = realPerfNow;
+    Date.now = realDateNow;
   }
   return client.realtime.rebuilds > 0;
 }


### PR DESCRIPTION
## Summary
Two independent device-connector bugs, both surfaced while investigating a prod Realtime "Unauthorized" flood:

- **Clock-skew refresh storm**: a forward-skewed device clock makes `@supabase/auth-js` treat every fresh token as already-expired, refreshing in a tight loop forever (confirmed in prod: one device did 9,300+ refreshes/24h vs a healthy ~1/50min baseline, and recurred again days later on the same machine). Disables `autoRefreshToken` and drives refresh on our own fixed 45-min cadence, and corrects `Date.now()` for the process from the `Date` header every Supabase response carries — covers every expiry check in the library regardless of where it lives, rather than chasing individual call sites (two rounds of this fix landed on the wrong mechanism before this one).
- **Half-open socket wedge**: `checkConnectionHealth()` trusted `channel.state === 'joined'` as proof of life with no independent verification, so a half-open socket (sleep/wake, dead peer) could leave it reading `'joined'` forever with zero recovery attempt and zero telemetry. Cross-checks against the last confirmed realtime heartbeat reply and forces a recreate once it goes stale.

## Test plan
- [x] `npm run build` clean
- [x] `node test/test-remote-channel-reconnect.js` — 10/10 passing
- [x] Verified each new test is a genuine repro: stashed the fix, confirmed the relevant tests fail against unfixed code, restored, confirmed all pass
- [x] Independently adversarially reviewed (separate pass re-ran build/tests/repro itself rather than trusting the implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7Fbq5nDibWXDHGxHn6zRq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when realtime connections become stale, stuck, or miss heartbeat signals.
  * Improved authentication token refresh reliability, including support for differences between local and server time.
  * Improved cleanup when connection monitoring and token refresh are stopped.

* **Reliability**
  * Unhealthy realtime channels are detected and recreated automatically.
  * Connection and session timing remains reliable when the device clock changes unexpectedly.
  * Telemetry timestamps are better aligned with server time.
  * Sessions that cannot be restored after sign-out are correctly marked offline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->