### PR TITLE
Fix codespell tasklist false positive

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -3,4 +3,4 @@
 skip = .git*,*.svg,package-lock.json,*.css,.codespellrc
 check-hidden = true
 # ignore-regex = 
-# ignore-words-list =
+ignore-words-list = fo

--- a/src/tools/process.ts
+++ b/src/tools/process.ts
@@ -7,7 +7,7 @@ import { KillProcessArgsSchema } from './schemas.js';
 const execAsync = promisify(exec);
 
 /**
- * Parse `tasklist /fo csv /nh` output (#662). Fields per row, all quoted:
+ * Parse `tasklist /FO CSV /NH` output (#662). Fields per row, all quoted:
  * [Image Name, PID, Session Name, Session#, Mem Usage]. CSV instead of the
  * default table: image names can contain spaces and Mem Usage contains
  * thousands separators, so positional whitespace splitting can't work.
@@ -51,7 +51,7 @@ export function parsePsAux(stdout: string): ProcessInfo[] {
 
 export async function listProcesses(): Promise<ServerResult> {
   const isWindows = os.platform() === 'win32';
-  const command = isWindows ? 'tasklist /fo csv /nh' : 'ps aux';
+  const command = isWindows ? 'tasklist /FO CSV /NH' : 'ps aux';
   try {
     const { stdout } = await execAsync(command);
     const processes = isWindows ? parseWindowsTasklistCsv(stdout) : parsePsAux(stdout);

--- a/test/test-list-processes.js
+++ b/test/test-list-processes.js
@@ -14,7 +14,7 @@ async function test(name, fn) {
   catch (e) { failures++; console.log(`🔴 FAIL  ${name}\n   ${e.message}`); }
 }
 
-// CRLF line endings and quoted CSV, exactly as tasklist /fo csv /nh emits.
+// CRLF line endings and quoted CSV, exactly as tasklist /FO CSV /NH emits.
 const TASKLIST_CSV = [
   '"System Idle Process","0","Services","0","8 K"',
   '"System","4","Services","0","21,436 K"',
@@ -55,7 +55,7 @@ await test('tasklist CSV: session name/number never leak into cpu/memory', () =>
 
 await test('tasklist table output (the old command) yields no NaN garbage rows', () => {
   // Regression guard for the header/separator symptom from #662: even if fed
-  // the wrong format, the parser must drop unparseable rows, not emit NaN.
+  // the wrong format, the parser must drop unparsable rows, not emit NaN.
   const legacyTable = 'Image Name  PID Session Name  Session#  Mem Usage\r\n=========== === ============ ========= =========\r\nSystem   4 Services 0 21,436 K\r\n';
   const rows = parseWindowsTasklistCsv(legacyTable);
   assert.ok(rows.every(r => !Number.isNaN(r.pid)));


### PR DESCRIPTION
## Summary
- whitelist `fo` in codespell because it is the Windows `tasklist /FO` switch
- use conventional uppercase `/FO CSV /NH` spelling in code/comments
- fix `unparseable` -> `unparsable`

## Validation
- tracked-file codespell passes locally
- `node test/test-list-processes.js` passes

This is intentionally split out from #679.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Windows process-listing command references to use consistent uppercase flags.
  - Corrected wording in a process-listing test comment.

- **Chores**
  - Added a project-specific term to the spell-check ignore list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->