### PR TITLE
feat(security): support scoped directory permissions via commandScopes (#663)

### DIFF
--- a/src/command-manager.ts
+++ b/src/command-manager.ts
@@ -226,25 +226,42 @@ class CommandManager {
         }
     }
 
-    async validateCommand(command: string): Promise<boolean> {
+    async validateCommand(command: string, workingDirectory?: string): Promise<boolean> {
         try {
-            // Get blocked commands from config
+            // Get blocked commands and scoped permissions from config
             const config = await configManager.getConfig();
             const blockedCommands = config.blockedCommands || [];
+            const commandScopes = config.commandScopes || {};
             
             // Extract all commands from the command string
             const allCommands = this.extractCommands(command);
             
+            const isAllowedInScope = (cmd: string): boolean => {
+                if (!workingDirectory || !commandScopes[cmd]) return false;
+                const allowedDirs = commandScopes[cmd];
+                const resolvedWorkingDir = path.resolve(workingDirectory);
+                return allowedDirs.some(dir => {
+                    const resolvedAllowed = path.resolve(dir);
+                    return resolvedWorkingDir === resolvedAllowed || resolvedWorkingDir.startsWith(resolvedAllowed + path.sep);
+                });
+            };
+
             // If there are no commands extracted, fall back to base command
             if (allCommands.length === 0) {
                 const baseCommand = this.getBaseCommand(command);
-                return !blockedCommands.includes(baseCommand);
+                if (!baseCommand) return true;
+                if (blockedCommands.includes(baseCommand)) {
+                    return isAllowedInScope(baseCommand);
+                }
+                return true;
             }
             
             // Check if any of the extracted commands are in the blocked list
             for (const cmd of allCommands) {
                 if (blockedCommands.includes(cmd)) {
-                    return false; // Command is blocked
+                    if (!isAllowedInScope(cmd)) {
+                        return false; // Command is blocked and not permitted in current scope
+                    }
                 }
             }
             

--- a/src/config-manager.ts
+++ b/src/config-manager.ts
@@ -8,6 +8,7 @@ import { CONFIG_FILE } from './config.js';
 
 export interface ServerConfig {
   blockedCommands?: string[];
+  commandScopes?: Record<string, string[]>; // Command -> allowed directories override (#663)
   defaultShell?: string;
   allowedDirectories?: string[];
   telemetryEnabled?: boolean; // New field for telemetry control

--- a/src/tools/improved-process-tools.ts
+++ b/src/tools/improved-process-tools.ts
@@ -117,7 +117,7 @@ export async function startProcess(args: unknown): Promise<ServerResult> {
     });
   }
 
-  const isAllowed = await commandManager.validateCommand(parsed.data.command);
+  const isAllowed = await commandManager.validateCommand(parsed.data.command, parsed.data.working_directory);
   if (!isAllowed) {
     return {
       content: [{ type: "text", text: `Error: Command not allowed: ${parsed.data.command}` }],


### PR DESCRIPTION
### Summary

Fixes #663.

Allows configuring per-directory exemptions for blocked commands via `commandScopes` mapping in `ServerConfig` (e.g. allowing `Remove-Item` or `rm` exclusively within trusted project directories while keeping it globally blocked elsewhere).

### Changes
- Added `commandScopes?: Record<string, string[]>` to `ServerConfig`.
- Updated `commandManager.validateCommand(command, workingDirectory)` to check path boundaries against `commandScopes[cmd]`.
- Forwarded `working_directory` in `startProcess` to command validator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added directory-specific command permissions, allowing configured commands to run in approved working directories.
  * Process launch checks now evaluate the requested working directory when validating commands.
* **Bug Fixes**
  * Improved command validation for empty or partially parsed commands.
  * Blocked commands remain denied unless explicitly permitted for the current directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->