### PR TITLE
fix(plugin): pin the npm version in the plugin launch args instead of @latest

### DIFF
--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -24,7 +24,10 @@
   "mcpServers": {
     "desktop-commander": {
       "command": "npx",
-      "args": ["-y", "@wonderwhy-er/desktop-commander@latest"]
+      "args": [
+        "-y",
+        "@wonderwhy-er/desktop-commander@0.2.47"
+      ]
     }
   }
 }

--- a/plugins/cursor/.cursor-plugin/plugin.json
+++ b/plugins/cursor/.cursor-plugin/plugin.json
@@ -35,7 +35,10 @@
   "mcpServers": {
     "desktop-commander": {
       "command": "npx",
-      "args": ["-y", "@wonderwhy-er/desktop-commander@latest"]
+      "args": [
+        "-y",
+        "@wonderwhy-er/desktop-commander@0.2.47"
+      ]
     }
   }
 }

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -1,6 +1,17 @@
 import { readFileSync, writeFileSync } from 'fs';
 import path from 'path';
 
+const PACKAGE_NAME = '@wonderwhy-er/desktop-commander';
+
+// Plugin manifests pin the npm version in their MCP launch args, so they have
+// to move with every release. They cannot use `@latest`: npx re-resolves that
+// on every launch and reinstalls the whole dependency tree whenever the cached
+// copy is stale, which can outlast a host's connect timeout on a slow machine.
+const PLUGIN_MANIFESTS = [
+    'plugins/claude/.claude-plugin/plugin.json',
+    'plugins/cursor/.cursor-plugin/plugin.json'
+];
+
 function bumpVersion(version, type = 'patch') {
     const [major, minor, patch] = version.split('.').map(Number);
     switch(type) {
@@ -49,4 +60,23 @@ writeFileSync('server.json', JSON.stringify(serverJson, null, 2) + '\n');
 const versionFileContent = `export const VERSION = '${version}';\n`;
 writeFileSync('src/version.ts', versionFileContent);
 
-console.log(`Version ${version} synchronized${shouldBump ? ' and bumped' : ''} across package.json, server.json, and version.ts`);
+// Update the pinned launch version in each plugin manifest
+const updatedManifests = [];
+PLUGIN_MANIFESTS.forEach(manifestPath => {
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    const server = manifest.mcpServers && manifest.mcpServers['desktop-commander'];
+    if (!server || !Array.isArray(server.args)) {
+        console.warn(`Skipped ${manifestPath}: no desktop-commander mcpServers args to update`);
+        return;
+    }
+    server.args = server.args.map(arg =>
+        typeof arg === 'string' && arg.startsWith(`${PACKAGE_NAME}@`)
+            ? `${PACKAGE_NAME}@${version}`
+            : arg
+    );
+    writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
+    updatedManifests.push(path.basename(path.dirname(manifestPath)) + '/plugin.json');
+});
+
+const targets = ['package.json', 'server.json', 'version.ts', ...updatedManifests].join(', ');
+console.log(`Version ${version} synchronized${shouldBump ? ' and bumped' : ''} across ${targets}`);

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -75,7 +75,7 @@ PLUGIN_MANIFESTS.forEach(manifestPath => {
             : arg
     );
     writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
-    updatedManifests.push(path.basename(path.dirname(manifestPath)) + '/plugin.json');
+    updatedManifests.push(manifestPath);
 });
 
 const targets = ['package.json', 'server.json', 'version.ts', ...updatedManifests].join(', ');


### PR DESCRIPTION
Fixes the startup failure reported in #655: a plugin-launched server that can never connect on a machine where installing the package takes longer than the host's connect timeout.

### The bug

Both plugin manifests launch the server as `npx -y @wonderwhy-er/desktop-commander@latest`. `@latest` makes npm re-resolve the version on every launch, and the npx cache key hashes the *spec string* rather than the resolved version - so as soon as a new version is published, every launch reinstalls the whole tree **in place** before the server can answer `initialize`.

On my machine that install is ~75 s (534 packages, AV-scanned corporate Windows). Claude Desktop gives up at 120 s and kills the process mid-install, leaving a half-written tree (`Error: Cannot find module 'ajv'`). The next launch reinstalls again. It never converges, and disable/enable - the client's own advice in the error message - just restarts the loop. Measured `initialize` round-trip: no reply within 180 s while broken, then 15.4 s and 11.7 s once the cache was whole.

### The change

- `plugins/claude/.claude-plugin/plugin.json` and `plugins/cursor/.cursor-plugin/plugin.json`: pin the launch arg to `@0.2.47`. A pinned spec gets its own cache key, is installed exactly once, and an interrupted launch can no longer poison a tree that later launches depend on.
- `scripts/sync-version.js`: move that pinned arg alongside `package.json`, `server.json` and `version.ts`, so pinning does not become a manual step that is easy to forget. It rewrites only an arg that already targets this package, and skips a manifest without the expected block with a warning rather than throwing.

The manifests are committed in `JSON.stringify(..., null, 2)` form, so `npm run sync-version` is byte-for-byte a no-op on them.

### Tested

Ran the script against a fixture tree:

| case | result |
|---|---|
| version already 0.2.47 | both manifests byte-identical afterwards (md5 unchanged) |
| `--bump`, 0.2.47 to 0.2.48 | package.json, server.json (both places), version.ts and both manifests updated |
| manifest with `mcpServers` removed | warned and skipped, exit 0, the other manifest still updated |

### Notes for review

- I reproduced the failure only on Claude Desktop 1.34493.1 / Windows 11. The Cursor manifest is changed for consistency, not because I saw it fail there - say the word and I will drop it.
- `0.2.47` is the version published as I write this. If you would rather the pins land on whatever `npm run sync-version` produces at release time, the script change alone is enough.
- If `@latest` is deliberate - plugin users picking up new builds without a plugin release - then this is the wrong trade and `--prefer-offline` in the args is the smaller alternative. Happy to switch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated plugin integrations to use a stable desktop-commander release instead of a floating latest version.
  * Improved version synchronization so supported plugin configurations stay aligned automatically.
  * Added warnings when plugin configurations cannot be updated and clearer reporting of completed updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->