### PR TITLE
docs(search): clarify pattern matching semantics

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -662,11 +662,17 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                         - searchType="content": Search inside files for text patterns
                         
                         PATTERN MATCHING MODES:
-                        - Default (literalSearch=false): Patterns are treated as regular expressions
-                        - Literal (literalSearch=true): Patterns are treated as exact strings
+                        - File-name searches use glob semantics, not regular expressions:
+                          * Glob patterns such as "*.txt" are used as-is.
+                          * Plain patterns such as "target" are treated as substring matches.
+                          * literalSearch is ignored for searchType="files".
+                        - Text content searches use regular expressions by default.
+                          * Set literalSearch=true for fixed-string matching when searching text content.
+                        - Excel and DOCX content searches always use literal substring matching.
                         
                         WHEN TO USE literalSearch=true:
-                        Use literal search when searching for code patterns with special characters:
+                        literalSearch only affects text content searches. Use it for code or text that
+                        contains regex metacharacters you want to match literally, such as:
                         - Function calls with parentheses and quotes
                         - Array access with brackets
                         - Object methods with dots and parentheses
@@ -674,9 +680,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                         - Any pattern containing: . * + ? ^ $ { } [ ] | \\ ( )
                         
                         IMPORTANT PARAMETERS:
-                        - pattern: What to search for (file names OR content text)
-                        - literalSearch: Use exact string matching instead of regex (default: false)
-                        - filePattern: Optional filter to limit search to specific file types (e.g., "*.js", "package.json")
+                        - pattern: File searches use glob/exact/substring semantics; text content uses regex by default
+                        - literalSearch: Fixed-string mode for text content only; ignored for file searches
+                        - filePattern: Optional glob filter to limit search to specific file types (e.g., "*.js", "package.json")
                         - ignoreCase: Case-insensitive search (default: true). Works for both file names and content.
                         - earlyTermination: Stop search early when exact filename match is found (optional: defaults to true for file searches, false for content searches)
                         

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -193,16 +193,22 @@ export const GiveFeedbackArgsSchema = z.object({
 // Search schemas (renamed for natural language)
 export const StartSearchArgsSchema = z.object({
   path: z.string(),
-  pattern: z.string(),
+  pattern: z.string().describe(
+    'Search pattern. File searches use exact filename, glob, or substring matching (not regex). Content searches use regex for text files by default; Excel and DOCX content uses literal substring matching.'
+  ),
   searchType: z.enum(['files', 'content']).default('files'),
-  filePattern: z.string().optional(),
+  filePattern: z.string().optional().describe(
+    'Optional glob filter for file names/types (for example *.js or *.js|*.ts).'
+  ),
   ignoreCase: z.boolean().optional().default(true),
   maxResults: z.number().optional(),
   includeHidden: z.boolean().optional().default(false),
   contextLines: z.number().optional().default(5),
   timeout_ms: z.number().optional(), // Match process naming convention
   earlyTermination: z.boolean().optional(), // Stop search early when exact filename match is found (default: true for files, false for content)
-  literalSearch: z.boolean().optional().default(false), // Force literal string matching (-F flag) instead of regex
+  literalSearch: z.boolean().optional().default(false).describe(
+    'Only affects text content searches: false uses regex and true uses fixed-string matching. For file searches this option is ignored; Excel and DOCX content searches are always literal.'
+  ),
   // 'ui' marks widget-fired calls (e.g. markdown link-target search);
   // excluded from tool-call telemetry (see isUiOriginCall in server.ts).
   origin: z.enum(['ui', 'llm']).optional(),

--- a/test/test-search-tool-contract.js
+++ b/test/test-search-tool-contract.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/**
+ * Regression test: the published start_search contract must describe the
+ * different pattern semantics for file, text-content, and Office searches.
+ */
+
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+
+const transport = new StdioClientTransport({
+  command: process.execPath,
+  args: [path.join(PROJECT_ROOT, 'dist/index.js'), '--no-onboarding'],
+  cwd: PROJECT_ROOT,
+  stderr: 'pipe',
+  env: { ...process.env, DESKTOP_COMMANDER_DISABLE_TELEMETRY: 'true' },
+});
+
+const client = new Client(
+  { name: 'search-contract-test', version: '1.0.0' },
+  { capabilities: {} }
+);
+
+try {
+  await client.connect(transport, { timeout: 30000 });
+  const tools = await client.listTools();
+  const searchTool = tools.tools.find((tool) => tool.name === 'start_search');
+  assert.ok(searchTool, 'start_search should be published');
+
+  const description = searchTool.description ?? '';
+  assert.match(description, /file(?:-name)? searches?.*glob/is,
+    'tool description should explain that file-name search uses glob semantics');
+  assert.match(description, /file(?:-name)? searches?.*(?:not|instead of).*regular expressions?/is,
+    'tool description should explicitly distinguish file-name search from regex');
+  assert.match(description, /literalSearch.*only.*text content/is,
+    'tool description should scope literalSearch to text content search');
+  assert.match(description, /Excel.*DOCX.*literal/is,
+    'tool description should document Office content as literal matching');
+
+  const properties = searchTool.inputSchema?.properties ?? {};
+  assert.match(properties.pattern?.description ?? '', /files?.*glob.*content.*regex/is,
+    'pattern schema should distinguish file glob and content regex semantics');
+  assert.match(properties.literalSearch?.description ?? '', /text content.*files?.*ignored/is,
+    'literalSearch schema should say it applies to text content and is ignored for files');
+  assert.match(properties.filePattern?.description ?? '', /glob/is,
+    'filePattern schema should identify its syntax as glob');
+
+  console.log('✅ start_search published contract documents matching semantics');
+} finally {
+  await client.close();
+}


### PR DESCRIPTION
## Summary

- document that `searchType="files"` uses exact filename / glob / substring matching, not regex
- scope `literalSearch` to text-content search and document that it is ignored for file-name search
- document that Excel/DOCX content search is currently literal-only
- add matching descriptions to the published JSON schema for `pattern`, `literalSearch`, and `filePattern`
- add an MCP-level regression test that inspects the actual `listTools()` contract seen by clients

No search runtime behavior is changed.

## Why

The current tool description says `literalSearch=false` means patterns are regular expressions without limiting that statement to text content search. In reality, filename search is implemented with ripgrep `--glob` / `--iglob`, while Office content search is intentionally literal-only after #400.

A filename regex such as `target-.*\\.txt$` therefore returns no matches even though the published contract can lead an agent to expect regex semantics. Glob `*.txt` and plain substring `target` work as implemented.

Fixes #641

## Validation

- TDD red: the new MCP contract test failed against current `main` because the published description did not document file glob semantics
- mutation check: reverting only the production description/schema changes made the regression test fail again; restoring them made it pass
- `node test/test-search-tool-contract.js`
- `node test/test-literal-search.js`
- `node test/test-search-code.js`
- `npm test` -> runner reports 48/48 passed, exit 0 (including the new test)
- `git diff --check`

### Pre-existing suite/tooling notes

The current `main` test runner still contains two unrelated hidden failures in `test-allowed-directories.js` and `test-edit-block-occurrences.js` even while reporting exit 0; those are separately addressed by #640 and #639.

`npm run validate:tools` builds successfully but then fails on a clean checkout because `mcpb-bundle/manifest.json` is absent. That pre-existing clean-checkout validation issue is already addressed in the broader #551.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified search behavior for file-name patterns, content regular expressions, and literal matching.
  * Documented that Excel and DOCX searches always use literal matching.
  * Improved parameter descriptions for search patterns, file filters, and literal-search options.

* **Tests**
  * Added coverage to verify the published search tool documentation and input schema accurately describe these behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->