### PR TITLE
fix(process): parse tasklist as CSV on Windows so list_processes returns real fields

### DIFF
--- a/src/tools/process.ts
+++ b/src/tools/process.ts
@@ -6,22 +6,55 @@ import { KillProcessArgsSchema } from './schemas.js';
 
 const execAsync = promisify(exec);
 
+/**
+ * Parse `tasklist /fo csv /nh` output (#662). Fields per row, all quoted:
+ * [Image Name, PID, Session Name, Session#, Mem Usage]. CSV instead of the
+ * default table: image names can contain spaces and Mem Usage contains
+ * thousands separators, so positional whitespace splitting can't work.
+ * tasklist has no live per-process CPU%, so cpu is reported as n/a.
+ */
+export function parseWindowsTasklistCsv(stdout: string): ProcessInfo[] {
+  return stdout.split(/\r?\n/)
+    .filter(Boolean)
+    .map(line => {
+      const fields = (line.match(/"([^"]*)"/g) || []).map(f => f.slice(1, -1));
+      return {
+        pid: parseInt(fields[1], 10),
+        command: fields[0] ?? '',
+        cpu: 'n/a',
+        memory: fields[4] ?? '',
+      } as ProcessInfo;
+    })
+    .filter(p => !Number.isNaN(p.pid));
+}
+
+/**
+ * Parse `ps aux` output: 11 whitespace-separated columns, COMMAND from
+ * column 10 onward (it can contain spaces, so it must be rejoined, not
+ * taken as the last token).
+ */
+export function parsePsAux(stdout: string): ProcessInfo[] {
+  return stdout.split(/\r?\n/)
+    .slice(1)
+    .filter(Boolean)
+    .map(line => {
+      const parts = line.trim().split(/\s+/);
+      return {
+        pid: parseInt(parts[1], 10),
+        command: parts.slice(10).join(' ') || parts[parts.length - 1],
+        cpu: parts[2],
+        memory: parts[3],
+      } as ProcessInfo;
+    })
+    .filter(p => !Number.isNaN(p.pid));
+}
+
 export async function listProcesses(): Promise<ServerResult> {
-  const command = os.platform() === 'win32' ? 'tasklist' : 'ps aux';
+  const isWindows = os.platform() === 'win32';
+  const command = isWindows ? 'tasklist /fo csv /nh' : 'ps aux';
   try {
     const { stdout } = await execAsync(command);
-    const processes = stdout.split('\n')
-      .slice(1)
-      .filter(Boolean)
-      .map(line => {
-        const parts = line.split(/\s+/);
-        return {
-          pid: parseInt(parts[1]),
-          command: parts[parts.length - 1],
-          cpu: parts[2],
-          memory: parts[3],
-        } as ProcessInfo;
-      });
+    const processes = isWindows ? parseWindowsTasklistCsv(stdout) : parsePsAux(stdout);
 
     return {
       content: [{

--- a/test/test-list-processes.js
+++ b/test/test-list-processes.js
@@ -1,0 +1,87 @@
+/**
+ * Tests for listProcesses parsing (#662): Windows tasklist output was parsed
+ * with ps-aux column logic, garbling every field. Parsers are pure and
+ * platform-independent, so both are tested everywhere; a live smoke runs on
+ * the current platform only.
+ */
+import assert from 'assert';
+import os from 'os';
+import { parseWindowsTasklistCsv, parsePsAux, listProcesses } from '../dist/tools/process.js';
+
+let failures = 0;
+async function test(name, fn) {
+  try { await fn(); console.log(`✅ PASS  ${name}`); }
+  catch (e) { failures++; console.log(`🔴 FAIL  ${name}\n   ${e.message}`); }
+}
+
+// CRLF line endings and quoted CSV, exactly as tasklist /fo csv /nh emits.
+const TASKLIST_CSV = [
+  '"System Idle Process","0","Services","0","8 K"',
+  '"System","4","Services","0","21,436 K"',
+  '"Claude Helper.exe","14004","Console","1","155,200 K"',
+  '"node.exe","76844","Console","1","113,672 K"',
+  '',
+].join('\r\n');
+
+// ps aux with header row and a command containing spaces.
+const PS_AUX = [
+  'USER  PID %CPU %MEM    VSZ   RSS TTY STAT START TIME COMMAND',
+  'root    1  0.0  0.1 168000 11000 ?   Ss   Jan01 0:04 /sbin/init splash',
+  'edu  8794  1.2  0.5 409000 82000 ?   S    10:15 0:01 node dist/index.js remote --debug',
+  '',
+].join('\n');
+
+await test('tasklist CSV: image name, pid, memory land in the right fields', () => {
+  const rows = parseWindowsTasklistCsv(TASKLIST_CSV);
+  assert.strictEqual(rows.length, 4);
+  const system = rows.find(r => r.pid === 4);
+  assert.strictEqual(system.command, 'System');
+  assert.strictEqual(system.memory, '21,436 K');
+  assert.strictEqual(system.cpu, 'n/a');
+});
+
+await test('tasklist CSV: image names with spaces stay intact (no column shift)', () => {
+  const helper = parseWindowsTasklistCsv(TASKLIST_CSV).find(r => r.pid === 14004);
+  assert.strictEqual(helper.command, 'Claude Helper.exe');
+  assert.strictEqual(helper.memory, '155,200 K');
+});
+
+await test('tasklist CSV: session name/number never leak into cpu/memory', () => {
+  for (const r of parseWindowsTasklistCsv(TASKLIST_CSV)) {
+    assert.ok(!['Services', 'Console'].includes(r.cpu), `cpu leaked session name: ${r.cpu}`);
+    assert.ok(!['0', '1'].includes(r.memory), `memory leaked session number: ${r.memory}`);
+  }
+});
+
+await test('tasklist table output (the old command) yields no NaN garbage rows', () => {
+  // Regression guard for the header/separator symptom from #662: even if fed
+  // the wrong format, the parser must drop unparseable rows, not emit NaN.
+  const legacyTable = 'Image Name  PID Session Name  Session#  Mem Usage\r\n=========== === ============ ========= =========\r\nSystem   4 Services 0 21,436 K\r\n';
+  const rows = parseWindowsTasklistCsv(legacyTable);
+  assert.ok(rows.every(r => !Number.isNaN(r.pid)));
+});
+
+await test('ps aux: commands with spaces are rejoined, not truncated to last token', () => {
+  const rows = parsePsAux(PS_AUX);
+  assert.strictEqual(rows.length, 2);
+  assert.strictEqual(rows[1].command, 'node dist/index.js remote --debug');
+  assert.strictEqual(rows[1].cpu, '1.2');
+  assert.strictEqual(rows[1].memory, '0.5');
+});
+
+await test('ps aux: CRLF input leaves no trailing-\\r empty column', () => {
+  const rows = parsePsAux(PS_AUX.replace(/\n/g, '\r\n'));
+  assert.strictEqual(rows[0].command, '/sbin/init splash');
+});
+
+await test(`live smoke on ${os.platform()}: real output parses with no NaN/empty rows`, async () => {
+  const result = await listProcesses();
+  assert.ok(!result.isError, 'listProcesses returned error');
+  const lines = result.content[0].text.split('\n');
+  assert.ok(lines.length > 5, 'suspiciously few processes');
+  assert.ok(lines.every(l => !l.includes('PID: NaN')), 'NaN pid rows present');
+  assert.ok(lines.every(l => !/Command: ,/.test(l)), 'empty command rows present');
+});
+
+console.log(failures > 0 ? `🔴 list-processes: ${failures} failing test(s).` : '✅ list-processes: 0 failing test(s).');
+process.exit(failures > 0 ? 1 : 0);


### PR DESCRIPTION
Fixes #662.

listProcesses ran `tasklist` on Windows but parsed it with the ps-aux column logic, so every row came out garbled: command empty (the trailing-`\r` empty token), cpu holding the session name, memory holding the session number, plus `PID: NaN` rows from the header/separator lines.

Windows now uses `tasklist /fo csv /nh` and a CSV parser (image names can contain spaces, Mem Usage contains thousands separators, so positional splitting can't work). tasklist has no live per-process CPU%, so cpu is reported as `n/a`. The ps-aux path also rejoins COMMAND from column 10 onward instead of taking the last token, and both paths split on `\r?\n` and drop non-numeric-pid rows.

Both parsers are exported pure functions with fixture tests in `test/test-list-processes.js` plus a live smoke on the current platform.

Testing: reproduced the garbled output live on Windows 11 via the MCP tool; on this branch the fixture tests pass 7/7 and the same live call returns 0 NaN rows with real image names and memory. Negative control: same live check against main's parser shows 20 NaN rows and empty commands on all 503 rows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process list accuracy on Windows by correctly interpreting task details, including names with spaces.
  * Fixed process information parsing on Unix-like systems when commands contain spaces.
  * Prevented invalid CPU and memory values from appearing in process listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->