### PR TITLE
feat(remote-device): attribute which transport actually delivered eac…

### DIFF
--- a/src/remote-device/device.ts
+++ b/src/remote-device/device.ts
@@ -282,6 +282,10 @@ export class MCPDevice {
 
     async handleNewToolCall(payload: any) {
         const toolCall = payload.new;
+        // Which pipe actually delivered this call (doorbell / legacy) —
+        // written back onto the row so server-side analytics can tell actual
+        // delivery apart from dispatch intent (metadata.transport).
+        const delivered_via = payload.__delivered_via ?? null;
         // Expect toolCall to include a device_id field used to route calls to this device instance.
         const { id: call_id, tool_name, tool_args, device_id, metadata = {} } = toolCall;
 
@@ -351,7 +355,7 @@ export class MCPDevice {
 
             // Update database with result, THEN ring the doorbell — the server
             // fetches the row by id on the doorbell, so the write must land first.
-            await this.remoteChannel.updateCallResult(call_id, 'completed', result);
+            await this.remoteChannel.updateCallResult(call_id, 'completed', result, null, { metadata, deliveredVia: delivered_via });
             await this.remoteChannel.notifyResult(call_id);
 
         } catch (error: any) {
@@ -361,7 +365,7 @@ export class MCPDevice {
             // and takes the device process down.
             try {
                 await captureRemote('remote_device_tool_call_failed', { error, tool_name });
-                await this.remoteChannel.updateCallResult(call_id, 'failed', null, error.message);
+                await this.remoteChannel.updateCallResult(call_id, 'failed', null, error.message, { metadata, deliveredVia: delivered_via });
                 await this.remoteChannel.notifyResult(call_id);
             } catch (reportError: any) {
                 console.error(`❌ Could not report failure for ${call_id}:`, reportError?.message);

--- a/src/remote-device/remote-channel.ts
+++ b/src/remote-device/remote-channel.ts
@@ -404,7 +404,10 @@ export class RemoteChannel {
                     },
                     (payload: any) => {
                         console.debug('[DEBUG] Realtime event received, payload:', payload?.new?.id);
-                        this.dispatchToolCall(payload);
+                        // Tag the delivery path so the result row can attribute which
+                        // pipe ACTUALLY delivered (metadata.transport only records
+                        // dispatch intent — during doorbell failures the two diverge).
+                        this.dispatchToolCall({ ...payload, __delivered_via: 'legacy' });
                     }
                 )
                 .subscribe((status: string) => {
@@ -573,7 +576,7 @@ export class RemoteChannel {
         }
 
         // Same payload shape as postgres_changes ({ new: row }).
-        this.dispatchToolCall({ new: row });
+        this.dispatchToolCall({ new: row, __delivered_via: 'doorbell' });
     }
 
     /**
@@ -850,12 +853,25 @@ export class RemoteChannel {
         return claimed;
     }
 
-    async updateCallResult(callId: string, status: string, result: any = null, errorMessage: string | null = null) {
+    async updateCallResult(
+        callId: string,
+        status: string,
+        result: any = null,
+        errorMessage: string | null = null,
+        attribution: { metadata: any; deliveredVia: string | null } | null = null
+    ) {
         if (!this.client) throw new Error('Client not initialized');
         const updateData: any = {
             status: status,
             completed_at: new Date().toISOString()
         };
+        // Stamp which pipe actually delivered the call. Merged over the row's
+        // dispatch-time metadata (which the caller carries from the delivered
+        // payload) so transport intent and actual delivery coexist for the
+        // server's result-claim analytics event.
+        if (attribution?.deliveredVia) {
+            updateData.metadata = { ...(attribution.metadata ?? {}), delivered_via: attribution.deliveredVia };
+        }
 
         // Strip NUL (U+0000) before it reaches the jsonb `result` column.
         // jsonb cannot store  and rejects the whole write (Postgres 22P05),


### PR DESCRIPTION
Each receive path tags the call (doorbell / legacy) and the tag is written into the row's metadata with the result, so server-side analytics can distinguish ACTUAL delivery from dispatch intent (metadata.transport). The two diverge silently: on 2026-08-21 ~50% of broadcast-tagged traffic was delivered by the legacy pipe for an hour (Supabase refusing fresh channel joins) and every delivery metric stayed green. Pre-009, delivered_via=legacy IS the doorbell-failure meter, and its decay to ~zero under the new dispatch retry loop is the evidence the 009 flip rests on.

Devices hold the UPDATE grant on metadata (verified against staging RLS); the merge preserves dispatch-time metadata alongside the stamp.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Remote device sessions now persist by default, with an option to disable persistence.
  * Improved startup validation and recovery for expired, revoked, or invalid device sessions.
  * Remote connections now recover automatically after temporary disconnections when possible.
  * Improved connection health monitoring, token refresh, and handling of signed-out sessions.
  * Improved tracking of remote tool-call delivery and call-result attribution, including failed calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->