### PR TITLE
chore(remote-device): remove dead legacy postgres_changes transport

### DIFF
--- a/src/remote-device/remote-channel.ts
+++ b/src/remote-device/remote-channel.ts
@@ -75,9 +75,6 @@ const SOCKET_SETTLE_POLL_MS = 20;
 export class RemoteChannel {
     private client: SupabaseClient | null = null;
     private channel: RealtimeChannel | null = null;
-    /** Legacy listener, on its own public channel so a private-channel auth
-     * failure can't take both transports down. Removed at the flip (009). */
-    private legacyChannel: RealtimeChannel | null = null;
     private heartbeatInterval: NodeJS.Timeout | null = null;
     private connectionCheckInterval: NodeJS.Timeout | null = null;
     /** Device the heartbeat timer maintains; null = stopped, so re-arm is inert. */
@@ -273,9 +270,6 @@ export class RemoteChannel {
             // Create and subscribe to the channel
             console.debug('[DEBUG] Calling createChannel()');
 
-            // Independent safety net for the doorbell transport.
-            this.createLegacyChannel();
-
             await this.createChannel().catch((error) => {
                 console.debug(`[DEBUG] Failed to create channel, will retry after socket reconnect: ${error?.message || error} — ${this.connState()}`);
             });
@@ -333,10 +327,11 @@ export class RemoteChannel {
         }
 
         this.presenceTracked = false;
-        console.error('❌ Presence track failed after retries — reverting to the legacy transport tier');
+        console.error('❌ Presence track failed after retries — withdrawing broadcast capability');
         captureRemote('remote_channel_presence_track_error', { attempts }).catch(() => { });
         // Withdraw: a stale flag with no presence makes the server refuse to
-        // dispatch at all. The legacy tier keeps the device usable.
+        // dispatch at all. The faster heartbeat tier keeps the device's status
+        // accurate for the DB-status fallback while it recovers.
         await this.setTransportCapable(false);
     }
 
@@ -371,7 +366,7 @@ export class RemoteChannel {
                 return;
             }
             this.transportCapableWritten = capable;
-            console.debug(`[DEBUG] Transport capability set to ${capable ? 'broadcast_v1' : 'legacy'}`);
+            console.debug(`[DEBUG] Transport capability set to ${capable ? 'broadcast_v1' : 'withdrawn'}`);
             // Tier changed — move last_seen onto the cadence that tier's sweep
             // threshold expects (no-op if the heartbeat hasn't started yet).
             this.scheduleHeartbeat();
@@ -383,45 +378,6 @@ export class RemoteChannel {
         } catch (error: any) {
             console.error('[DEBUG] Transport capability update threw:', error?.message);
         }
-    }
-
-    /**
-     * Legacy postgres_changes listener on its own public channel. Best-effort:
-     * failures are logged, never thrown. Removed at the flip (009).
-     */
-    private createLegacyChannel(): void {
-        if (!this.client || !this.user?.id) return;
-        try {
-            this.legacyChannel = this.client
-                .channel('device_tool_call_queue')
-                .on(
-                    'postgres_changes' as any,
-                    {
-                        event: 'INSERT',
-                        schema: 'public',
-                        table: 'mcp_remote_calls',
-                        filter: `user_id=eq.${this.user.id}`
-                    },
-                    (payload: any) => {
-                        console.debug('[DEBUG] Realtime event received, payload:', payload?.new?.id);
-                        this.dispatchToolCall(payload);
-                    }
-                )
-                .subscribe((status: string) => {
-                    console.debug(`[DEBUG] Legacy channel status: ${status}`);
-                });
-        } catch (error: any) {
-            console.debug('[DEBUG] Legacy channel subscribe failed (doorbell path unaffected):', error?.message);
-        }
-    }
-
-    /** Tear down the legacy channel (best effort). */
-    private async removeLegacyChannel(): Promise<void> {
-        if (!this.legacyChannel || !this.client) return;
-        try {
-            await this.client.removeChannel(this.legacyChannel);
-        } catch { /* best effort */ }
-        this.legacyChannel = null;
     }
 
     /** Create and subscribe the private channel (initial join and recreation). */
@@ -565,14 +521,13 @@ export class RemoteChannel {
             await captureRemote('remote_channel_doorbell_row_missing', { call_id: callId });
             return;
         }
