### PR TITLE
fix(terminal): decode stdout/stderr chunks with a stateful UTF-8 decoder

### DIFF
--- a/src/terminal-manager.ts
+++ b/src/terminal-manager.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'child_process';
+import { StringDecoder } from 'string_decoder';
 import path from 'path';
 import { TerminalSession, CommandExecutionResult, ActiveSession, TimingInfo, OutputEvent } from './types.js';
 import { DEFAULT_COMMAND_TIMEOUT } from './config.js';
@@ -294,6 +295,12 @@ export class TerminalManager {
       // Quick prompt patterns for immediate detection
       const quickPromptPatterns = />>>\s*$|>\s*$|\$\s*$|#\s*$/;
 
+      // A multibyte UTF-8 character can be split across two 'data' chunks; a
+      // stateful decoder holds the incomplete tail byte(s) and prepends them
+      // to the next chunk instead of replacing them with U+FFFD per chunk.
+      const stdoutDecoder = new StringDecoder('utf8');
+      const stderrDecoder = new StringDecoder('utf8');
+
       const resolveOnce = (result: CommandExecutionResult) => {
         if (resolved) return;
         resolved = true;
@@ -318,7 +325,7 @@ export class TerminalManager {
       };
 
       childProcess.stdout.on('data', (data: any) => {
-        const text = data.toString();
+        const text = stdoutDecoder.write(data);
         const now = Date.now();
 
         if (!firstOutputTime) firstOutputTime = now;
@@ -364,7 +371,7 @@ export class TerminalManager {
       });
 
       childProcess.stderr.on('data', (data: any) => {
-        const text = data.toString();
+        const text = stderrDecoder.write(data);
         const now = Date.now();
 
         if (!firstOutputTime) firstOutputTime = now;
@@ -419,6 +426,14 @@ export class TerminalManager {
       }, timeoutMs);
 
       childProcess.on('exit', (code: any) => {
+        // Flush any incomplete multibyte sequence still buffered by the
+        // decoders, so a process that exits mid-character doesn't drop it.
+        const flushed = stdoutDecoder.end() + stderrDecoder.end();
+        if (flushed) {
+          if (!resolved) output += flushed;
+          this.appendToLineBuffer(session, flushed);
+        }
+
         if (childProcess.pid) {
           // Store completed session before removing active session
           this.completedSessions.set(childProcess.pid, {

--- a/test/test-utf8-chunk-boundary.js
+++ b/test/test-utf8-chunk-boundary.js
@@ -1,0 +1,68 @@
+import assert from 'assert';
+import { startProcess, readProcessOutput } from '../dist/tools/improved-process-tools.js';
+
+/**
+ * Regression test for issue #628: a multibyte UTF-8 character split across
+ * two stdout 'data' chunks decoded to U+FFFD replacement characters instead
+ * of the original character, because each chunk was decoded independently.
+ *
+ * This test should:
+ * - FAIL when the bug exists (current behavior)
+ * - PASS when the bug is fixed (desired behavior)
+ */
+async function testUtf8SplitAcrossChunks() {
+  console.log('Testing UTF-8 character split across two stdout chunks...');
+
+  // The euro sign (U+20AC) is the 3-byte UTF-8 sequence 0xE2 0x82 0xAC.
+  // Write the first 2 bytes, then (after a delay long enough to force two
+  // separate 'data' events) write the final byte.
+  const command = 'node -e "' +
+    'process.stdout.write(Buffer.from([0xE2,0x82]));' +
+    'setTimeout(() => process.stdout.write(Buffer.from([0xAC])), 400);' +
+    '"';
+
+  const startResult = await startProcess({
+    command,
+    timeout_ms: 100 // returns well before the second chunk is written
+  });
+
+  const pidMatch = startResult.content[0].text.match(/Process started with PID (\d+)/);
+  assert(pidMatch, 'Should get PID from start_process');
+  const pid = parseInt(pidMatch[1]);
+
+  // Wait for both chunks to have been written and the process to exit.
+  await new Promise(resolve => setTimeout(resolve, 1500));
+
+  const readResult = await readProcessOutput({ pid, timeout_ms: 1000 });
+  assert(!readResult.isError, 'Should be able to read the completed process output');
+
+  const text = readResult.content[0].text;
+  assert(!text.includes('�'),
+    `Output should not contain a replacement character from a mis-decoded chunk boundary, got: ${JSON.stringify(text)}`);
+  assert(text.includes('€'),
+    `Output should contain the euro sign reassembled across chunks, got: ${JSON.stringify(text)}`);
+
+  console.log('Multibyte character correctly reassembled across chunk boundary');
+}
+
+async function runTests() {
+  try {
+    await testUtf8SplitAcrossChunks();
+    console.log('\nAll tests passed - UTF-8 chunk boundaries are handled correctly!');
+    return true;
+  } catch (error) {
+    console.log('\nTest failed:', error.message);
+    console.log('This indicates the bug still exists:');
+    console.log('   a multibyte character split across two stdout chunks decodes to U+FFFD');
+    return false;
+  }
+}
+
+runTests()
+  .then(success => {
+    process.exit(success ? 0 : 1);
+  })
+  .catch(error => {
+    console.error('Test error:', error);
+    process.exit(1);
+  });


### PR DESCRIPTION
Fixes #628.

## Root cause

`TerminalManager.executeCommand` (`src/terminal-manager.ts`) decodes each
stdout/stderr `Buffer` chunk independently with `data.toString()`. Node's
default UTF-8 decode assumes every buffer is a complete, self-contained
byte sequence, so a multibyte character split across two `data` events
(common with slow or chunked child-process output) decodes to U+FFFD
replacement characters on the first partial chunk, and the split bytes
can never be recombined once the second chunk arrives.

## Fix

Give each stream its own `node:string_decoder` `StringDecoder`. A
`StringDecoder` buffers an incomplete trailing multibyte sequence and
prepends it to the next chunk before decoding, so a character split
across chunk boundaries reassembles correctly. Both decoders are also
flushed (`.end()`) on process exit, so a process that exits mid-character
still emits its buffered tail instead of silently dropping it.

## Verification

- New regression test `test/test-utf8-chunk-boundary.js`: starts a child
  process that writes the 3-byte UTF-8 sequence for `€` split across two
  `stdout.write` calls 400ms apart, then asserts the reassembled output
  contains `€` and no replacement character. Confirmed fails on `main`
  (`git log` HEAD `9bd8422`, produces two U+FFFD) and passes on this
  branch, in the same Docker image.
- Full `node test/run-all-tests.js` suite: 43/48 pass. The other 5
  (`test-default-shell.js`, `test-enhanced-repl.js`,
  `test-markdown-editor-edit-diff.js`,
  `test-markdown-editor-roundtrip.js`, `test-pdf-creation.js`) fail
  identically on unmodified `main` in the same container, so they are
  pre-existing environment gaps (no default shell, no PDF toolchain),
  unrelated to this change.
- `npx tsc --noEmit` and `codespell` (this repo's only CI job) both clean
  on the changed files.

Not verified: real-world child processes producing genuinely chunked
multibyte output (this used an artificial two-write repro to force the
split deterministically), and the equivalent path on Windows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal output handling for multibyte UTF-8 characters split across data chunks.
  - Ensured buffered text is flushed when a process exits, preventing missing or corrupted characters.

- **Tests**
  - Added coverage verifying that split UTF-8 characters, including the euro sign, display correctly without replacement characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->