### PR TITLE
test(edit_block): fix occurrence test false positives

### DIFF
--- a/test/test-edit-block-occurrences.js
+++ b/test/test-edit-block-occurrences.js
@@ -27,6 +27,18 @@ const MULTI_OCCURRENCE_FILE = path.join(TEST_DIR, 'multiple_occurrences.txt');
 const CONTEXT_TEST_FILE = path.join(TEST_DIR, 'context_test.txt');
 
 /**
+ * Assert that an edit_block result indicates a successful plain-text edit.
+ * Successful exact matches return a file preview, not a legacy success string.
+ */
+function assertEditBlockSuccess(result, message) {
+  assert.strictEqual(result.content[0].type, 'text', `${message} (should return text content)`);
+  assert.ok(
+    /\[Reading \d+ lines? from/.test(result.content[0].text),
+    `${message} (text should contain file-preview status line)`
+  );
+}
+
+/**
  * Setup function to prepare the test environment
  */
 async function setup() {
@@ -154,11 +166,7 @@ async function testExactNumberOfOccurrences() {
     });
     
     // Check that the operation succeeded
-    assert.strictEqual(result.content[0].type, 'text', 'Result should be text');
-    assert.ok(
-      result.content[0].text.includes('Successfully applied 4 edits'),
-      'Should report success with the correct number of edits'
-    );
+    assertEditBlockSuccess(result, 'Should report success with the correct number of edits');
     
     // Verify the file content
     const fileContent = await fs.readFile(MULTI_OCCURRENCE_FILE, 'utf8');
@@ -198,11 +206,7 @@ This is a MODIFIED target line in the header.`,
     });
     
     // Check that the operation succeeded
-    assert.strictEqual(result.content[0].type, 'text', 'Result should be text');
-    assert.ok(
-      result.content[0].text.includes('Successfully applied 1 edit'),
-      'Should report success with the header edit'
-    );
+    assertEditBlockSuccess(result, 'Should report success with the header edit');
     
     // Target the occurrence in the footer section using context
     result = await handleEditBlock({
@@ -215,11 +219,7 @@ This is a MODIFIED target line in the footer.`,
     });
     
     // Check that the operation succeeded
-    assert.strictEqual(result.content[0].type, 'text', 'Result should be text');
-    assert.ok(
-      result.content[0].text.includes('Successfully applied 1 edit'),
-      'Should report success with the footer edit'
-    );
+    assertEditBlockSuccess(result, 'Should report success with the footer edit');
     
     // Verify the file content
     const fileContent = await fs.readFile(CONTEXT_TEST_FILE, 'utf8');
@@ -281,28 +281,19 @@ async function testNonExistentPattern() {
  */
 async function testEmptySearchString() {
   console.log('\nTest 6: Empty search string');
-  
-  try {
-    // Try to use an empty search string
-    const result = await handleEditBlock({
+
+  await assert.rejects(
+    handleEditBlock({
       file_path: CONTEXT_TEST_FILE,
       old_string: '',
       new_string: 'This replacement should not be applied.',
       expected_replacements: 1
-    });
-    
-    // Check that we got the appropriate error message
-    assert.strictEqual(result.content[0].type, 'text', 'Result should be text');
-    assert.ok(
-      result.content[0].text.includes('Empty search strings are not allowed'),
-      'Should report that empty search strings are not allowed'
-    );
-    
-    console.log('✓ Test correctly rejected empty search string');
-  } catch (error) {
-    console.error('❌ Test failed:', error);
-    throw error;
-  }
+    }),
+    error => error?.name === 'ZodError',
+    'Empty search strings should be rejected by edit_block argument validation'
+  );
+
+  console.log('✓ Test correctly rejected empty search string');
 }
 
 /**
@@ -351,7 +342,9 @@ export default async function runTests() {
 
 // If this file is run directly (not imported), execute the test
 if (import.meta.url === `file://${process.argv[1]}`) {
-  runTests().catch(error => {
+  runTests().then(success => {
+    process.exit(success ? 0 : 1);
+  }).catch(error => {
     console.error('❌ Unhandled error:', error);
     process.exit(1);
   });


### PR DESCRIPTION
## Summary
- update `test-edit-block-occurrences.js` to assert the current plain-text `edit_block` preview response instead of the pre-file-preview success string
- update the empty-search case to expect the current schema-validation rejection
- propagate `runTests()` failures to the process exit code so the subprocess test runner cannot report an assertion failure as passed

## Why
The test had drifted across two intentional contract changes:
- the file-preview work changed successful plain-text edits to return a `[Reading ...]` preview and updated other edit tests, but this occurrence test kept asserting the old `Successfully applied ...` text
- empty `old_string` values are intentionally treated as omitted by `EditBlockArgsSchema`

Because the direct entrypoint ignored the boolean returned by `runTests()`, those stale assertions printed failures while the process still exited 0, so `test/run-all-tests.js` counted the file as passed.

## Verification
- reproduced on upstream `main`: Test 3 raised `ERR_ASSERTION` while `node test/test-edit-block-occurrences.js` exited 0
- after exit propagation, the remaining stale empty-search assertion correctly made the process exit 1
- after updating the stale contracts, `node test/test-edit-block-occurrences.js` passes all 6 cases with exit 0
- `git diff --check` passes
- full `npm test` runner reports 47/47 passed, exit 0; investigation also exposed a separate pre-existing hidden failure in `test-allowed-directories.js`, which is intentionally not bundled into this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated edit-operation tests to validate successful results consistently.
  * Improved empty-search coverage to verify input validation errors.
  * Enhanced direct test execution with clear success and failure exit statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->