### PR TITLE
fix(read_file): honor configured fileReadLineLimit

### DIFF
--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -57,7 +57,7 @@ export const ReadFileArgsSchema = z.object({
   path: z.string(),
   isUrl: z.boolean().optional().default(false),
   offset: z.number().optional().default(0),
-  length: z.number().optional().default(1000),
+  length: z.number().optional(),
   sheet: z.string().optional(),  // String only for MCP client compatibility (Cursor doesn't support union types in JSON Schema)
   range: z.string().optional(),
   options: z.record(z.any()).optional(),

--- a/test/test-read-file-line-limit.js
+++ b/test/test-read-file-line-limit.js
@@ -1,0 +1,59 @@
+import assert from 'assert';
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { configManager } from '../dist/config-manager.js';
+import { handleReadFile } from '../dist/handlers/filesystem-handlers.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const TEST_DIR = path.join(__dirname, 'test_read_file_line_limit');
+const TEST_FILE = path.join(TEST_DIR, 'twenty-lines.txt');
+
+function extractReadCount(result) {
+  const text = result?.content?.[0]?.text ?? '';
+  const match = text.match(/\[Reading (\d+) lines/);
+  return match ? Number(match[1]) : null;
+}
+
+let originalConfig;
+let exitCode = 0;
+
+try {
+  originalConfig = await configManager.getConfig();
+  await fs.mkdir(TEST_DIR, { recursive: true });
+  await fs.writeFile(
+    TEST_FILE,
+    Array.from({ length: 20 }, (_, i) => `line-${i + 1}`).join('\n'),
+    'utf8'
+  );
+
+  await configManager.setValue('allowedDirectories', [TEST_DIR]);
+  await configManager.setValue('fileReadLineLimit', 7);
+
+  const omittedLength = await handleReadFile({ path: TEST_FILE });
+  assert.strictEqual(
+    extractReadCount(omittedLength),
+    7,
+    'read_file should use fileReadLineLimit when length is omitted'
+  );
+  console.log('✓ omitted length uses configured fileReadLineLimit');
+
+  const explicitLength = await handleReadFile({ path: TEST_FILE, length: 4 });
+  assert.strictEqual(
+    extractReadCount(explicitLength),
+    4,
+    'explicit read_file length should override fileReadLineLimit'
+  );
+  console.log('✓ explicit length overrides configured fileReadLineLimit');
+} catch (error) {
+  console.error(`✗ ${error.message}`);
+  exitCode = 1;
+} finally {
+  await fs.rm(TEST_DIR, { recursive: true, force: true });
+  if (originalConfig) {
+    await configManager.updateConfig(originalConfig);
+  }
+}
+
+process.exit(exitCode);


### PR DESCRIPTION
## Summary

- let the existing `read_file` handler apply `config.fileReadLineLimit` when callers omit `length`
- preserve explicit `length` values as the higher-priority per-call override
- add a regression test covering both omitted and explicit `length`

## Root cause

`ReadFileArgsSchema` assigned `length` a hardcoded Zod default of `1000`. Because `handleReadFile` parses arguments before applying its configured fallback, an omitted `length` arrived at the handler as `1000`, so `parsed.length ?? config.fileReadLineLimit` could never use the configured value.

The lower-level file reader already honors `fileReadLineLimit` when no length is supplied, so the fix is to leave the schema field optional instead of injecting a second default.

## Testing

- reproduced on current `main` with `fileReadLineLimit: 7`: omitted `length` read 1000 lines while the lower-level reader read 7
- regression test fails before the fix and passes after it
- `npm test`: 48 passed, 0 failed
- `git diff --check`

Addresses the `fileReadLineLimit` report in #147.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - File reading now uses the configured line limit when no length is specified.
  - Explicit line limits continue to override the configured default.

- **Tests**
  - Added coverage verifying default and custom line-limit behavior when reading files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->