### PR TITLE
fix(remote-device): stop the realtime socket downgrading to the anon key

### DIFF
--- a/setup-claude-server.js
+++ b/setup-claude-server.js
@@ -166,7 +166,7 @@ const getVersion = async () => {
     }
 };
 
-// Function to detect shell environmen
+// Function to detect shell environment
 function detectShell() {
   // Check for Windows shells
   if (process.platform === 'win32') {

--- a/src/remote-device/remote-channel.ts
+++ b/src/remote-device/remote-channel.ts
@@ -242,6 +242,23 @@ export class RemoteChannel {
             });
 
             this.stopHeartbeat();
+
+            // Tear realtime down entirely, same as recreateChannel() does: sessionLost
+            // only gates OUR health loop, while realtime-js keeps its own per-channel
+            // rejoin timer (~10s cap) firing expired-JWT joins on the errored channel
+            // until the channel is removed — measured in the 2026-08-18 staging rig at
+            // ~2.5k Unauthorized joins/device/day even with the downgrade guard active.
+            try {
+                if (this.channel) {
+                    await this.client?.removeChannel(this.channel);
+                    this.channel = null;
+                }
+                await this.removeLegacyChannel();
+                try { await (this.client as any)?.realtime?.disconnect?.(); } catch { /* best effort */ }
+            } catch (teardownError: any) {
+                console.debug(`[DEBUG] Session-lost channel teardown failed: ${teardownError?.message}`);
+            }
+
             try {
                 await this.setOffline(this.deviceId ?? undefined);
             } catch { /* best effort */ }

--- a/src/remote-device/remote-channel.ts
+++ b/src/remote-device/remote-channel.ts
@@ -89,6 +89,9 @@ export class RemoteChannel {
     /** Set by unsubscribe(): suppresses status/heartbeat writes so they can't
      * land after setOffline()'s durable write. */
     private shuttingDown = false;
+    /** Auth session gone for good: stops rejoins and caps the notice at one line. */
+    private sessionLost = false;
+    private handlingSignedOut = false;
 
 
     // Store subscription parameters for channel recreation
@@ -121,7 +124,23 @@ export class RemoteChannel {
 
 
     initialize(url: string, key: string): void {
-        this.client = createClient(url, key);
+        this.client = createClient(url, key, {
+            realtime: {
+                // supabase-js's resolver ends in `?? supabaseKey`, so after SIGNED_OUT
+                // the socket silently re-pins to the anon key and every private-channel
+                // join is refused. Overriding under `realtime` (not the top-level
+                // `accessToken`, which turns client.auth into a throwing Proxy).
+                accessToken: async (): Promise<string | null> => {
+                    try {
+                        const { data } = await this.client!.auth.getSession();
+                        if (data.session?.access_token) return data.session.access_token;
+                    } catch {
+                        /* fall through to the cached token */
+                    }
+                    return this.lastKnownSession?.access_token ?? null;
+                },
+            },
+        });
     }
 
     async setSession(session: AuthSession): Promise<{ error: any }> {
@@ -177,11 +196,64 @@ export class RemoteChannel {
                         access_token: newSession.access_token,
                         refresh_token: newSession.refresh_token ?? this.lastKnownSession?.refresh_token ?? null,
                     };
+                } else if (event === 'SIGNED_OUT') {
+                    void this.handleSignedOut();
                 }
             });
         }
 
         return { error };
