### PR TITLE
fix(remote): reauthorize after revoked persisted device

### DIFF
--- a/src/npm-scripts/remote.ts
+++ b/src/npm-scripts/remote.ts
@@ -1,7 +1,34 @@
-import { MCPDevice } from '../remote-device/device.js';
+import { MCPDevice, getRemoteDeviceConfigPath } from '../remote-device/device.js';
+import fs from 'fs/promises';
 import os from 'os';
 
 export async function runRemote() {
+    if (process.argv.includes('--help') || process.argv.includes('-h')) {
+        console.log(`Desktop Commander Remote MCP device
+
+Usage:
+  desktop-commander remote [options]
+
+Options:
+  --logout              Remove saved local Remote MCP credentials and exit
+  --no-persist-session  Do not reuse or save authentication for this run
+  --disable-no-sleep    Do not prevent sleep while the remote device is running
+  --debug                Enable verbose debug logging
+  -h, --help             Show this help`);
+        return;
+    }
+    if (process.argv.includes('--logout')) {
+        const configPath = getRemoteDeviceConfigPath();
+        try {
+            await fs.rm(configPath, { force: true });
+            console.log('🔓 Logged out locally. Saved Remote MCP device credentials were removed.');
+            console.log(`   ${configPath}`);
+        } catch (error: any) {
+            console.error('❌ Failed to remove saved Remote MCP credentials:', error.message);
+            process.exitCode = 1;
+        }
+        return;
+    }
     // --persist-session is kept as an accepted no-op so existing invocations
     // and docs keep working; --no-persist-session opts back out.
     const persistSession = !process.argv.includes('--no-persist-session');

--- a/src/remote-device/README.md
+++ b/src/remote-device/README.md
@@ -91,6 +91,13 @@ desktop-commander-device --no-persist-session
 
 > **Note**: The device ID and authentication tokens are persisted by default to `~/.desktop-commander-device/device.json` (mode 0600), so the device reconnects without re-authorization. Pass `--no-persist-session` to keep tokens in memory only — the device then requires a full browser re-authorization on every start, and each one leaves a live server-side session behind.
 
+**Log out locally and remove the saved device credentials:**
+```bash
+desktop-commander remote --logout
+```
+
+This removes `~/.desktop-commander-device/device.json` from the current machine. It does not revoke the device from the Remote MCP dashboard; use **Revoke** there if you also want to invalidate the remote device authorization.
+
 **If using local installation** from the project root directory:
 
 ```bash

--- a/src/remote-device/device.ts
+++ b/src/remote-device/device.ts
@@ -21,6 +21,12 @@ export interface MCPDeviceOptions {
  * (the device process, not the shared server).
  */
 const SEEN_CALL_IDS_MAX = 100;
+const PERSISTED_DEVICE_LOOKUP_ATTEMPTS = 3;
+const PERSISTED_DEVICE_LOOKUP_RETRY_MS = 250;
+
+export function getRemoteDeviceConfigPath() {
+    return path.join(os.homedir(), '.desktop-commander-device', 'device.json');
+}
 
 export class MCPDevice {
     private baseServerUrl: string;
@@ -38,7 +44,7 @@ export class MCPDevice {
         this.remoteChannel = new RemoteChannel();
         this.deviceId = undefined;
         this.isShuttingDown = false;
-        this.configPath = path.join(os.homedir(), '.desktop-commander-device', 'device.json');
+        this.configPath = getRemoteDeviceConfigPath();
         // Default ON. Off meant a full re-authorization on every start, and each
         // one mints a fresh GoTrue session that nothing ever revokes; the orphaned
         // refresh-token families get replayed, trip GoTrue's reuse detection, and
@@ -133,13 +139,14 @@ export class MCPDevice {
                     session = null;
                 } else {
                     console.log('   - ✅ Session restored');
+                    console.log('   - ℹ️  To log out locally: npx @wonderwhy-er/desktop-commander@latest remote --logout');
 
                     // Revoking a device removes its server-side mcp_devices row, but the
                     // local config can still hold a valid user session + the now-deleted
                     // device ID. Do not silently recreate the revoked device with that
                     // old session: revocation must require a fresh browser authorization.
                     if (this.deviceId) {
-                        const persistedDevice = await this.remoteChannel.findDevice(this.deviceId);
+                        const persistedDevice = await this.findPersistedDeviceWithRetry(this.deviceId);
                         if (!persistedDevice) {
                             console.log(`   - ⚠️ Persisted device ${this.deviceId} was revoked or removed`);
                             await this.clearPersistedConfig();
@@ -211,6 +218,22 @@ export class MCPDevice {
         }
     }
 
+
+
+    private async findPersistedDeviceWithRetry(deviceId: string) {
+        let lastError: any;
+        for (let attempt = 1; attempt <= PERSISTED_DEVICE_LOOKUP_ATTEMPTS; attempt++) {
+            try {
+                return await this.remoteChannel.findDevice(deviceId);
+            } catch (error: any) {
+                lastError = error;
+                if (attempt === PERSISTED_DEVICE_LOOKUP_ATTEMPTS) break;
+                console.warn(`   - ⚠️ Device lookup failed (${attempt}/${PERSISTED_DEVICE_LOOKUP_ATTEMPTS}); retrying...`);
+                await new Promise((resolve) => setTimeout(resolve, PERSISTED_DEVICE_LOOKUP_RETRY_MS * attempt));
+            }
+        }
+        throw lastError;
+    }
 
     async loadPersistedConfig() {
         try {

--- a/src/remote-device/device.ts
+++ b/src/remote-device/device.ts
@@ -133,6 +133,20 @@ export class MCPDevice {
                     session = null;
                 } else {
                     console.log('   - ✅ Session restored');
+
+                    // Revoking a device removes its server-side mcp_devices row, but the
+                    // local config can still hold a valid user session + the now-deleted
+                    // device ID. Do not silently recreate the revoked device with that
+                    // old session: revocation must require a fresh browser authorization.
+                    if (this.deviceId) {
+                        const persistedDevice = await this.remoteChannel.findDevice(this.deviceId);
+                        if (!persistedDevice) {
+                            console.log(`   - ⚠️ Persisted device ${this.deviceId} was revoked or removed`);
+                            await this.clearPersistedConfig();
+                            this.deviceId = undefined;
+                            session = null;
+                        }
+                    }
                 }
             }
 
@@ -234,6 +248,16 @@ export class MCPDevice {
             return null;
         } finally {
             // No need to ensure device ID here
+        }
+    }
+
+    async clearPersistedConfig() {
+        try {
+            await fs.rm(this.configPath, { force: true });
+            console.debug('[DEBUG] Cleared stale persisted config:', this.configPath);
+        } catch (error: any) {
+            console.warn('⚠️ Failed to clear stale config:', error.message);
+            await captureRemote('remote_device_config_clear_error', { error });
         }
     }
 


### PR DESCRIPTION
## What
- detect when a persisted device ID no longer exists after session restore
- clear the stale local device config
- require a fresh browser device authorization instead of failing startup

## Why
Revoking a Remote MCP device deletes its server-side device row, but the local client can still restore a valid persisted user session plus the deleted device ID. Startup then fails with `Device not found` and never offers reauthorization.

## Safety
A revoked device is not silently recreated from the old session. The stale device ID is cleared and the normal browser authorization flow must complete again.

## Validation
- `npm run build`
- `npm test` — 58/58 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--help`/`-h` usage information for the remote command.
  * Added `--logout` to remove saved device credentials from the current machine.

* **Bug Fixes**
  * Improved session restoration when a previously authorized device is no longer available.
  * Clears outdated local authorization data and requires re-authorization when necessary.
  * Added retries for transient device lookup failures.

* **Documentation**
  * Documented local logout and clarified dashboard-based device revocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->