### PR TITLE
Fix broken Smithery badge (returns HTTP 500)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![npm downloads](https://img.shields.io/npm/dw/@wonderwhy-er/desktop-commander)](https://www.npmjs.com/package/@wonderwhy-er/desktop-commander)
 [![AgentAudit Verified](https://agentaudit.dev/api/badge/desktop-commander)](https://agentaudit.dev/skills/desktop-commander)
 [![Trust Score](https://archestra.ai/mcp-catalog/api/badge/quality/wonderwhy-er/DesktopCommanderMCP)](https://archestra.ai/mcp-catalog/wonderwhy-er__desktopcommandermcp)
-[![smithery badge](https://smithery.ai/badge/@wonderwhy-er/desktop-commander)](https://smithery.ai/server/@wonderwhy-er/desktop-commander)
+[![Listed on Skillselion](https://skillselion.com/badge/mcp/tool/io.github.wonderwhy-er/desktop-commander.svg)](https://skillselion.com/mcp/tool/io.github.wonderwhy-er/desktop-commander)
 [![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-support-yellow.svg)](https://www.buymeacoffee.com/wonderwhyer)
 
 


### PR DESCRIPTION
The Smithery badge in the README is serving **HTTP 500**, so it renders as a broken image:

```
https://smithery.ai/badge/@wonderwhy-er/desktop-commander   ->  500
```

This isn't specific to this repo — Smithery's badge endpoint is failing across the ecosystem. Your Smithery *install* link still works and is still referenced in the install instructions further down, so nothing is lost by dropping the dead image.

**What this PR does:** removes that one dead badge line, and offers ours in its place.

```markdown
[![Listed on Skillselion](https://skillselion.com/badge/mcp/tool/io.github.wonderwhy-er/desktop-commander.svg)](https://skillselion.com/mcp/tool/io.github.wonderwhy-er/desktop-commander)
```

We'd be happy to have ours sit there instead — Skillselion is an independent directory of agent skills and MCP servers, and Desktop Commander is already listed at [skillselion.com/mcp/tool/io.github.wonderwhy-er/desktop-commander](https://skillselion.com/mcp/tool/io.github.wonderwhy-er/desktop-commander) whether or not you take the badge.

**Entirely your call, and no hard feelings either way:**
- Happy for the badge to stay → merge as is.
- Prefer the dead badge just gone → say so and I'll amend this to a removal-only change.
- Prefer nothing touched → close it, no reply needed.

Your **Glama** badge returns 200 and I left it untouched. Only the dead Smithery image was changed.
