### PR TITLE
fix: close text read streams after early exit

### DIFF
--- a/src/utils/files/text.ts
+++ b/src/utils/files/text.ts
@@ -353,23 +353,27 @@ export class TextFileHandler implements FileHandler {
         fileTotalLines?: number,
         signal?: AbortSignal
     ): Promise<FileResult> {
+        const stream = createReadStream(filePath, { signal });
         const rl = createInterface({
-            input: createReadStream(filePath, { signal }),
+            input: stream,
             crlfDelay: Infinity
         });
 
         const result: string[] = [];
         let lineNumber = 0;
 
-        for await (const line of rl) {
-            if (lineNumber >= offset && result.length < length) {
-                result.push(line);
+        try {
+            for await (const line of rl) {
+                if (lineNumber >= offset && result.length < length) {
+                    result.push(line);
+                }
+                if (result.length >= length) break;
+                lineNumber++;
             }
-            if (result.length >= length) break;
-            lineNumber++;
+        } finally {
+            rl.close();
+            stream.destroy();
         }
-
-        rl.close();
 
         if (includeStatusMessage) {
             const statusMessage = this.generateEnhancedStatusMessage(result.length, offset, fileTotalLines, false);
@@ -394,21 +398,25 @@ export class TextFileHandler implements FileHandler {
         signal?: AbortSignal
     ): Promise<FileResult> {
         // First, do a quick scan to estimate lines per byte
+        const sampleStream = createReadStream(filePath, { signal });
         const rl = createInterface({
-            input: createReadStream(filePath, { signal }),
+            input: sampleStream,
             crlfDelay: Infinity
         });
 
         let sampleLines = 0;
         let bytesRead = 0;
 
-        for await (const line of rl) {
-            bytesRead += Buffer.byteLength(line, 'utf-8') + 1;
-            sampleLines++;
-            if (bytesRead >= READ_PERFORMANCE_THRESHOLDS.SAMPLE_SIZE) break;
+        try {
+            for await (const line of rl) {
+                bytesRead += Buffer.byteLength(line, 'utf-8') + 1;
+                sampleLines++;
+                if (bytesRead >= READ_PERFORMANCE_THRESHOLDS.SAMPLE_SIZE) break;
+            }
+        } finally {
+            rl.close();
+            sampleStream.destroy();
         }
-
-        rl.close();
 
         if (sampleLines === 0) {
             return await this.readFromStartWithReadline(filePath, offset, length, mimeType, includeStatusMessage, fileTotalLines, signal);
@@ -432,20 +440,23 @@ export class TextFileHandler implements FileHandler {
             const result: string[] = [];
             let firstLineSkipped = false;
 
-            for await (const line of rl2) {
-                if (!firstLineSkipped && startPosition > 0) {
-                    firstLineSkipped = true;
-                    continue;
-                }
+            try {
+                for await (const line of rl2) {
+                    if (!firstLineSkipped && startPosition > 0) {
+                        firstLineSkipped = true;
+                        continue;
+                    }
 
-                if (result.length < length) {
-                    result.push(line);
-                } else {
-                    break;
+                    if (result.length < length) {
+                        result.push(line);
+                    } else {
+                        break;
+                    }
                 }
+            } finally {
+                rl2.close();
+                stream.destroy();
             }
-
-            rl2.close();
 
             const content = includeStatusMessage
                 ? `${this.generateEnhancedStatusMessage(result.length, offset, fileTotalLines, false)}\n\n${result.join('\n')}`

--- a/src/utils/files/text.ts
+++ b/src/utils/files/text.ts
@@ -39,6 +39,15 @@ const READ_PERFORMANCE_THRESHOLDS = {
     CHUNK_SIZE: 8192,             // 8KB chunks for reverse reading
 } as const;
 
+async function destroyReadStream(stream: ReturnType<typeof createReadStream>): Promise<void> {
+    if (stream.closed) return;
+
+    await new Promise<void>((resolve) => {
+        stream.once('close', resolve);
+        stream.destroy();
+    });
+}
+
 /**
  * Text file handler implementation
  * Binary detection is done at the factory level - this handler assumes file is text
@@ -372,7 +381,7 @@ export class TextFileHandler implements FileHandler {
             }
         } finally {
             rl.close();
-            stream.destroy();
+            await destroyReadStream(stream);
         }
 
         if (includeStatusMessage) {
@@ -415,7 +424,7 @@ export class TextFileHandler implements FileHandler {
             }
         } finally {
             rl.close();
-            sampleStream.destroy();
+            await destroyReadStream(sampleStream);
         }
 
         if (sampleLines === 0) {
@@ -455,7 +464,7 @@ export class TextFileHandler implements FileHandler {
                 }
             } finally {
                 rl2.close();
-                stream.destroy();
+                await destroyReadStream(stream);
             }
 
             const content = includeStatusMessage

--- a/test/test-read-file-large-stream-release.js
+++ b/test/test-read-file-large-stream-release.js
@@ -1,4 +1,4 @@
-﻿import assert from 'node:assert/strict';
+import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';

--- a/test/test-read-file-large-stream-release.js
+++ b/test/test-read-file-large-stream-release.js
@@ -1,0 +1,23 @@
+﻿import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { readFile } from '../dist/tools/filesystem.js';
+
+const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'desktop-commander-large-read-release-'));
+const target = path.join(dir, 'target.txt');
+const replacement = path.join(dir, 'replacement.txt');
+
+try {
+  const line = `${'x'.repeat(127)}\n`;
+  await fs.writeFile(target, line.repeat(90000));
+  await readFile(target, { offset: 2000, length: 5 });
+  await fs.writeFile(replacement, 'replacement\n');
+
+  await fs.rename(replacement, target);
+
+  assert.equal(await fs.readFile(target, 'utf8'), 'replacement\n');
+  console.log('large read_file releases sampling and result streams before returning');
+} finally {
+  await fs.rm(dir, { recursive: true, force: true });
+}

--- a/test/test-read-file-stream-close-order.js
+++ b/test/test-read-file-stream-close-order.js
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import fsSync from 'node:fs';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { readFile, readMultipleFiles } from '../dist/tools/filesystem.js';
+
+const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'desktop-commander-read-close-order-'));
+
+async function assertReadAwaitsStreamClose(label, operation) {
+  const originalDestroy = fsSync.ReadStream.prototype._destroy;
+  let pendingCloses = 0;
+  let completedCloses = 0;
+
+  fsSync.ReadStream.prototype._destroy = function delayedDestroy(error, callback) {
+    pendingCloses += 1;
+    setTimeout(() => {
+      originalDestroy.call(this, error, (...args) => {
+        pendingCloses -= 1;
+        completedCloses += 1;
+        callback(...args);
+      });
+    }, 75);
+  };
+
+  try {
+    await operation();
+    assert.equal(
+      pendingCloses,
+      0,
+      `${label} returned before its ReadStream close completed`,
+    );
+    assert.ok(completedCloses > 0, `${label} did not exercise a ReadStream close`);
+  } finally {
+    fsSync.ReadStream.prototype._destroy = originalDestroy;
+    if (pendingCloses > 0) {
+      await new Promise(resolve => setTimeout(resolve, 150));
+    }
+  }
+}
+
+try {
+  const defaultTarget = path.join(dir, 'default.txt');
+  await fs.writeFile(defaultTarget, 'line\n'.repeat(2000));
+  await assertReadAwaitsStreamClose('default-budget readFile', () => readFile(defaultTarget));
+
+  const largeTarget = path.join(dir, 'large.txt');
+  const largeLine = `${'x'.repeat(127)}\n`;
+  await fs.writeFile(largeTarget, largeLine.repeat(90000));
+  await assertReadAwaitsStreamClose('large estimated-position readFile', () =>
+    readFile(largeTarget, { offset: 2000, length: 5 }),
+  );
+
+  const multiA = path.join(dir, 'multi-a.txt');
+  const multiB = path.join(dir, 'multi-b.txt');
+  await Promise.all([
+    fs.writeFile(multiA, 'a\n'.repeat(2000)),
+    fs.writeFile(multiB, 'b\n'.repeat(2000)),
+  ]);
+  await assertReadAwaitsStreamClose('readMultipleFiles', () =>
+    readMultipleFiles([multiA, multiB]),
+  );
+
+  console.log('read paths await ReadStream closure before resolving');
+} finally {
+  await fs.rm(dir, { recursive: true, force: true });
+}

--- a/test/test-read-file-stream-release.js
+++ b/test/test-read-file-stream-release.js
@@ -1,4 +1,4 @@
-﻿import assert from 'node:assert/strict';
+import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';

--- a/test/test-read-file-stream-release.js
+++ b/test/test-read-file-stream-release.js
@@ -1,0 +1,22 @@
+﻿import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { readFile } from '../dist/tools/filesystem.js';
+
+const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'desktop-commander-read-release-'));
+const target = path.join(dir, 'target.txt');
+const replacement = path.join(dir, 'replacement.txt');
+
+try {
+  await fs.writeFile(target, 'one\ntwo\nthree\nfour\nfive\n');
+  await readFile(target, { offset: 0, length: 5 });
+  await fs.writeFile(replacement, 'replacement\n');
+
+  await fs.rename(replacement, target);
+
+  assert.equal(await fs.readFile(target, 'utf8'), 'replacement\n');
+  console.log('read_file releases its stream before returning');
+} finally {
+  await fs.rm(dir, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

Close text `ReadStream`s deterministically when pagination exits a `readline` loop early.

This fixes the Windows handle leak described in #631, where a successful `read_file` can leave the target open and block atomic replace/rename with `EPERM` / access denied.

## Fix

- retain the stream used by `readFromStartWithReadline`
- for each early-exit stream, subscribe to `close`, call `destroy()`, and await descriptor release before returning
- apply the same close ordering to the sampling and result streams in `readFromEstimatedPosition`
- leave the fully drained `readFromEndWithReadline` path unchanged

No pagination/output API changes are intended.

## Regression tests

The PR now covers both the original Windows symptom and the async close-order race:

1. small explicit-budget read followed immediately by atomic replacement
2. >10 MiB deep-offset estimated-position read followed immediately by replacement
3. deterministic close-order test that delays `ReadStream._destroy` by 75 ms and proves the public read promise cannot resolve while any stream close is pending
4. public default-budget `readFile(path)` coverage
5. public `readMultipleFiles([a, b])` coverage

Before the close-order fix, the deterministic regression fails on the default-budget public path with:

```text
AssertionError: default-budget readFile returned before its ReadStream close completed
1 !== 0
```

After the fix, all covered read paths wait for `close` before resolving.

## Verification

Fresh Windows verification at `8f3e403`:

- `npm run build` — passed
- `node test/test-read-file-stream-close-order.js` — passed
- `node test/test-read-file-stream-release.js` — passed
- `node test/test-read-file-large-stream-release.js` — passed
- `node test/test-file-handlers.js` — passed
- `node test/test-read-abort-timeout.js` — 4/4 passed
- `git diff --cached --check` before commit — passed

An older repro script, `test/repro/test-read-abort-frees-thread.js`, is not Windows-portable because its fixture shells out to `dd ... 2>/dev/null`; it fails before application code executes and is intentionally not changed here.

I did not run the entire broad test matrix locally; focused file-reader coverage, build, and repository CI/review are used for the remaining configured checks.

Closes #631