### PR TITLE
fix(remote-device): persist the session by default

### DIFF
--- a/src/npm-scripts/remote.ts
+++ b/src/npm-scripts/remote.ts
@@ -2,7 +2,12 @@ import { MCPDevice } from '../remote-device/device.js';
 import os from 'os';
 
 export async function runRemote() {
-    const persistSession = process.argv.includes('--persist-session');
+    // --persist-session is kept as an accepted no-op so existing invocations
+    // and docs keep working; --no-persist-session opts back out.
+    const persistSession = !process.argv.includes('--no-persist-session');
+    if (!persistSession) {
+        console.log('🔓 Session persistence disabled — re-authorization required on every start');
+    }
     const disableNoSleep = process.argv.includes('--disable-no-sleep');
     const verbose = process.argv.includes('--debug');
     console.debug('[DEBUG] Verbose mode: ', verbose);

--- a/src/remote-device/README.md
+++ b/src/remote-device/README.md
@@ -84,12 +84,12 @@ Run from the project repository without global installation:
 desktop-commander-device
 ```
 
-**With session persistence** (optional):
+**Without session persistence** (opt out):
 ```bash
-desktop-commander-device --persist-session
+desktop-commander-device --no-persist-session
 ```
 
-> **Note**: By default, only the device ID is persisted. Use `--persist-session` to also save authentication tokens between restarts. This allows the device to reconnect automatically without re-authentication.
+> **Note**: The device ID and authentication tokens are persisted by default to `~/.desktop-commander-device/device.json` (mode 0600), so the device reconnects without re-authorization. Pass `--no-persist-session` to keep tokens in memory only — the device then requires a full browser re-authorization on every start, and each one leaves a live server-side session behind.
 
 **If using local installation** from the project root directory:
 

--- a/src/remote-device/device.ts
+++ b/src/remote-device/device.ts
@@ -40,10 +40,9 @@ export class MCPDevice {
         this.isShuttingDown = false;
         this.configPath = path.join(os.homedir(), '.desktop-commander-device', 'device.json');
         // Default ON. Off meant a full re-authorization on every start, and each
-        // one mints a fresh GoTrue session that nothing ever revokes — 364k live
-        // sessions across 21k users, whose orphaned refresh-token families get
-        // replayed, trip GoTrue's reuse detection, and take the whole family down
-        // including the token a healthy connector is holding.
+        // one mints a fresh GoTrue session that nothing ever revokes; the orphaned
+        // refresh-token families get replayed, trip GoTrue's reuse detection, and
+        // take the whole family down including the token a healthy connector holds.
         this.persistSession = options.persistSession ?? true;
 
         // Initialize desktop integration

--- a/src/remote-device/device.ts
+++ b/src/remote-device/device.ts
@@ -39,7 +39,12 @@ export class MCPDevice {
         this.deviceId = undefined;
         this.isShuttingDown = false;
         this.configPath = path.join(os.homedir(), '.desktop-commander-device', 'device.json');
-        this.persistSession = options.persistSession || false;
+        // Default ON. Off meant a full re-authorization on every start, and each
+        // one mints a fresh GoTrue session that nothing ever revokes — 364k live
+        // sessions across 21k users, whose orphaned refresh-token families get
+        // replayed, trip GoTrue's reuse detection, and take the whole family down
+        // including the token a healthy connector is holding.
+        this.persistSession = options.persistSession ?? true;
 
         // Initialize desktop integration
         this.desktop = new DesktopCommanderIntegration();
@@ -427,11 +432,13 @@ if (isMainModule) {
     // Parse command-line arguments
     const args = process.argv.slice(2);
     const options = {
-        persistSession: args.includes('--persist-session')
+        // --persist-session is kept as an accepted no-op so existing invocations
+        // and docs keep working; --no-persist-session opts back out.
+        persistSession: !args.includes('--no-persist-session')
     };
 
-    if (options.persistSession) {
-        console.log('🔒 Session persistence enabled');
+    if (!options.persistSession) {
+        console.log('🔓 Session persistence disabled — re-authorization required on every start');
     }
 
     const device = new MCPDevice(options);

--- a/src/remote-device/device.ts
+++ b/src/remote-device/device.ts
@@ -207,13 +207,21 @@ export class MCPDevice {
             this.deviceId = config?.deviceId;
             console.debug('[DEBUG] Loaded device ID:', this.deviceId);
 
-            console.log('💾 Found persisted session for device ' + this.deviceId);
-            if (config.session) {
+            if (config.session && this.persistSession) {
+                console.log('💾 Found persisted session for device ' + this.deviceId);
                 console.debug('[DEBUG] Session found in config, returning session');
                 return config.session;
             }
 
-            console.debug('[DEBUG] No session in config');
+            // A previously saved session must not be reused on an opted-out run:
+            // it would skip the re-authorization the flag promises, and the save
+            // at the end of start() then discards a possibly-rotated refresh
+            // token — orphaning one more live server-side session.
+            if (config.session) {
+                console.debug('[DEBUG] Ignoring persisted session (--no-persist-session)');
+            } else {
+                console.debug('[DEBUG] No session in config');
+            }
             return null;
         } catch (error: any) {
 


### PR DESCRIPTION
Off-by-default meant a full browser re-authorization on every connector start, each minting a fresh GoTrue session that nothing ever revokes. Those orphaned refresh-token families get replayed, trip GoTrue's reuse detection, and revoke the whole family including the token a healthy connector is holding, which is the upstream trigger of the anon-key downgrade wedge (#632).

--persist-session stays as an accepted no-op; --no-persist-session opts back out (tokens in memory only, re-auth every start).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Session persistence is now enabled by default for remote device connections.
  * Added `--no-persist-session` to disable local session persistence.
  * Device IDs and authentication tokens are stored securely with restricted file permissions.
  * Disabling persistence requires browser re-authorization whenever the connection starts.

* **Documentation**
  * Updated usage guidance to explain persistence defaults, opt-out behavior, and re-authorization requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->