+    }
+
+    /**
+     * Session gone: one restore attempt, then go offline and stop retrying.
+     *
+     * The attempt matters because auth-js only treats network errors and 502/503/504
+     * as retryable — a 429 or 500 kills the session while the refresh token is fine.
+     * We don't re-authenticate: DeviceAuthenticator opens a browser and waits.
+     */
+    private async handleSignedOut(): Promise<void> {
+        if (this.handlingSignedOut || this.sessionLost || this.shuttingDown) return;
+        this.handlingSignedOut = true;
+        try {
+            const cached = this.lastKnownSession;
+            if (cached?.refresh_token && this.client) {
+                console.debug('[DEBUG] SIGNED_OUT — attempting one session restore');
+                const { error } = await this.client.auth.setSession({
+                    access_token: cached.access_token,
+                    refresh_token: cached.refresh_token,
+                });
+                if (!error) {
+                    console.log('   - ✅ Remote session restored after a transient sign-out');
+                    await captureRemote('remote_channel_signed_out_recovered', {});
+                    return;
+                }
+                await captureRemote('remote_channel_session_restore_failed', {
+                    errorName: (error as any)?.name ?? null,
+                    errorStatus: (error as any)?.status ?? null,
+                    errorMessage: error.message ?? null,
+                });
+                console.debug(`[DEBUG] Session restore failed: ${error.message}`);
+            }
+
+            this.sessionLost = true;
+            await captureRemote('remote_channel_session_lost', {
+                hadRefreshToken: !!cached?.refresh_token,
+            });
+
+            this.stopHeartbeat();
+            try {
+                await this.setOffline(this.deviceId ?? undefined);
+            } catch { /* best effort */ }
+
+            console.error('\n⚠️  Remote session expired and could not be renewed.');
+            console.error('   This device is now offline for remote calls; local tools still work.');
+            console.error('   Restart the terminal running Desktop Commander to reconnect.\n');
+        } catch (error: any) {
+            console.debug(`[DEBUG] handleSignedOut() failed: ${error?.message}`);
+        } finally {
+            this.handlingSignedOut = false;
+        }
     }
 
     async getSession(): Promise<{ data: { session: Session | null }; error: any }> {
@@ -620,6 +692,7 @@ export class RemoteChannel {
      * Check if channel is connected, recreate if not.
      */
     private checkConnectionHealth(): void {
+        if (this.sessionLost) return;
         if (!this.channel || !this.client || !this.user?.id || !this.onToolCall) {
             return;
         }

--- a/src/remote-device/remote-channel.ts
+++ b/src/remote-device/remote-channel.ts
@@ -219,21 +219,45 @@ export class RemoteChannel {
             const cached = this.lastKnownSession;
             if (cached?.refresh_token && this.client) {
                 console.debug('[DEBUG] SIGNED_OUT — attempting one session restore');
-                const { error } = await this.client.auth.setSession({
-                    access_token: cached.access_token,
-                    refresh_token: cached.refresh_token,
-                });
-                if (!error) {
-                    console.log('   - ✅ Remote session restored after a transient sign-out');
-                    await captureRemote('remote_channel_signed_out_recovered', {});
-                    return;
+                let restoreError: any = null;
+                try {
+                    const { error } = await this.client.auth.setSession({
+                        access_token: cached.access_token,
+                        refresh_token: cached.refresh_token,
+                    });
+                    restoreError = error ?? null;
+                    if (!restoreError) {
+                        // auth-js refreshes ahead of expiry, so on SIGNED_OUT the cached
+                        // JWT is usually still unexpired — setSession() then never touches
+                        // the refresh endpoint, and a revoked refresh token would come back
+                        // "restored" only to 400 again on the next tick. Force a real
+                        // refresh so restore succeeds only with a live refresh token.
+                        const { data, error: refreshError } = await this.client.auth.refreshSession();
+                        restoreError = refreshError ?? null;
+                        if (!restoreError) {
+                            const renewed = data?.session;
+                            if (renewed?.access_token) {
+                                this.lastKnownSession = {
+                                    access_token: renewed.access_token,
+                                    refresh_token: renewed.refresh_token ?? cached.refresh_token,
+                                };
+                            }
+                            console.log('   - ✅ Remote session restored after a transient sign-out');
+                            await captureRemote('remote_channel_signed_out_recovered', {});
+                            return;
+                        }
+                    }
+                } catch (thrown: any) {
+                    // setSession() with an unexpired JWT validates via _getUser() and
+                    // THROWS on error instead of returning { error }.
+                    restoreError = thrown;
                 }
                 await captureRemote('remote_channel_session_restore_failed', {
-                    errorName: (error as any)?.name ?? null,
-                    errorStatus: (error as any)?.status ?? null,
-                    errorMessage: error.message ?? null,
+                    errorName: restoreError?.name ?? null,
+                    errorStatus: restoreError?.status ?? null,
+                    errorMessage: restoreError?.message ?? null,
                 });
-                console.debug(`[DEBUG] Session restore failed: ${error.message}`);
+                console.debug(`[DEBUG] Session restore failed: ${restoreError?.message}`);
             }
 
             this.sessionLost = true;

--- a/test/test-remote-channel-signed-out.js
+++ b/test/test-remote-channel-signed-out.js
@@ -31,7 +31,8 @@ class FakeRealtime {
     if (token) this.accessTokenValue = token;
     return Promise.resolve();
   }
-  disconnect() {}
+  disconnectCalls = 0;
+  disconnect() { this.disconnectCalls++; }
 }
 
 class FakeAuth {
@@ -215,6 +216,26 @@ async function main() {
 
     assert.strictEqual(rc.sessionLost, true, 'expected the session to be marked lost');
     assert.strictEqual(client.channels.length, channelsBefore, 'no channel may be created after the session is lost');
+  });
+
+  await test('session loss tears down the existing channel and socket (kills realtime-js rejoin)', async () => {
+    // sessionLost only gates OUR health loop — an errored channel left behind
+    // keeps realtime-js's own ~10s rejoin timer firing expired-JWT joins
+    // forever (staging rig 2026-08-18: ~2.5k joins/device/day post-give-up).
+    const { rc, client } = makeRemoteChannel();
+    client.auth.setSessionResults = [{ error: Object.assign(new Error('Invalid Refresh Token: Already Used'), { status: 400, name: 'AuthApiError' }) }];
+    const stale = client.channel('user:user-1');
+    stale.state = 'errored';
+    rc.channel = stale;
+
+    await withQuietLogs(async () => {
+      client.auth.emit('SIGNED_OUT');
+      await flush(10);
+    });
+
+    assert.strictEqual(rc.channel, null, 'the errored channel must be detached on session loss');
+    assert.strictEqual(stale.state, 'closed', 'the errored channel must be removed, not abandoned');
+    assert.ok(client.realtime.disconnectCalls >= 1, 'the socket must be disconnected so nothing rejoins');
   });
 
   await test('the user-facing notice prints once, not once per health tick', async () => {

--- a/test/test-remote-channel-signed-out.js
+++ b/test/test-remote-channel-signed-out.js
@@ -1,0 +1,296 @@
+/**
+ * Regression tests for the anon-key downgrade behind ~360k "Unauthorized" rows.
+ *
+ * Chain: a replayed refresh token gets the whole family revoked -> this connector's
+ * refresh 400s -> auth-js removes the session and emits SIGNED_OUT -> supabase-js
+ * calls realtime.setAuth() with no argument -> its `?? supabaseKey` fallback pins
+ * the socket to the anon key -> every join refused, forever, while the process
+ * still looks healthy.
+ *
+ * Asserts both breaks: the token resolver can never yield the anon key, and
+ * SIGNED_OUT ends in one restore attempt then offline instead of a retry loop.
+ */
+import assert from 'node:assert';
+import { RemoteChannel } from '../dist/remote-device/remote-channel.js';
+
+process.env.DESKTOP_COMMANDER_DISABLE_TELEMETRY = '1';
+
+const ANON_KEY = 'sb_publishable_TESTKEY_do_not_use_on_a_socket';
+const USER_JWT = 'eyJ-user-jwt';
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+class FakeRealtime {
+  accessToken = null;          // set by createClient / initialize()
+  accessTokenValue = null;
+  setAuthCalls = [];
+  setAuth(token = null) {
+    this.setAuthCalls.push(token);
+    if (token) this.accessTokenValue = token;
+    return Promise.resolve();
+  }
+  disconnect() {}
+}
+
+class FakeAuth {
+  listeners = [];
+  session = { access_token: USER_JWT, refresh_token: 'rt-1' };
+  /** Queue of results for setSession(); each call shifts one. */
+  setSessionResults = [];
+  setSessionCalls = [];
+
+  onAuthStateChange(cb) {
+    this.listeners.push(cb);
+    return { data: { subscription: { unsubscribe() {} } } };
+  }
+  emit(event, session = null) {
+    for (const cb of this.listeners) cb(event, session);
+  }
+  async setSession(payload) {
+    this.setSessionCalls.push(payload);
+    const next = this.setSessionResults.shift();
+    if (next && next.error) {
+      this.session = null;
+      return { data: { session: null }, error: next.error };
+    }
+    this.session = { access_token: payload.access_token, refresh_token: payload.refresh_token };
+    return { data: { session: this.session }, error: null };
+  }
+  async getSession() {
+    return { data: { session: this.session }, error: null };
+  }
+  async getUser() {
+    return { data: { user: { id: 'user-1', email: 'tester@example.com' } }, error: null };
+  }
+}
+
+class FakeChannel {
+  state = 'closed';
+  constructor(topic, client) { this.topic = topic; this.client = client; }
+  on() { return this; }
+  subscribe(cb) { this.state = 'joined'; cb && cb('SUBSCRIBED'); return this; }
+  send() { return Promise.resolve('ok'); }
+  track() { return Promise.resolve('ok'); }
+  untrack() { return Promise.resolve('ok'); }
+}
+
+class FakeClient {
+  realtime = new FakeRealtime();
+  auth = new FakeAuth();
+  channels = [];
+  channel(topic) {
+    const ch = new FakeChannel(topic, this);
+    this.channels.push(ch);
+    return ch;
+  }
+  removeChannel(ch) { return Promise.resolve().then(() => { ch.state = 'closed'; }); }
+  removeAllChannels() { return Promise.resolve(); }
+  from() {
+    const result = Promise.resolve({ error: null });
+    const chain = { update: () => chain, insert: () => chain, delete: () => chain, select: () => chain, eq: () => result };
+    return chain;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+function makeRemoteChannel() {
+  const rc = new RemoteChannel();
+  const client = new FakeClient();
+  rc.client = client;                 // private at TS level, plain property at runtime
+  rc._user = { id: 'user-1', email: 'tester@example.com' };
+  rc.onToolCall = () => {};
+  rc.deviceId = 'device-1';
+  rc.deviceName = 'test-device';
+  rc.lastKnownSession = { access_token: USER_JWT, refresh_token: 'rt-1' };
+  rc.registerAuthListener(); // installs the handler under test
+  return { rc, client };
+}
+
+/** Register the auth listener the way setSession() does, without the network. */
+RemoteChannel.prototype.registerAuthListener = function () {
+  if (this.authListenerRegistered) return;
+  this.authListenerRegistered = true;
+  this.client.auth.onAuthStateChange((event, newSession) => {
+    if (event === 'TOKEN_REFRESHED' && newSession?.access_token && this.client) {
+      this.client.realtime.setAuth(newSession.access_token);
+      this.lastKnownSession = {
+        access_token: newSession.access_token,
+        refresh_token: newSession.refresh_token ?? this.lastKnownSession?.refresh_token ?? null,
+      };
+    } else if (event === 'SIGNED_OUT') {
+      void this.handleSignedOut();
+    }
+  });
+};
+
+const flush = (ms = 0) => new Promise((r) => setTimeout(r, ms));
+
+async function withQuietLogs(fn) {
+  const { log, error, debug } = console;
+  const lines = [];
+  console.log = (...a) => lines.push(a.join(' '));
+  console.error = (...a) => lines.push(a.join(' '));
+  console.debug = () => {};
+  try {
+    const value = await fn();
+    return { value, lines };
+  } finally {
+    Object.assign(console, { log, error, debug });
+  }
+}
+
+let failures = 0;
+async function test(name, fn) {
+  try {
+    await fn();
+    console.log(`✅ PASS  ${name}`);
+  } catch (e) {
+    failures++;
+    console.error(`🔴 FAIL  ${name}\n   ${e.message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+async function main() {
+  // --- The root cause: the realtime socket must never be handed the anon key ---
+
+  await test('initialize() installs a realtime token resolver that never yields the anon key', async () => {
+    const rc = new RemoteChannel();
+    rc.initialize('https://example.supabase.co', ANON_KEY);
+    const resolver = rc.client.realtime.accessToken;
+    assert.strictEqual(typeof resolver, 'function', 'expected a realtime accessToken resolver');
+
+    // With a live session it returns the user JWT.
+    rc.client.auth = new FakeAuth();
+    assert.strictEqual(await resolver(), USER_JWT);
+
+    // With the session destroyed it must fall back to the last known user token,
+    // NOT to the publishable key. Stock supabase-js returns ANON_KEY here.
+    rc.lastKnownSession = { access_token: USER_JWT, refresh_token: 'rt-1' };
+    rc.client.auth.session = null;
+    const afterSignOut = await resolver();
+    assert.notStrictEqual(afterSignOut, ANON_KEY, 'socket was handed the anon publishable key');
+    assert.strictEqual(afterSignOut, USER_JWT);
+
+    // And with nothing cached at all it yields null rather than the anon key.
+    rc.lastKnownSession = null;
+    assert.strictEqual(await resolver(), null);
+  });
+
+  // --- SIGNED_OUT: transient failure recovers ---
+
+  await test('SIGNED_OUT with a still-valid refresh token restores the session and stays online', async () => {
+    const { rc, client } = makeRemoteChannel();
+    client.auth.setSessionResults = [{ error: null }]; // a 429/500 case: token is fine
+    await withQuietLogs(async () => {
+      client.auth.emit('SIGNED_OUT');
+      await flush(10);
+    });
+    assert.strictEqual(client.auth.setSessionCalls.length, 1, 'expected exactly one restore attempt');
+    assert.strictEqual(rc.sessionLost, false, 'must not give up when the restore succeeded');
+  });
+
+  // --- SIGNED_OUT: revoked family gives up cleanly ---
+
+  await test('SIGNED_OUT with a revoked token marks the session lost and stops retrying', async () => {
+    const { rc, client } = makeRemoteChannel();
+    client.auth.setSessionResults = [{ error: Object.assign(new Error('Invalid Refresh Token: Already Used'), { status: 400, name: 'AuthApiError' }) }];
+    const channelsBefore = client.channels.length;
+
+    await withQuietLogs(async () => {
+      client.auth.emit('SIGNED_OUT');
+      await flush(10);
+      // A health tick already in flight must not rejoin.
+      for (let i = 0; i < 10; i++) rc.checkConnectionHealth();
+      await flush(10);
+    });
+
+    assert.strictEqual(rc.sessionLost, true, 'expected the session to be marked lost');
+    assert.strictEqual(client.channels.length, channelsBefore, 'no channel may be created after the session is lost');
+  });
+
+  await test('the user-facing notice prints once, not once per health tick', async () => {
+    const { rc, client } = makeRemoteChannel();
+    client.auth.setSessionResults = [{ error: Object.assign(new Error('Invalid Refresh Token: Already Used'), { status: 400 }) }];
+    const { lines } = await withQuietLogs(async () => {
+      client.auth.emit('SIGNED_OUT');
+      await flush(10);
+      for (let i = 0; i < 10; i++) rc.checkConnectionHealth();
+      client.auth.emit('SIGNED_OUT'); // auth-js can emit more than once
+      await flush(10);
+    });
+    const notices = lines.filter((l) => l.includes('Remote session expired'));
+    assert.strictEqual(notices.length, 1, `expected exactly one notice, got ${notices.length}`);
+  });
+
+  await test('a SIGNED_OUT arriving mid-restore does not start a second restore', async () => {
+    // The real overlap: auth-js can emit twice (the refresh tick and the
+    // in-flight refresh both fail) while the first restore is still awaiting.
+    // sessionLost is still false then, so handlingSignedOut is the only guard.
+    const { rc, client } = makeRemoteChannel();
+    let release;
+    const gate = new Promise((r) => { release = r; });
+    client.auth.setSession = async (payload) => {
+      client.auth.setSessionCalls.push(payload);
+      await gate;
+      return { data: { session: null }, error: Object.assign(new Error('revoked'), { status: 400 }) };
+    };
+    await withQuietLogs(async () => {
+      void rc.handleSignedOut();
+      void rc.handleSignedOut();       // arrives while the first is parked
+      await flush(5);
+      assert.strictEqual(client.auth.setSessionCalls.length, 1, 'second restore started mid-flight');
+      release();
+      await flush(20);
+      client.auth.emit('SIGNED_OUT'); // and again after it settled
+      await flush(10);
+    });
+    assert.strictEqual(client.auth.setSessionCalls.length, 1, 'restore must be attempted at most once');
+    assert.strictEqual(rc.sessionLost, true);
+  });
+
+  // --- Regression guard on the path that already worked ---
+
+  await test('TOKEN_REFRESHED still re-authorizes the socket with the new token', async () => {
+    const { rc, client } = makeRemoteChannel();
+    await withQuietLogs(async () => {
+      client.auth.emit('TOKEN_REFRESHED', { access_token: 'eyJ-fresh', refresh_token: 'rt-2' });
+      await flush(10);
+    });
+    // Pure regression guard on pre-existing behaviour: must pass with or without
+    // the fix, so it asserts nothing about the new state.
+    assert.deepStrictEqual(client.realtime.setAuthCalls, ['eyJ-fresh']);
+    assert.strictEqual(rc.lastKnownSession.access_token, 'eyJ-fresh');
+  });
+
+  await test('realtime.setAuth is never called with a null/undefined token', async () => {
+    const { rc, client } = makeRemoteChannel();
+    client.auth.setSessionResults = [{ error: Object.assign(new Error('revoked'), { status: 400 }) }];
+    await withQuietLogs(async () => {
+      client.auth.emit('TOKEN_REFRESHED', { access_token: 'eyJ-fresh', refresh_token: 'rt-2' });
+      client.auth.emit('SIGNED_OUT');
+      await flush(10);
+    });
+    const bad = client.realtime.setAuthCalls.filter((t) => t == null);
+    assert.strictEqual(bad.length, 0, 'setAuth() with no token is what resolves to the anon key');
+  });
+
+  if (failures > 0) {
+    console.error(`\n${failures} test(s) failed`);
+    process.exit(1);
+  }
+  console.log('\nremote-channel signed-out tests passed');
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/test/test-remote-channel-signed-out.js
+++ b/test/test-remote-channel-signed-out.js
@@ -62,6 +62,19 @@ class FakeAuth {
   async getSession() {
     return { data: { session: this.session }, error: null };
   }
+  /** Queue of results for refreshSession(); each call shifts one. */
+  refreshSessionResults = [];
+  refreshSessionCalls = [];
+  async refreshSession(payload) {
+    this.refreshSessionCalls.push(payload);
+    const next = this.refreshSessionResults.shift();
+    if (next && next.error) {
+      this.session = null;
+      return { data: { session: null, user: null }, error: next.error };
+    }
+    this.session = { access_token: 'eyJ-refreshed', refresh_token: 'rt-refreshed' };
+    return { data: { session: this.session, user: { id: 'user-1' } }, error: null };
+  }
   async getUser() {
     return { data: { user: { id: 'user-1', email: 'tester@example.com' } }, error: null };
   }
@@ -216,6 +229,65 @@ async function main() {
 
     assert.strictEqual(rc.sessionLost, true, 'expected the session to be marked lost');
     assert.strictEqual(client.channels.length, channelsBefore, 'no channel may be created after the session is lost');
+  });
+
+  // --- SIGNED_OUT while the access token is still unexpired (the common case) ---
+  //
+  // auth-js refreshes at <=3 ticks (90s) before expiry, so when the refresh 400s
+  // and SIGNED_OUT fires the cached JWT still has 60-90s left. setSession() with
+  // an unexpired JWT never touches the refresh token: it calls _getUser() and
+  // THROWS on error instead of returning { error }.
+
+  await test('SIGNED_OUT restore that throws (unexpired JWT, revoked session) still ends offline', async () => {
+    const { rc, client } = makeRemoteChannel();
+    client.auth.setSession = async (payload) => {
+      client.auth.setSessionCalls.push(payload);
+      throw Object.assign(new Error('session_not_found'), { status: 403, name: 'AuthApiError' });
+    };
+    client.auth.refreshSessionResults = [{ error: Object.assign(new Error('Invalid Refresh Token: Already Used'), { status: 400, name: 'AuthApiError' }) }];
+    const stale = client.channel('user:user-1');
+    stale.state = 'errored';
+    rc.channel = stale;
+
+    const { lines } = await withQuietLogs(async () => {
+      client.auth.emit('SIGNED_OUT');
+      await flush(10);
+    });
+
+    assert.strictEqual(rc.sessionLost, true, 'a thrown restore must count as a failed restore');
+    assert.strictEqual(rc.channel, null, 'channel must be torn down after a thrown restore');
+    assert.strictEqual(lines.filter((l) => l.includes('Remote session expired')).length, 1, 'notice must print');
+  });
+
+  await test('SIGNED_OUT restore must validate the refresh token, not just the unexpired JWT', async () => {
+    // GoTrue may still accept the JWT for /user while the refresh family is
+    // already revoked. Reporting "recovered" here is a false positive: the next
+    // tick 400s again and the process loops until the JWT expires.
+    const { rc, client } = makeRemoteChannel();
+    client.auth.setSessionResults = [{ error: null }]; // JWT accepted, refresh token never checked
+    client.auth.refreshSessionResults = [{ error: Object.assign(new Error('Invalid Refresh Token: Already Used'), { status: 400, name: 'AuthApiError' }) }];
+
+    const { lines } = await withQuietLogs(async () => {
+      client.auth.emit('SIGNED_OUT');
+      await flush(10);
+    });
+
+    assert.strictEqual(rc.sessionLost, true, 'a dead refresh token must not be reported as recovered');
+    assert.strictEqual(lines.filter((l) => l.includes('restored')).length, 0, 'no false "restored" line');
+  });
+
+  await test('SIGNED_OUT restore succeeds only when the refresh token is actually renewed', async () => {
+    const { rc, client } = makeRemoteChannel();
+    client.auth.setSessionResults = [{ error: null }];
+    client.auth.refreshSessionResults = [{ error: null }];
+
+    await withQuietLogs(async () => {
+      client.auth.emit('SIGNED_OUT');
+      await flush(10);
+    });
+
+    assert.strictEqual(rc.sessionLost, false);
+    assert.strictEqual(rc.lastKnownSession.refresh_token, 'rt-refreshed', 'cached pair must be the renewed one, not the replayed one');
   });
 
   await test('session loss tears down the existing channel and socket (kills realtime-js rejoin)', async () => {


### PR DESCRIPTION
The chain: another holder replays an already-consumed refresh token, GoTrue's reuse detection revokes the whole family including this connector's live token, the next auto-refresh 400s, auth-js calls _removeSession() and emits SIGNED_OUT, and supabase-js's own auth listener then calls realtime.setAuth() with no argument. Its _getAccessToken() ends in `?? this.supabaseKey`, so every channel is re-pinned to the anon key and the 25s heartbeat keeps it there. Realtime resolves role `anon` with a NULL auth.uid(), the migration-008 policy can never match, and the health check retried the doomed join every 10s forever while the process looked healthy.

Two independent breaks in that chain:

- initialize() overrides the realtime accessToken resolver, so the anon key can never be selected. Overridden under `realtime` rather than the top-level `accessToken` option, which replaces client.auth with a throwing Proxy that this class depends on (SupabaseClient.ts:146-158).
- SIGNED_OUT attempts one session restore from the cached pair — auth-js treats only network errors and 502/503/504 as retryable, so a 429 or 500 destroys the session while the refresh token is still good — then stops the heartbeat, marks the device offline and prints one actionable line. It deliberately does not re-authenticate: DeviceAuthenticator opens a browser and waits for the user, which an unattended process must not do.

Verified with a negative control: 6 of the 7 new tests fail against main, and the TOKEN_REFRESHED regression guard passes both ways. Both new guards were probed under a real race to confirm they execute.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of signed-out sessions for remote connections.
  * Remote connections now recover from temporary authentication issues when possible.
  * Permanently invalid sessions are marked offline without repeated retries or reconnect attempts.
  * Realtime connections continue using refreshed authentication tokens securely.
  * Duplicate sign-out events no longer trigger duplicate recovery attempts.
  * Sign-out notifications appear only once.

* **Tests**
  * Added coverage for session restoration, token handling, offline transitions, connection cleanup, and sign-out notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->