### PR TITLE
test: fix allowedDirectories false positive

### DIFF
--- a/test/test-allowed-directories.js
+++ b/test/test-allowed-directories.js
@@ -414,9 +414,9 @@ export default async function runTests() {
 // If this file is run directly (not imported), execute the test
 if (import.meta.url === `file://${process.argv[1]}`) {
   runTests().then(success => {
-    process.exit(success ? 0 : 1);
+    process.exitCode = success ? 0 : 1;
   }).catch(error => {
     console.error('❌ Unhandled error:', error);
-    process.exit(1);
+    process.exitCode = 1;
   });
 }

--- a/test/test-allowed-directories.js
+++ b/test/test-allowed-directories.js
@@ -31,6 +31,15 @@ const ROOT_PATH = '/';
 const isWindows = process.platform === 'win32';
 const TEST_ROOT_PATH = isWindows ? 'C:/' : '/';
 
+function isWithinDirectory(basePath, targetPath) {
+  const relative = path.relative(basePath, targetPath);
+  return relative === '' || (
+    relative !== '..' &&
+    !relative.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relative)
+  );
+}
+
 /**
  * Helper function to clean up test directories
  */
@@ -239,8 +248,8 @@ async function testHomeAllowedDirectory() {
     console.log(`DEBUG Test4 - Config: ${JSON.stringify(config.allowedDirectories)}`);
     assert.deepStrictEqual(config.allowedDirectories, [HOME_DIR], 'allowedDirectories should contain only the home directory');
     
-    // Check if OUTSIDE_DIR is inside the home directory
-    const isOutsideDirInHome = OUTSIDE_DIR.toLowerCase().startsWith(HOME_DIR.toLowerCase());
+    const isTestDirInHome = isWithinDirectory(HOME_DIR, TEST_DIR);
+    const isOutsideDirInHome = isWithinDirectory(HOME_DIR, OUTSIDE_DIR);
 
     // Test access to various locations
     const testDirAccess = await isPathAccessible(TEST_DIR);
@@ -250,9 +259,9 @@ async function testHomeAllowedDirectory() {
     const outsideDirAccess = await isPathAccessible(OUTSIDE_DIR);
     const rootAccess = await isPathAccessible(TEST_ROOT_PATH);
     
-    // Only test directory and its contents should be accessible
-    assert.strictEqual(testDirAccess, true, 'Test directory should be accessible');
-    assert.strictEqual(testFileAccess, true, 'Files in test directory should be accessible');
+    // Only the home directory and paths inside it should be accessible
+    assert.strictEqual(testDirAccess, isTestDirInHome, 'Test directory access should match whether it is inside home');
+    assert.strictEqual(testFileAccess, isTestDirInHome, 'Test file access should match whether it is inside home');
     assert.strictEqual(homeDirAccess, true, 'Home directory should be accessible');
     assert.strictEqual(homeTildaDirAccess, true, 'HOME TILDA directory should be accessible');
     
@@ -404,7 +413,9 @@ export default async function runTests() {
 
 // If this file is run directly (not imported), execute the test
 if (import.meta.url === `file://${process.argv[1]}`) {
-  runTests().catch(error => {
+  runTests().then(success => {
+    process.exit(success ? 0 : 1);
+  }).catch(error => {
     console.error('❌ Unhandled error:', error);
     process.exit(1);
   });


### PR DESCRIPTION
## Summary
- make the HOME-only `allowedDirectories` test derive test-dir expectations from actual path containment instead of always expecting the repository test directory to be allowed
- use `path.relative()` for containment checks so prefix-sharing sibling paths are not mistaken for children
- propagate `runTests()` failures to the direct process exit code so the subprocess runner cannot count assertion failures as passed

## Why
`testHomeAllowedDirectory()` configures `allowedDirectories` to contain only `HOME_DIR`, but it unconditionally expected `TEST_DIR` and its file to remain accessible. When the repository is outside HOME (for example HOME=`/root` with the checkout under `/kaggle/...`), the production path validator correctly blocks those paths, the test prints `false !== true`, and then `runTests()` returns `false`.

The direct entrypoint ignored that boolean, so `test/run-all-tests.js` saw exit code 0 and reported the failed test file as passed.

## Verification
- reproduced on upstream `main`: `testHomeAllowedDirectory()` printed `false !== true` and the direct process exited 0
- after exit propagation alone, the same stale assertion made the process exit 1
- after correcting the HOME containment expectation, the test passes with both:
  - normal HOME where the repository is outside HOME
  - a HOME that contains the repository
- combined verification with the companion edit-block test fix in #639: full `npm test` reports 47/47 passed, exit 0, and an explicit log scan finds no `AssertionError`, `ERR_ASSERTION`, `❌ Test failed:`, or boolean assertion mismatch markers
- `git diff --check` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory access checks to correctly handle paths inside and outside permitted directories.
  * Updated test execution to report success or failure with the appropriate exit status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->