-        // Optimization, not a guard — saves a hop when the legacy path already
-        // claimed this. Exactly-once lives in device.ts (seenCallIds + DB claim).
+        // Optimization, not a guard — saves a hop on a duplicate doorbell
+        // (retry, reconnect). Exactly-once lives in device.ts (seenCallIds + DB claim).
         if (row.status !== 'pending') {
-            console.debug('[DEBUG] Doorbell call already claimed via legacy path:', callId);
+            console.debug('[DEBUG] Doorbell call already claimed:', callId);
             return;
         }
 
-        // Same payload shape as postgres_changes ({ new: row }).
         this.dispatchToolCall({ new: row });
     }
 
@@ -762,9 +717,6 @@ export class RemoteChannel {
                     await this.client!.removeChannel(this.channel);
                     this.channel = null;
                 }
-                // Rebuild the legacy channel too: it shares the socket, so a
-                // socket-level wedge takes it down with the private channel.
-                await this.removeLegacyChannel();
 
                 // FIX (core): force a brand-new WebSocket. After idle / wifi-loss the socket can
                 // be HALF-OPEN (readyState OPEN but dead); reusing it made every join TIME_OUT
@@ -776,19 +728,12 @@ export class RemoteChannel {
                 // _teardownConnection() nulls the conn.onclose that would clear
                 // it, so only an internal ~100ms fallback timer does. connect()
                 // early-returns for that whole window, so rebuilding here makes
-                // subscribe()'s socket.connect() a silent no-op and BOTH
-                // channels sit in 'joining' until the 10s join timeout — the
-                // wasted-first-recreate that left the device dark on the legacy
-                // channel too. Wait for the state to settle before rebuilding.
+                // subscribe()'s socket.connect() a silent no-op and the channel
+                // sits in 'joining' until the 10s join timeout — a wasted first
+                // recreate. Wait for the state to settle before rebuilding.
                 await this.waitForSocketSettled();
 
                 console.debug('[DEBUG] Calling createChannel() for recreation');
-                // Rebuild the legacy safety net FIRST and unconditionally: if
-                // createChannel() throws or exceeds RECREATE_TIMEOUT_MS, anything
-                // after it is skipped, which used to leave the fallback dead for
-                // the entire duration of a private-channel outage — every
-                // subsequent health tick repeating the same teardown.
-                this.createLegacyChannel();
                 await this.createChannel();
             }, RECREATE_TIMEOUT_MS, 'recreateChannel');
         } catch (err: any) {
@@ -905,15 +850,9 @@ export class RemoteChannel {
         }
     }
 
