### PR TITLE
docs: document timeout_ms in start_process tool description

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -926,6 +926,12 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                         Process finished execution
                         Process running (use read_process_output)
 
+                        PARAMETERS:
+                        - command: Command to execute (required)
+                        - timeout_ms: Max wait for initial process state, in ms (REQUIRED - pass a JSON number, e.g. 5000; omitting it or passing a string fails schema validation before the command runs)
+                        - shell: Shell to use (optional, defaults to config.defaultShell)
+                        - verbose_timing: Enable detailed performance telemetry (default: false)
+
                         PERFORMANCE DEBUGGING (verbose_timing parameter):
                         Set verbose_timing: true to get detailed timing information including:
                         - Exit reason (early_exit_quick_pattern, early_exit_periodic_check, process_exit, timeout)


### PR DESCRIPTION
## Summary

- add a PARAMETERS section to the `start_process` tool description, documenting `command`, `timeout_ms`, `shell`, and `verbose_timing`
- mirrors the PARAMETERS section `interact_with_process` already has

## Why

`StartProcessArgsSchema` requires `timeout_ms` (`z.number()`, no default), but the tool description never mentions it. Agents building calls from the description omit the parameter and get rejected at validation before any command runs (`invalid_type: Required` on `timeout_ms`). A numeric string is rejected too. The sibling process tools already document the parameter; `start_process` is the outlier.

Companion to #551 (schema: optional + default) and #553 (schema `.describe()`). If #551 merges first, the `timeout_ms` line below should be updated from "REQUIRED" to "default: …ms" on rebase.

## Validation

- `npm run build`
- verified the compiled tool listing for `start_process` contains the PARAMETERS section

Fixes #671


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added parameter documentation to the `start_process` tool, including accepted values and the requirement that `timeout_ms` be provided as a JSON number.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->