### PR TITLE
docs(ai-tools-setup): correct the Claude Desktop log path and document the npx cold-start failure

### DIFF
--- a/skills/ai-tools-setup/references/claude-desktop-mcp.md
+++ b/skills/ai-tools-setup/references/claude-desktop-mcp.md
@@ -4,6 +4,25 @@ How to install Claude Desktop, add MCP servers, and inspect / validate / repair
 MCP configuration files. This is the most common and most mechanical task — high
 success rate when done carefully.
 
+## Where a server actually comes from
+
+Work out which mechanism launches the server before editing anything. They fail
+independently and can serve the *same* tools:
+
+- **A config-file entry** someone wrote by hand or with a setup script — the
+  table below.
+- **An extension** (`.mcpb` / `.dxt`) the client installed and launches with its
+  own bundled Node. Nothing about it appears in `claude_desktop_config.json`.
+- **A plugin**, which declares its own `mcpServers` block inside `plugin.json`.
+  Also absent from `claude_desktop_config.json`.
+
+This matters when the settings page reports a failure. "Unable to connect to
+extension server" next to something called `desktop-commander` may be the
+*plugin's* server while the identically-named extension is running fine and
+serving tools. Confirm in the logs which of the two is actually broken before
+touching a config file — the logs name them differently (`[Display Name]` for an
+extension, `plugin:<plugin>:<server>` for a plugin).
+
 ## Config file locations
 
 MCP-capable clients each keep their own config. Find the right one first.