-    /**
-     * Reachable by SOME transport — the private channel or, during the
-     * transition, the independent legacy one. Gates the heartbeat and `status`:
-     * asking only about the private channel starves last_seen for a device whose
-     * legacy channel is fine, and the 45s sweep then blacks it out.
-     * Collapses to a single check at the flip (009).
-     */
+    /** Reachable means the private channel is joined. Gates the heartbeat and `status`. */
     private isReachable(): boolean {
-        return this.channel?.state === 'joined' || this.legacyChannel?.state === 'joined';
+        return this.channel?.state === 'joined';
     }
 
     /**
@@ -1175,7 +1114,7 @@ export class RemoteChannel {
         // SUBSCRIBED would queue 'online' after the durable write.
         this.shuttingDown = true;
         // Budget against device.ts's 5s force-exit, worst case:
-        //   250 drain + 3x300 leave + 500 session + 3000 spawnSync = 4650ms.
+        //   250 drain + 2x300 leave + 500 session + 3000 spawnSync = 4350ms.
         // In practice only the untrack bound binds — removeChannel/unsubscribe
         // set state='leaving' first, so their leave push resolves inline.
         const LEAVE_BOUND_MS = 300;
@@ -1183,7 +1122,6 @@ export class RemoteChannel {
         // heartbeat PATCH (it doesn't use the chain), but the gate above stops
         // any new one and an in-flight one started earlier.
         await Promise.race([this.statusWriteChain, this.sleep(250)]);
-        await Promise.race([this.removeLegacyChannel(), this.sleep(LEAVE_BOUND_MS)]);
         if (this.channel) {
             // Leave presence on the graceful path (socket close covers the abrupt
             // one). Bounded: a half-open socket still reports 'joined', so the

--- a/test/test-remote-transport.js
+++ b/test/test-remote-transport.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Remote transport tests (Broadcast/Presence + legacy fallback).
+ * Remote transport tests (Broadcast/Presence).
  *
  * Sections:
  *   1. Exactly-once execution under dual delivery
@@ -302,16 +302,16 @@ await test('the result row is written BEFORE the doorbell is rung', async () => 
 // --- 4. Heartbeat cadence tiers ---------------------------------------------
 // The server tiers its offline sweep on the capability FLAG, not the app
 // version, and the flag is only set once presence is proven. So an unproven
-// device is judged by the 45s legacy rule and must heartbeat fast enough to
-// survive it, or it is swept offline while its legacy channel still works.
+// device is judged by the fast 45s rule and must heartbeat fast enough to
+// survive it, or it is swept offline before it ever proves presence.
 
-await test('legacy tier heartbeats inside the server 45s sweep threshold', async () => {
+await test('unproven tier heartbeats inside the server 45s sweep threshold', async () => {
   const { rc } = makeRemoteChannel();
-  rc.transportCapableWritten = null; // never written = legacy tier
+  rc.transportCapableWritten = null; // never written = unproven tier
   const cadence = rc.heartbeatIntervalMs();
   assert(
     cadence * 2 < SERVER_LEGACY_OFFLINE_TIMEOUT_MS,
-    `legacy cadence ${cadence}ms must allow >=2 writes inside ${SERVER_LEGACY_OFFLINE_TIMEOUT_MS}ms`
+    `unproven-tier cadence ${cadence}ms must allow >=2 writes inside ${SERVER_LEGACY_OFFLINE_TIMEOUT_MS}ms`
   );
   rc.transportCapableWritten = false; // explicitly withdrawn
   assert(rc.heartbeatIntervalMs() === cadence, 'a withdrawn capability uses the fast cadence');
@@ -367,24 +367,12 @@ await test('stopHeartbeat halts the self-rescheduling timer', async () => {
 });
 
 // --- 5. Reachability and status writes --------------------------------------
-// `status` is what the server's device selection filters on, and it is
-// transport-agnostic — so it must follow "reachable by ANY transport", never the
-// private channel alone.
-
-await test('heartbeat writes when only the legacy channel is joined', async () => {
-  const { rc, client } = makeRemoteChannel();
-  rc.channel = null; // private channel never joined
-  rc.legacyChannel = makeChannelState('joined'); // fallback is up
-  await rc.updateHeartbeat(DEVICE_ID);
-  assert(client.writes.length === 1, 'legacy-only reachable device must still write last_seen');
-  assert(client.writes[0].last_seen, 'write should bump last_seen');
-  assert(client.writes[0].status === 'online', 'write should assert online');
-});
+// `status` is what the server's device selection filters on, so it must
+// follow the private channel's real join state.
 
 await test('heartbeat stays silent when no transport is joined', async () => {
   const { rc, client } = makeRemoteChannel();
   rc.channel = makeChannelState('errored');
-  rc.legacyChannel = makeChannelState('closed');
   await rc.updateHeartbeat(DEVICE_ID);
   assert(client.writes.length === 0, 'a deaf device must let the sweep age its row out');
 });
@@ -392,25 +380,13 @@ await test('heartbeat stays silent when no transport is joined', async () => {
 await test('heartbeat writes when the private channel is joined', async () => {
   const { rc, client } = makeRemoteChannel();
   rc.channel = makeChannelState('joined');
-  rc.legacyChannel = null;
   await rc.updateHeartbeat(DEVICE_ID);
   assert(client.writes.length === 1, 'private channel joined = reachable');
 });
 
-await test('private-channel failure keeps status online while legacy is joined', async () => {
+await test('status goes offline when the private channel is not joined', async () => {
   const { rc, client } = makeRemoteChannel();
   rc.channel = makeChannelState('errored');
-  rc.legacyChannel = makeChannelState('joined');
-  rc.syncReachabilityStatus();
-  await rc.statusWriteChain;
-  assert(client.writes.length === 1, 'one status write');
-  assert(client.writes[0].status === 'online', 'still reachable via legacy = online');
-});
-
-await test('status goes offline when no transport is joined', async () => {
-  const { rc, client } = makeRemoteChannel();
-  rc.channel = makeChannelState('errored');
-  rc.legacyChannel = makeChannelState('closed');
   rc.syncReachabilityStatus();
   await rc.statusWriteChain;
   assert(client.writes[0].status === 'offline', 'genuinely deaf device goes offline');
@@ -446,34 +422,18 @@ await test('concurrent status writes stay ordered', async () => {
 // --- 6. Capability withdrawal -----------------------------------------------
 // For a flagged device the server treats absent presence as authoritative
 // offline and applies that overlay before selection, overriding `status`. So a
-// device that cannot join the private channel must stop advertising the flag or
-// it is undispatchable however healthy its legacy channel is.
+// device that cannot join the private channel must stop advertising the flag
+// or it is undispatchable — there is no other transport to fall back on.
 
 await test('sustained recreate failure withdraws the transport capability', async () => {
   const { rc, client } = makeRemoteChannel();
   rc.transportCapableWritten = true; // previously proven
-  rc.legacyChannel = makeChannelState('joined');
   rc.sleep = () => Promise.resolve(); // skip the jittered backoff
-  const order = [];
-  rc.createChannel = () => {
-    order.push('private');
-    return Promise.reject(new Error('Unauthorized'));
-  };
-  rc.createLegacyChannel = () => { order.push('legacy'); };
+  rc.createChannel = () => Promise.reject(new Error('Unauthorized'));
   rc.channel = makeChannelState('errored');
 
   for (let i = 0; i < 3; i++) await rc.recreateChannel();
 
-  // Also proves the recreate reached createChannel rather than dying earlier,
-  // and that the legacy net is rebuilt first and on every attempt.
-  assert(
-    order.slice(0, 2).join(',') === 'legacy,private',
-    `legacy net must be rebuilt first: ${JSON.stringify(order)}`
-  );
-  assert(
-    order.filter((o) => o === 'legacy').length === 3,
-    'legacy net must be rebuilt on every recreate attempt'
-  );
   assert(rc.transportCapableWritten === false, 'capability must be withdrawn');
   const capWrite = client.writes.find((w) => w.capabilities);
   assert(capWrite, 'a capabilities write should have been issued');
@@ -487,10 +447,8 @@ await test('sustained recreate failure withdraws the transport capability', asyn
 await test('a single recreate failure does not withdraw the capability', async () => {
   const { rc } = makeRemoteChannel();
   rc.transportCapableWritten = true;
-  rc.legacyChannel = makeChannelState('joined');
   rc.sleep = () => Promise.resolve();
   rc.createChannel = () => Promise.reject(new Error('transient'));
-  rc.createLegacyChannel = () => {};
   rc.channel = makeChannelState('errored');
   await rc.recreateChannel();
   assert(rc.transportCapableWritten === true, 'one blip must not withdraw');
@@ -499,10 +457,8 @@ await test('a single recreate failure does not withdraw the capability', async (
 await test('a hanging capability withdrawal cannot pin the recreate guard', async () => {
   const { rc } = makeRemoteChannel();
   rc.transportCapableWritten = true;
-  rc.legacyChannel = makeChannelState('joined');
   rc.sleep = () => Promise.resolve();
   rc.createChannel = () => Promise.reject(new Error('Unauthorized'));
-  rc.createLegacyChannel = () => {};
   rc.channel = makeChannelState('errored');
   rc.setTransportCapable = () => new Promise(() => {}); // never settles
   const realWithTimeout = rc.withTimeout.bind(rc);
@@ -520,7 +476,6 @@ await test('a hanging capability withdrawal cannot pin the recreate guard', asyn
 await test('status writes are suppressed once shutting down', async () => {
   const { rc, client } = makeRemoteChannel();
   rc.channel = makeChannelState('joined');
-  rc.legacyChannel = makeChannelState('joined');
   rc.shuttingDown = true;
   rc.syncReachabilityStatus();
   rc.queueStatusWrite('online');
@@ -538,7 +493,6 @@ await test('heartbeat is suppressed once shutting down', async () => {
 
 await test('unsubscribe is bounded and still clears the channel', async () => {
   const { rc } = makeRemoteChannel();
-  rc.legacyChannel = null;
   rc.channel = {
     state: 'joined',
     untrack: () => new Promise(() => {}), // never settles


### PR DESCRIPTION
Migration 009 on the server removed mcp_remote_calls from the realtime publication, which made the device's postgres_changes listener (device_tool_call_queue) permanently non-functional - the join could never succeed since the table left the publication. This removes createLegacyChannel/removeLegacyChannel and its call sites, and collapses isReachable() to a single check on the private channel (the legacy branch could never be true post-009 anyway).

Also updates comments/log lines that described the removed channel as if still active, and removes the test coverage that exercised the dual-channel fallback. Heartbeat tiering (fast cadence for an unproven or withdrawn device) is untouched - that's a liveness-detection speed concept independent of which transport delivers calls.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed the deprecated fallback transport for remote-device communication.
  - Reachability and online status now reflect the private broadcast connection exclusively.
  - Updated connection recovery and failure handling to accurately report when broadcast access is unavailable.
- **Tests**
  - Updated connection, heartbeat, shutdown, unsubscribe, and recovery coverage for the simplified transport behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->