### PR TITLE
Remove uninstall feedback call offer

### DIFF
--- a/uninstall-claude-server.js
+++ b/uninstall-claude-server.js
@@ -693,12 +693,6 @@ export default async function uninstall() {
             logToFile('\nIf you want to reinstall later, you can run:');
             logToFile('npx @wonderwhy-er/desktop-commander@latest setup');
 
-            logToFile('\n🎁 We\'re sorry to see you leaving, we’d love to understand your decision not to use Desktop Commander.')
-            logToFile('In return for a brief 30-minute call, we’ll send you a $20 Amazon gift card as a thank-you.');
-            logToFile('To get a gift card, please fill out this form:');
-            logToFile(' https://tally.so/r/w8lyRo');
-
-
             logToFile('\nThank you for using Desktop Commander! 👋\n');
             
             // Send final tracking event
@@ -712,11 +706,6 @@ export default async function uninstall() {
             logToFile('You may need to manually remove Desktop Commander from Claude\'s configuration.');
             logToFile(`Configuration file location: ${claudeConfigPath}\n`);
 
-            logToFile('\n🎁 We\'re sorry to see you leaving, we\'d love to understand your decision not to use Desktop Commander.')
-            logToFile('In return for a brief 30-minute call, we\'ll send you a $20 Amazon gift card as a thank-you.');
-            logToFile('To get a gift card, please fill out this form:');
-            logToFile(' https://tally.so/r/w8lyRo');
-            
             await ensureTrackingCompleted('uninstall_partial_failure');
             
             return false;
@@ -735,10 +724,6 @@ export default async function uninstall() {
         logToFile('You may need to manually remove Desktop Commander from Claude\'s configuration.');
         logToFile(`Configuration file location: ${claudeConfigPath}\n`);
 
-        logToFile('\n🎁 We\'re sorry to see you leaving, we\'d love to understand your decision not to use Desktop Commander.')
-        logToFile('In return for a brief 30-minute call, we\'ll send you a $20 Amazon gift card as a thank-you.');
-        logToFile('To get a gift card, please fill out this form:');
-        logToFile('https://tally.so/r/w8lyRo');
         return false;
     }
 }


### PR DESCRIPTION
## Summary
- remove the 30-minute feedback call offer from the uninstall flow
- remove the $20 Amazon gift card incentive and Tally link
- apply the removal to successful, partial-failure, and fatal-error uninstall paths

## Verification
- npm run build passes
- generated dist/uninstall-claude-server.js no longer contains the offer or Tally link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed gift-card survey solicitation messages from successful, partial-failure, and fatal-error uninstall messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->