@@ -43,6 +62,10 @@ Notes:
 - Use absolute paths for local scripts; `~` is not expanded inside JSON.
 - Secrets belong in `env` here (or the server's own config), never pasted into
   chat.
+- `@latest` in an `npx` arg re-resolves the version on **every** launch. When the
+  cached copy is stale, npx reinstalls the whole dependency tree before the
+  server can answer `initialize` — see "Slow cold start on Windows" below. For a
+  server the client auto-starts, a pinned version is far more predictable.
 
 ## Add a server end-to-end
 
@@ -73,9 +96,86 @@ When a user says MCP "isn't working," diagnose in this order:
 4. **Check credentials** — is the required `env` key present and valid?
 5. **Repair, back up first, restart the client, then re-verify.**
 
+## Where the logs are
+
+Read the logs instead of guessing — they name the exact launch command, the
+`PATH` it ran with, and the real error. Recent Claude Desktop builds moved the
+Windows log directory and the old one simply stops being written to, so a
+stale-looking directory is *not* evidence that nothing ran.
+
+| Claude Desktop | Windows |
+|---|---|
+| current (verified on 1.34493.1) | `%LOCALAPPDATA%\Claude\Logs\` |
+| older builds | `%APPDATA%\Claude\logs\` |
+
+On macOS the logs live under `~/Library/Logs/Claude/`.
+
+Files worth opening:
+
+- `main.log` — the client's own view: which server it is starting, with what
+  command, and why a connection failed. Grep for `LocalMcpServerManager`
+  (plugin-provided servers) and `localMcpBridge`.
+- `mcp.log` and `mcp-server-<Display Name>.log` — per-server JSON-RPC traffic. A
+  server that answers `initialize` and lists tools here is up, and the problem is
+  somewhere else.
+
+## Slow cold start on Windows (`npx`-launched servers)
+
+Symptom: the extensions/plugins page shows *"Unable to connect to extension
+server. Please try disabling and re-enabling the extension."* Toggling it changes
+nothing, and `main.log` shows the same attempt failing on a loop:
+
+```
+[LocalMcpServerManager] Connecting to plugin:<plugin>:<server>
+[LocalMcpServerManager] Failed to connect to plugin:<plugin>:<server>:
+    Request timed out { code: 'REQUEST_TIMEOUT', data: { timeout: 120000 } }
+```
+
+Cause, when the launch command is `npx -y <pkg>@latest`: npm re-resolves
+`@latest` on every start, and if the npx-cached copy is behind the published
+version it reinstalls the entire dependency tree *before* the server can answer
+`initialize`. A ~500-package tree on AV-scanned corporate hardware has been
+measured at ~75 s, which is past the client's connect timeout. The client then
+kills the process mid-install, leaving a half-written tree in the npx cache —
+running the cached entry point directly then fails with
+`Error: Cannot find module '<dep>'`. The next launch reinstalls again. It never
+converges on its own, which is exactly why disable/enable does not help.
+
+The npx cache key is a hash of the *spec string*, not of the resolved version, so
+`<pkg>@latest` keeps reinstalling in place over the same directory rather than
+building a fresh one alongside it.
+
+Fix — complete the install once outside the client, where nothing kills it:
+
+```powershell
+# 1. drop the half-written cache entry
+Get-ChildItem "$env:LOCALAPPDATA\npm-cache\_npx" -Directory |
+  Where-Object { Test-Path "$($_.FullName)\node_modules\<scope>\<pkg>" } |
+  Remove-Item -Recurse -Force
+
+# 2. install it fully, without starting the server
+npm exec --yes --package=<pkg>@latest -- node -e "console.log('ok')"
+```
+
+Then let the client retry on its own, or toggle the extension. Confirm in
+`main.log`:
+
+```
+[LocalMcpServerManager] Connected to plugin:<plugin>:<server> (N tools)
+```
+
+Measure rather than assume: spawn the launch command yourself, write a single
+`initialize` request to its stdin, and time the reply. Healthy is seconds. If
+nothing comes back within a couple of minutes, you are watching an install, not a
+hung server.
+
+This recurs on every new release of the package. Pinning an exact version in the
+launch args avoids it for good — a pinned spec gets its own cache key and is
+never reinstalled.
+
 ## Connection health check
 
-Separate the three failure classes so you fix the right thing:
+Separate the failure classes so you fix the right thing:
 
 - **Config typo** → client shows the server as failed immediately on start; the
   JSON or command is wrong. Fix the file.
@@ -83,6 +183,9 @@ Separate the three failure classes so you fix the right thing:
   manually reproduces the crash. Fix deps/runtime.
 - **Auth failure** → server starts and lists tools, but calls fail with 401/403.
   Fix the API key/token.
+- **Cold start too slow** → the client times out and retries indefinitely while
+  the process is still installing or starting. Nothing in the config is wrong and
+  running the command by hand eventually works. See "Slow cold start on Windows".
 
 ## Claude Desktop install
 


### PR DESCRIPTION
Docs only - `skills/ai-tools-setup/references/claude-desktop-mcp.md`. No code, no behaviour change.

I hit a failure this week that the skill walked me straight past, so this is the page I wish had been there.

### What changed

**1. Log path.** The reference sends the reader to `%APPDATA%\Claude\logs`. On Claude Desktop 1.34493.1 that directory is stale - mine stopped being written at 2026-08-21 08:37, the moment the app quit for its own update - and the live logs are in `%LOCALAPPDATA%\Claude\Logs`. Following the old path on a current build shows an empty-looking directory, which reads as "nothing ran". Both are now in a small table, with the current one marked as verified on the build I tested.

**2. New section: slow cold start on Windows.** A server launched as `npx -y <pkg>@latest` re-resolves the version on every start; when the cached copy is stale it reinstalls the whole tree before answering `initialize`. I measured ~75 s for a ~500-package tree on AV-scanned corporate hardware, against a 120 s connect timeout. The client kills it mid-install, the npx cache is left half-written (`Cannot find module '<dep>'`), and every later launch reinstalls again. It never converges, so disable/enable - the client's own advice in the error message - just restarts the loop. The section gives the warm-the-cache fix and the log line that proves it worked. Full write-up with timings in #655.

**3. New note: where a server actually comes from.** Config entry vs. extension vs. plugin, and how the logs name each. In my case the extension was healthy and serving tools the whole time while the plugin's server was the one failing - the settings page calls both `desktop-commander`, so it is easy to spend a while fixing the wrong thing.

**4. Health-check triage** gains a fourth class (cold start too slow), for the case where nothing in the config is wrong and running the command by hand eventually works.

### What I verified myself

Windows 11 Enterprise, Claude Desktop 1.34493.1, node v25.7.0, npm 11.10.1: the log paths, the timeout loop in `main.log`, the ~75 s install, the corrupt-cache error, and the `initialize` round-trip before (no reply within 180 s) and after (15.4 s, then 11.7 s) warming the cache.

The macOS log path (`~/Library/Logs/Claude/`) is the one line here I could **not** verify - no Mac to hand. Please correct or drop it if it is wrong.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for distinguishing MCP server types and their log identifiers.
  * Documented Claude Desktop log locations and relevant troubleshooting files.
  * Added recommendations to pin package versions for more reliable launches.
  * Added Windows cold-start timeout diagnosis and recovery steps.
  * Documented slow startup as an additional connection failure category.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->