### PR TITLE
fix(telemetry): stop sending character_codes from fuzzy search

### DIFF
--- a/src/tools/edit.ts
+++ b/src/tools/edit.ts
@@ -295,6 +295,19 @@ RECOMMENDATION: For large search/replace operations, consider breaking them into
         await fuzzySearchLogger.log(logEntry);
         
         // Combine all fuzzy search data for single capture
+        //
+        // character_codes (characterCodeData.report) is deliberately NOT sent.
+        // It is a frequency map of the characters in the diff between the
+        // search text and the file text, so for a short diff it is close to
+        // recoverable file content — and mcp-privacy-policy.md states that
+        // file contents are not collected. It was added as diagnostics for the
+        // CRLF/LF normalization work in #103 (May 2025) to show whether failed
+        // matches came from \r (13), \n (10) or non-breaking spaces; that
+        // question is long since answered.
+        //
+        // The scalars below are kept: they are counts and lengths, and carry
+        // no recoverable content. The full report still goes to the local
+        // fuzzy-search.log for anyone debugging on their own machine.
         const fuzzySearchData = {
             similarity: similarity,
             execution_time_ms: executionTime,
@@ -302,7 +315,6 @@ RECOMMENDATION: For large search/replace operations, consider breaking them into
             file_size: content.length,
             threshold: FUZZY_THRESHOLD,
             found_text_length: fuzzyResult.value.length,
-            character_codes: characterCodeData.report,
             unique_character_count: characterCodeData.uniqueCount,
             total_diff_length: characterCodeData.diffLength
         };


### PR DESCRIPTION
## Why

`server_fuzzy_search_performed` sent `character_codes` — a frequency map of the characters in the diff between the search text and the matched file text (`edit.ts`, from `getCharacterCodeData`). For a short diff, a character histogram is close to recoverable content.

`mcp-privacy-policy.md` lists this under what is **not** collected:

> - **File contents**: The actual data or code in your files

So this was file-content-derived data leaving the machine, against a stated commitment.

## It's leftover scaffolding

`git log -S getCharacterCodeData` points at one commit: #103, May 2025, *"Detect line ending style and normalize line endings in edit string to file style"* — containing a commit literally named "add stats". It was diagnostics for the CRLF/LF normalization work, showing whether failed fuzzy matches came from `\r` (13), `\n` (10) or non-breaking spaces. That question is long since answered, so nothing is reading this now.

## What changed

One field removed from the `fuzzySearchData` object. That object feeds both `server_fuzzy_search_performed` call sites — the above-threshold capture and the below-threshold spread — so a single edit covers both.

**Kept deliberately:**

- `unique_character_count` and `total_diff_length` — a count and a length. No recoverable content, and they preserve the aggregate signal if anyone does want to spot an encoding anomaly.
- The full report in the local `fuzzy-search.log`. It never leaves the machine, and it's what someone debugging their own failed edit actually reads. The message returned to the user still points at that log path.

**Also checked:** the other fuzzy events, `fuzzy_search_recursive_metrics` and `fuzzy_search_iterative_metrics` (`fuzzySearchCore.ts:17`), carry only scalars — execution time, lengths, iterations, distances. Nothing else needed changing, and `character_codes` no longer appears anywhere in `src/` or the compiled `dist/`.

## Tests

`npm test` → **49/49 pass**, build clean.

## Note

This is the only item from the privacy audit that touches this repo. The larger one for `DesktopCommanderMCP` is that `mcp-privacy-policy.md` still describes Google Analytics 4 as the analytics provider — including Google's retention and IP handling — while `capture.ts` now posts to `telemetry.desktopcommander.app`. That's a `legal` repo change, tracked separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Privacy**
  * Fuzzy-search telemetry no longer includes character-code diagnostics.
  * Local fuzzy-search logs continue to retain character-code details.
  * Aggregate counts and length information remain available in telemetry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->