### PR TITLE
fix(remote): persist rotated auth sessions

### DIFF
--- a/src/remote-device/device.ts
+++ b/src/remote-device/device.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { RemoteChannel } from './remote-channel.js';
+import { RemoteChannel, type AuthSession } from './remote-channel.js';
 import { DeviceAuthenticator } from './device-authenticator.js';
 import { DesktopCommanderIntegration } from './desktop-commander-integration.js';
 import { fileURLToPath } from 'url';
@@ -36,6 +36,9 @@ export class MCPDevice {
     private configPath: string;
     private persistSession: boolean;
     private desktop: DesktopCommanderIntegration;
+    private configWriteChain: Promise<void> = Promise.resolve();
+    private configWriteSequence = 0;
+    private sessionPersistenceEnabled = false;
     /** Call ids already handled by THIS process (insertion-ordered, bounded). */
     private seenCallIds: Set<string> = new Set();
 
@@ -58,6 +61,18 @@ export class MCPDevice {
         this.setupShutdownHandlers();
     }
 
+    private enableSessionPersistence(): void {
+        if (!this.persistSession || this.sessionPersistenceEnabled) return;
+        this.sessionPersistenceEnabled = true;
+        this.remoteChannel.onSessionRotated((session) => this.queuePersistedSession(session));
+    }
+
+    private disableSessionPersistence(): void {
+        if (!this.sessionPersistenceEnabled) return;
+        this.remoteChannel.onSessionRotated(null);
+        this.sessionPersistenceEnabled = false;
+    }
+
     private setupShutdownHandlers() {
         const handleShutdown = async (signal: string) => {
             if (this.isShuttingDown) {
@@ -69,11 +84,11 @@ export class MCPDevice {
 
             console.log(`\n${signal} received, initiating graceful shutdown...`);
 
-            // Force exit after 5 seconds if graceful shutdown hangs
+            // Force exit after 10 seconds if graceful shutdown hangs
             const forceExit = setTimeout(() => {
                 console.error('\n⚠️ Graceful shutdown timed out, forcing exit...');
                 process.exit(1);
-            }, 5000);
+            }, 10000);
 
             try {
                 await this.shutdown();
@@ -186,8 +201,14 @@ export class MCPDevice {
             }
 
 
-            // Force save the current session immediately to ensure it's persisted
+            // Save only after a restored device has passed the #684 revoked-device
+            // lookup. Then arm rotation persistence so an internal startup refresh
+            // cannot recreate a config we just cleared for a revoked device.
+            await this.removeStalePersistedConfigTemps().catch((error: any) => {
+                console.debug('[DEBUG] Stale config temp cleanup failed:', error?.message ?? error);
+            });
             await this.savePersistedConfig();
+            this.enableSessionPersistence();
 
             const deviceName = os.hostname();
 
@@ -274,9 +295,33 @@ export class MCPDevice {
         }
     }
 
+    private async removeStalePersistedConfigTemps(): Promise<void> {
+        const dir = path.dirname(this.configPath);
+        const prefix = `${path.basename(this.configPath)}.tmp-`;
+        let names: string[];
+        try {
+            names = await fs.readdir(dir);
+        } catch (error: any) {
+            if (error?.code === 'ENOENT') return;
+            throw error;
+        }
+        for (const name of names) {
+            if (!name.startsWith(prefix)) continue;
+            const pid = Number(name.slice(prefix.length).split('-')[0]);
+            let alive = pid === process.pid;
+            if (!alive && Number.isInteger(pid) && pid > 0) {
+                try { process.kill(pid, 0); alive = true; }
+                catch (error: any) { alive = error?.code === 'EPERM'; }
+            }
+            if (alive) continue;
+            await fs.rm(path.join(dir, name), { force: true }).catch(() => { });
+        }
+    }
+
     async clearPersistedConfig() {
         try {
             await fs.rm(this.configPath, { force: true });
+            await this.removeStalePersistedConfigTemps();
             console.debug('[DEBUG] Cleared stale persisted config:', this.configPath);
         } catch (error: any) {
             console.warn('⚠️ Failed to clear stale config:', error.message);
@@ -284,29 +329,140 @@ export class MCPDevice {
         }
     }
 
+    private async writePersistedConfigSnapshot(config: {
+        deviceId?: string;
+        session: { access_token: string; refresh_token: string } | null;
+    }): Promise<void> {
+        const configDir = path.dirname(this.configPath);
+        const tempPath = `${this.configPath}.tmp-${process.pid}-${++this.configWriteSequence}`;
+        console.debug('[DEBUG] Creating config directory:', configDir);
+        await fs.mkdir(configDir, { recursive: true, mode: 0o700 });
+        try {
+            await fs.writeFile(tempPath, JSON.stringify(config, null, 2), { mode: 0o600 });
+            const deadline = performance.now() + 2000;
+            let delayMs = 10;
+            while (true) {
+                try {
+                    await fs.rename(tempPath, this.configPath);
+                    break;
+                } catch (error: any) {
+                    const retryable = error?.code === 'EPERM' || error?.code === 'EACCES' || error?.code === 'EBUSY';
+                    const remaining = deadline - performance.now();
+                    if (!retryable || remaining <= 0) throw error;
+                    await new Promise((resolve) => setTimeout(resolve, Math.min(delayMs, remaining)));
+                    delayMs = Math.min(delayMs * 2, 100);
+                }
+            }
+            console.debug('[DEBUG] Config saved atomically to:', this.configPath);
+        } finally {
+            await fs.rm(tempPath, { force: true }).catch(() => { });
+        }
+    }
+
+    private enqueueConfigWrite(operation: () => Promise<void>): Promise<void> {
+        const write = this.configWriteChain.then(operation);
+        this.configWriteChain = write.catch(() => { });
+        return write;
+    }
+
+    private queuePersistedConfig(config: {
+        deviceId?: string;
+        session: { access_token: string; refresh_token: string } | null;
+    }): Promise<void> {
+        return this.enqueueConfigWrite(() => this.writePersistedConfigSnapshot(config));
+    }
+
+    private queuePersistedIdentityOnly(): Promise<void> {
+        if (!this.deviceId) return Promise.resolve();
+        return this.enqueueConfigWrite(async () => {
+            try {
+                const existing = JSON.parse(await fs.readFile(this.configPath, 'utf8'));
+                if (existing?.session?.access_token && existing?.session?.refresh_token) return;
+            } catch (error: any) {
+                if (error?.code !== 'ENOENT' && !(error instanceof SyntaxError)) throw error;
+            }
+            await this.writePersistedConfigSnapshot({ deviceId: this.deviceId, session: null });
+        });
+    }
+
+    private queuePersistedSession(session: AuthSession): Promise<void> {
+        if (!this.persistSession) return Promise.resolve();
+        if (!this.deviceId) {
+            console.warn('⚠️ Refusing to persist refreshed credentials without a device ID');
+            void captureRemote('remote_device_config_incomplete_session_skipped', {
+                hasDeviceId: false,
+                hasAccessToken: !!session.access_token,
+                hasRefreshToken: !!session.refresh_token,
+            }).catch(() => { });
+            return Promise.resolve();
+        }
+        if (!session.access_token || !session.refresh_token) {
+            console.warn('⚠️ Refusing to overwrite persisted credentials with an incomplete refreshed session');
+            void captureRemote('remote_device_config_incomplete_session_skipped', {
+                hasDeviceId: true,
+                hasAccessToken: !!session.access_token,
+                hasRefreshToken: !!session.refresh_token,
+            }).catch(() => { });
+            return Promise.resolve();
+        }
+        return this.queuePersistedConfig({
+            deviceId: this.deviceId,
+            session: {
+                access_token: session.access_token,
+                refresh_token: session.refresh_token,
+            },
+        });
+    }
+    private async flushPersistedConfigWrites(timeoutMs = 2500): Promise<boolean> {
+        const deadline = performance.now() + timeoutMs;
+        while (true) {
+            const observed = this.configWriteChain;
+            const remaining = deadline - performance.now();
+            if (remaining <= 0) {
+                console.warn('⚠️ Timed out while draining persisted-session writes');
+                return false;
+            }
+            let timer: NodeJS.Timeout | undefined;
+            const timedOut = await Promise.race([
+                observed.then(() => false),
+                new Promise<boolean>((resolve) => {
+                    timer = setTimeout(() => resolve(true), remaining);
+                }),
+            ]);
+            if (timer) clearTimeout(timer);
+            if (timedOut) {
+                console.warn('⚠️ Timed out while draining persisted-session writes');
+                return false;
+            }
+            if (observed === this.configWriteChain) return true;
+        }
+    }
     async savePersistedConfig() {
         try {
             console.debug('[DEBUG] Saving persisted config, persistSession:', this.persistSession);
             const currentSessionStore = await this.remoteChannel.getSession();
             const session = currentSessionStore.data.session;
-
-            const config = {
-                deviceId: this.deviceId,
-                // Only save session if --persist-session flag is set
-                session: (session && this.persistSession) ? {
-                    access_token: session.access_token,
-                    refresh_token: session.refresh_token
-                } : null
-            };
-            // Ensure the config directory exists
-            console.debug('[DEBUG] Creating config directory:', path.dirname(this.configPath));
-            await fs.mkdir(path.dirname(this.configPath), { recursive: true });
-            await fs.writeFile(this.configPath, JSON.stringify(config, null, 2), { mode: 0o600 });
-            console.debug('[DEBUG] Config saved to:', this.configPath);
+            if (!this.persistSession) {
+                await this.queuePersistedConfig({ deviceId: this.deviceId, session: null });
+                return;
+            }
+            if (!session?.access_token || !session.refresh_token) {
+                console.warn('⚠️ Refusing to overwrite persisted credentials with an incomplete current session');
+                void captureRemote('remote_device_config_incomplete_session_skipped', {
+                    hasDeviceId: !!this.deviceId,
+                    hasAccessToken: !!session?.access_token,
+                    hasRefreshToken: !!session?.refresh_token,
+                }).catch(() => { });
+                await this.queuePersistedIdentityOnly();
+                return;
+            }
+            await this.queuePersistedSession({
+                access_token: session.access_token,
+                refresh_token: session.refresh_token,
+            });
         } catch (error: any) {
-            console.error(' - ❌ Failed to save config:', error.message);
-            console.debug('[DEBUG] Config save error details:', error);
-            await captureRemote('remote_device_config_save_error', { error });
+            console.error(' - ❌ Failed to persist current session:', error.message);
+            void captureRemote('remote_device_config_save_error', { error }).catch(() => { });
         }
     }
 
@@ -467,11 +623,32 @@ export class MCPDevice {
         console.debug('[DEBUG] Shutdown initiated for device:', this.deviceId);
 
         try {
-            // Stop heartbeat first to prevent new operations
+            // Stop future heartbeat/token-refresh ticks first. Keep the persistence
+            // observer armed while a refresh already in flight is given a bounded
+            // chance to finish and enqueue its rotated token snapshot.
             console.log('  → Stopping heartbeat...');
             console.debug('[DEBUG] Calling stopHeartbeat()');
             this.remoteChannel.stopHeartbeat();
             console.log('  ✓ Heartbeat stopped');
+
+            console.log('  → Waiting for in-flight token refresh...');
+            const refreshSettled = await this.remoteChannel.waitForTokenRefresh(1500);
+            console.log(refreshSettled
+                ? '  ✓ No token refresh pending at shutdown'
+                : '  ⚠️ Token refresh still in flight after shutdown bound');
+            if (!refreshSettled) {
+                void captureRemote('remote_device_token_refresh_shutdown_timeout', {}).catch(() => { });
+            }
+
+            console.log('  → Flushing persisted session...');
+            const persistedDrained = await this.flushPersistedConfigWrites();
+            this.disableSessionPersistence();
+            console.log(persistedDrained
+                ? '  ✓ Persisted-session writes drained'
+                : '  ⚠️ Persisted-session writes did not drain in time');
+            if (!persistedDrained) {
+                void captureRemote('remote_device_config_drain_timeout', {}).catch(() => { });
+            }
 
             // Unsubscribe from channel
             console.log('  → Unsubscribing from channel...');

--- a/src/remote-device/remote-channel.ts
+++ b/src/remote-device/remote-channel.ts
@@ -71,7 +71,7 @@ const TRANSPORT_WITHDRAW_AFTER_ATTEMPTS = 3;
 // Cap on the withdrawal write; it runs in a catch block RECREATE_TIMEOUT_MS
 // does not cover.
 const CAPABILITY_WRITE_TIMEOUT_MS = 5000;
-// Cap on the shutdown session fetch, which races device.ts's 5s force-exit.
+// Cap on the shutdown session fetch, which races device.ts's 10s force-exit.
 const OFFLINE_SESSION_TIMEOUT_MS = 500;
 // realtime-js parks in 'disconnecting' for ~100ms after a disconnect and
 // connect() early-returns for that whole window (see waitForSocketSettled).
@@ -136,6 +136,9 @@ export class RemoteChannel {
     private statusWriteChain: Promise<void> = Promise.resolve();
     /** Tokens from the last setSession / TOKEN_REFRESHED, for setOffline(). */
     private lastKnownSession: { access_token: string; refresh_token: string | null } | null = null;
+    /** Optional device-owned persistence observer. It receives the exact rotated
+     * token snapshot but is never awaited by auth-js's callback. */
+    private sessionRotatedObserver: ((session: AuthSession) => void | Promise<void>) | null = null;
     /** Set by unsubscribe(): suppresses status/heartbeat writes so they can't
      * land after setOffline()'s durable write. */
     private shuttingDown = false;
@@ -177,6 +180,9 @@ export class RemoteChannel {
     private heartbeatListenerRegistered = false;
     /** Our own fixed-cadence auth refresh timer — see TOKEN_REFRESH_INTERVAL_MS. */
     private tokenRefreshInterval: NodeJS.Timeout | null = null;
+    /** Manual refresh currently executing. Tracked so graceful shutdown can wait
+     * for a rotation that already reached the server before the timer was stopped. */
+    private tokenRefreshInFlight: Promise<void> | null = null;
 
     private _user: User | null = null;
     get user(): User | null { return this._user; }
@@ -214,6 +220,29 @@ export class RemoteChannel {
                     if (status === 'ok') this.lastHeartbeatOkAt = performance.now();
                 });
             } catch { /* no onHeartbeat on this client version: staleness check stays inert */ }
+        }
+    }
+
+    onSessionRotated(observer: ((session: AuthSession) => void | Promise<void>) | null): void {
+        this.sessionRotatedObserver = observer;
+    }
+
+    private notifySessionRotated(session: AuthSession): void {
+        const observer = this.sessionRotatedObserver;
+        if (!observer) return;
+        const snapshot: AuthSession = {
+            access_token: session.access_token,
+            refresh_token: session.refresh_token ?? null,
+        };
+        try {
+            const result = observer(snapshot);
+            void Promise.resolve(result).catch((error) => {
+                console.debug('[DEBUG] Session-rotated observer rejected:', error?.message ?? error);
+                captureRemote('remote_channel_session_rotated_observer_error', { error }).catch(() => { });
+            });
+        } catch (error: any) {
+            console.debug('[DEBUG] Session-rotated observer threw:', error?.message ?? error);
+            captureRemote('remote_channel_session_rotated_observer_error', { error }).catch(() => { });
         }
     }
 
@@ -266,10 +295,16 @@ export class RemoteChannel {
                 if (event === 'TOKEN_REFRESHED' && newSession?.access_token && this.client) {
                     console.debug('[DEBUG] Token refreshed — re-authorizing realtime socket');
                     this.client.realtime.setAuth(newSession.access_token);
-                    this.lastKnownSession = {
+                    const freshRefreshToken = newSession.refresh_token ?? null;
+                    const rotatedSession: AuthSession = {
                         access_token: newSession.access_token,
-                        refresh_token: newSession.refresh_token ?? this.lastKnownSession?.refresh_token ?? null,
+                        refresh_token: freshRefreshToken ?? this.lastKnownSession?.refresh_token ?? null,
                     };
+                    this.lastKnownSession = rotatedSession;
+                    // Persist only a refresh token delivered by THIS refresh event.
+                    // Falling back to the previous token is useful in-memory for
+                    // setOffline(), but that previous token may already be consumed.
+                    if (freshRefreshToken) this.notifySessionRotated(rotatedSession);
                 } else if (event === 'SIGNED_OUT') {
                     void this.handleSignedOut();
                 }
@@ -1163,20 +1198,29 @@ export class RemoteChannel {
         console.debug(`[DEBUG] Heartbeat started - connectionCheck: 10s, last_seen: ${this.heartbeatIntervalMs()}ms, tokenRefresh: ${TOKEN_REFRESH_INTERVAL_MS}ms`);
     }
 
-    private async refreshTokenNow(): Promise<void> {
-        if (!this.client || this.shuttingDown) return;
-        try {
-            const { error } = await this.client.auth.refreshSession();
-            if (error) {
-                console.error('[DEBUG] Manual token refresh failed:', error.message);
-                await captureRemote('remote_channel_token_refresh_error', { error });
-            } else {
-                console.debug('[DEBUG] Manual token refresh ok');
+    private refreshTokenNow(): Promise<void> {
+        if (!this.client || this.shuttingDown) return Promise.resolve();
+        if (this.tokenRefreshInFlight) return this.tokenRefreshInFlight;
+        const run = (async () => {
+            try {
+                const { error } = await this.client!.auth.refreshSession();
+                if (error) {
+                    console.error('[DEBUG] Manual token refresh failed:', error.message);
+                    await captureRemote('remote_channel_token_refresh_error', { error }).catch(() => { });
+                } else {
+                    console.debug('[DEBUG] Manual token refresh ok');
+                }
+            } catch (error: any) {
+                console.error('[DEBUG] Manual token refresh threw:', error?.message);
+                await captureRemote('remote_channel_token_refresh_error', { error }).catch(() => { });
             }
-        } catch (error: any) {
-            console.error('[DEBUG] Manual token refresh threw:', error?.message);
-            await captureRemote('remote_channel_token_refresh_error', { error });
-        }
+        })();
+        this.tokenRefreshInFlight = run;
+        const clearInFlight = () => {
+            if (this.tokenRefreshInFlight === run) this.tokenRefreshInFlight = null;
+        };
+        void run.then(clearInFlight, clearInFlight);
+        return run;
     }
 
     private startTokenRefresh(): void {
@@ -1190,6 +1234,23 @@ export class RemoteChannel {
         if (this.tokenRefreshInterval) {
             clearInterval(this.tokenRefreshInterval);
             this.tokenRefreshInterval = null;
+        }
+    }
+
+    async waitForTokenRefresh(timeoutMs = 1500): Promise<boolean> {
+        const inFlight = this.tokenRefreshInFlight;
+        if (!inFlight) return true;
+        let timer: NodeJS.Timeout | undefined;
+        try {
+            const timedOut = await Promise.race([
+                inFlight.then(() => false, () => false),
+                new Promise<boolean>((resolve) => {
+                    timer = setTimeout(() => resolve(true), timeoutMs);
+                }),
+            ]);
+            return !timedOut;
+        } finally {
+            if (timer) clearTimeout(timer);
         }
     }
 
@@ -1262,7 +1323,7 @@ export class RemoteChannel {
             // getSession() is not a cheap read: it takes a lock (10s acquire
             // timeout) and refreshes when the token is within ~90s of expiry,
             // POSTing /token with its own ~30s retry budget. On a just-woken
-            // machine that outlasts device.ts's 5s force-exit, and then spawnSync
+            // machine that outlasts device.ts's 10s force-exit, and then spawnSync
             // never runs and the offline write is lost. The subprocess calls
             // setSession() itself, so a slightly stale access_token is fine.
             const live = await Promise.race([
@@ -1354,7 +1415,7 @@ export class RemoteChannel {
         // SIGINT during recreateChannel()'s backoff, where the later join's
         // SUBSCRIBED would queue 'online' after the durable write.
         this.shuttingDown = true;
-        // Budget against device.ts's 5s force-exit, worst case:
+        // Budget against device.ts's 10s force-exit, worst case:
         //   250 drain + 2x300 leave + 500 session + 3000 spawnSync = 4350ms.
         // In practice only the untrack bound binds — removeChannel/unsubscribe
         // set state='leaving' first, so their leave push resolves inline.

--- a/test/test-remote-session-persistence.js
+++ b/test/test-remote-session-persistence.js
@@ -1,0 +1,515 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { MCPDevice } from '../dist/remote-device/device.js';
+import { RemoteChannel } from '../dist/remote-device/remote-channel.js';
+
+process.env.DESKTOP_COMMANDER_DISABLE_TELEMETRY = '1';
+
+class FakeAuth {
+  listeners = [];
+  getSessionCalls = 0;
+  session = { access_token: 'access-0', refresh_token: 'refresh-0' };
+
+  onAuthStateChange(callback) {
+    this.listeners.push(callback);
+    return { data: { subscription: { unsubscribe() {} } } };
+  }
+
+  async setSession(session) {
+    this.session = {
+      access_token: session.access_token,
+      refresh_token: session.refresh_token,
+    };
+    return { data: { session: this.session }, error: null };
+  }
+
+  async getUser() {
+    return { data: { user: { id: 'user-1', email: 'test@example.com' } }, error: null };
+  }
+
+  async getSession() {
+    this.getSessionCalls++;
+    return { data: { session: this.session }, error: null };
+  }
+
+  emit(event, session) {
+    for (const callback of this.listeners) callback(event, session);
+  }
+}
+
+class FakeRealtime {
+  setAuthCalls = [];
+
+  setAuth(token) {
+    this.setAuthCalls.push(token);
+  }
+}
+
+class FakeClient {
+  auth = new FakeAuth();
+  realtime = new FakeRealtime();
+}
+
+function makeDevice(configPath, persistSession = true) {
+  const device = Object.create(MCPDevice.prototype);
+  device.configPath = configPath;
+  device.deviceId = 'device-1';
+  device.persistSession = persistSession;
+  device.configWriteChain = Promise.resolve();
+  device.configWriteSequence = 0;
+  device.sessionPersistenceEnabled = false;
+  return device;
+}
+
+async function readConfig(configPath) {
+  return JSON.parse(await fs.readFile(configPath, 'utf8'));
+}
+
+async function withTempDir(prefix, fn) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  try {
+    return await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+function largeToken(prefix, index) {
+  return `${prefix}-${index}-` + 'x'.repeat(32 * 1024);
+}
+
+async function testRemoteChannelObserverUsesExactRotatedSnapshot() {
+  const channel = new RemoteChannel();
+  const client = new FakeClient();
+  channel.client = client;
+  const seen = [];
+  channel.onSessionRotated((session) => seen.push({ ...session }));
+
+  await channel.setSession({ access_token: 'access-0', refresh_token: 'refresh-0' });
+  const getSessionCallsBeforeRefresh = client.auth.getSessionCalls;
+  const rotated = { access_token: 'access-1', refresh_token: 'refresh-1' };
+  client.auth.session = rotated;
+  client.auth.emit('TOKEN_REFRESHED', rotated);
+
+  assert.deepEqual(seen, [rotated]);
+  assert.equal(client.auth.getSessionCalls, getSessionCallsBeforeRefresh,
+    'rotation observer must not re-enter auth state to recover the session');
+  assert.equal(client.realtime.setAuthCalls.at(-1), 'access-1');
+}
+
+async function testRefreshWithoutFreshRefreshTokenDoesNotPersistFallback() {
+  const channel = new RemoteChannel();
+  const client = new FakeClient();
+  channel.client = client;
+  const seen = [];
+  channel.onSessionRotated((session) => seen.push(session));
+
+  await channel.setSession({ access_token: 'access-0', refresh_token: 'refresh-0' });
+  channel.lastKnownSession = { access_token: 'access-0', refresh_token: 'refresh-0' };
+  client.auth.emit('TOKEN_REFRESHED', { access_token: 'access-only' });
+
+  assert.deepEqual(seen, []);
+  assert.equal(client.realtime.setAuthCalls.at(-1), 'access-only',
+    'realtime JWT should still update even when persistence cannot safely rotate');
+  assert.equal(channel.lastKnownSession.refresh_token, 'refresh-0',
+    'the previous refresh token may remain an in-memory fallback but must not be persisted');
+}
+
+async function testRemoteChannelTracksAndWaitsForInFlightRefresh() {
+  const channel = new RemoteChannel();
+  const client = new FakeClient();
+  channel.client = client;
+  let releaseRefresh;
+  let markStarted;
+  const started = new Promise((resolve) => { markStarted = resolve; });
+  const gate = new Promise((resolve) => { releaseRefresh = resolve; });
+  client.auth.refreshSession = async () => {
+    markStarted();
+    await gate;
+    return { data: { session: client.auth.session }, error: null };
+  };
+
+  const refresh = channel.refreshTokenNow();
+  await started;
+  assert.equal(await channel.waitForTokenRefresh(20), false,
+    'bounded wait must report a refresh that is still in flight');
+  releaseRefresh();
+  assert.equal(await channel.waitForTokenRefresh(200), true,
+    'bounded wait must observe the tracked refresh settling');
+  await refresh;
+}
+
+async function testRefreshFailureClearsInFlightTrackerAndAllowsRetry() {
+  const channel = new RemoteChannel();
+  const client = new FakeClient();
+  channel.client = client;
+  let calls = 0;
+  client.auth.refreshSession = async () => {
+    calls++;
+    if (calls === 1) throw new Error('synthetic refresh failure');
+    return { data: { session: client.auth.session }, error: null };
+  };
+
+  await channel.refreshTokenNow();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(channel.tokenRefreshInFlight, null,
+    'a failed refresh must clear the in-flight tracker');
+
+  await channel.refreshTokenNow();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(calls, 2, 'a cleared tracker must allow the next refresh to run');
+  assert.equal(channel.tokenRefreshInFlight, null);
+}
+
+async function testInFlightRefreshPersistsBeforeShutdownDisarmsObserver() {
+  await withTempDir('dc-session-shutdown-refresh-', async (dir) => {
+    const configPath = path.join(dir, 'device.json');
+    const channel = new RemoteChannel();
+    const client = new FakeClient();
+    channel.client = client;
+    await channel.setSession({ access_token: 'initial-a', refresh_token: 'initial-r' });
+
+    const device = makeDevice(configPath, true);
+    device.remoteChannel = channel;
+    device.isShuttingDown = false;
+    device.desktop = { async shutdown() {} };
+    channel.unsubscribe = async () => {};
+    channel.setOffline = async () => {};
+    device.enableSessionPersistence();
+
+    let releaseRefresh;
+    let markStarted;
+    const started = new Promise((resolve) => { markStarted = resolve; });
+    const gate = new Promise((resolve) => { releaseRefresh = resolve; });
+    client.auth.refreshSession = async () => {
+      markStarted();
+      await gate;
+      const rotated = { access_token: 'rotated-a', refresh_token: 'rotated-r' };
+      client.auth.session = rotated;
+      client.auth.emit('TOKEN_REFRESHED', rotated);
+      return { data: { session: rotated }, error: null };
+    };
+
+    const refresh = channel.refreshTokenNow();
+    await started;
+    setTimeout(() => releaseRefresh(), 30);
+    await device.shutdown();
+    await refresh;
+
+    const config = await readConfig(configPath);
+    assert.equal(config.deviceId, 'device-1');
+    assert.equal(config.session.access_token, 'rotated-a');
+    assert.equal(config.session.refresh_token, 'rotated-r');
+    assert.equal(device.sessionPersistenceEnabled, false,
+      'persistence observer must be disarmed after the rotated snapshot is drained');
+  });
+}
+
+async function testDeviceObserverPersistsLatestRotationAtomically() {
+  await withTempDir('dc-session-persist-', async (dir) => {
+    const configPath = path.join(dir, 'device.json');
+    const device = makeDevice(configPath, true);
+    let observer = null;
+    device.remoteChannel = { onSessionRotated(fn) { observer = fn; } };
+    device.enableSessionPersistence();
+    assert.equal(typeof observer, 'function');
+
+    await device.queuePersistedSession({
+      access_token: largeToken('seed-access', 0),
+      refresh_token: largeToken('seed-refresh', 0),
+    });
+
+    let stopReader = false;
+    const readFailures = [];
+    const reader = (async () => {
+      while (!stopReader) {
+        try {
+          const parsed = await readConfig(configPath);
+          assert.equal(parsed.deviceId, 'device-1');
+          assert.equal(typeof parsed.session?.access_token, 'string');
+          assert.equal(typeof parsed.session?.refresh_token, 'string');
+        } catch (error) {
+          readFailures.push(error);
+          break;
+        }
+        await new Promise((resolve) => setImmediate(resolve));
+      }
+    })();
+
+    const writes = [];
+    for (let i = 0; i < 100; i++) {
+      writes.push(observer({
+        access_token: largeToken('access', i),
+        refresh_token: largeToken('refresh', i),
+      }));
+    }
+    await Promise.all(writes);
+    stopReader = true;
+    await reader;
+
+    assert.deepEqual(readFailures, [], 'concurrent readers must never observe invalid JSON');
+    const config = await readConfig(configPath);
+    assert.equal(config.session.access_token, largeToken('access', 99));
+    assert.equal(config.session.refresh_token, largeToken('refresh', 99));
+    const leftovers = (await fs.readdir(dir)).filter((name) => name.includes('.tmp-'));
+    assert.deepEqual(leftovers, [], 'successful writes must not leave token-bearing temp files');
+  });
+}
+
+async function testIncompleteRotationCannotOverwriteValidCredentials() {
+  await withTempDir('dc-session-incomplete-', async (dir) => {
+    const configPath = path.join(dir, 'device.json');
+    const device = makeDevice(configPath, true);
+    await device.queuePersistedSession({
+      access_token: 'good-access',
+      refresh_token: 'good-refresh',
+    });
+    const before = await fs.readFile(configPath, 'utf8');
+
+    await device.queuePersistedSession({ access_token: 'new-access', refresh_token: null });
+    await device.configWriteChain;
+
+    const after = await fs.readFile(configPath, 'utf8');
+    assert.equal(after, before,
+      'missing refresh token must preserve the last complete persisted session');
+  });
+}
+
+async function testMissingDeviceIdCannotPersistCompleteSession() {
+  await withTempDir('dc-session-no-id-', async (dir) => {
+    const configPath = path.join(dir, 'device.json');
+    const device = makeDevice(configPath, true);
+    device.deviceId = undefined;
+
+    await device.queuePersistedSession({
+      access_token: 'access',
+      refresh_token: 'refresh',
+    });
+    await device.configWriteChain;
+
+    await assert.rejects(fs.access(configPath),
+      'complete tokens without a device id must not be persisted');
+  });
+}
+async function testCurrentSessionMissingPreservesExistingCredentials() {
+  await withTempDir('dc-session-current-', async (dir) => {
+    const configPath = path.join(dir, 'device.json');
+    const device = makeDevice(configPath, true);
+    await device.queuePersistedSession({
+      access_token: 'good-access',
+      refresh_token: 'good-refresh',
+    });
+    const before = await fs.readFile(configPath, 'utf8');
+    device.remoteChannel = {
+      async getSession() { return { data: { session: null }, error: null }; },
+    };
+
+    await device.savePersistedConfig();
+    const after = await fs.readFile(configPath, 'utf8');
+    assert.equal(after, before,
+      'missing current session must not erase valid persisted credentials');
+  });
+}
+
+async function testIncompleteFirstSessionStillPersistsDeviceIdentity() {
+  await withTempDir('dc-session-identity-', async (dir) => {
+    const configPath = path.join(dir, 'device.json');
+    const device = makeDevice(configPath, true);
+    device.remoteChannel = {
+      async getSession() {
+        return { data: { session: { access_token: 'access-only', refresh_token: null } } };
+      },
+    };
+
+    await device.savePersistedConfig();
+    const config = await readConfig(configPath);
+    assert.equal(config.deviceId, 'device-1');
+    assert.equal(config.session, null,
+      'an incomplete first session must not persist unusable credentials');
+  });
+}
+
+async function testPersistenceOptOutSavesIdentityOnlyAndIgnoresRotations() {
+  await withTempDir('dc-session-optout-', async (dir) => {
+    const configPath = path.join(dir, 'device.json');
+    const device = makeDevice(configPath, false);
+    let observer = 'unset';
+    device.remoteChannel = {
+      onSessionRotated(fn) { observer = fn; },
+      async getSession() {
+        return { data: { session: { access_token: 'access', refresh_token: 'refresh' } } };
+      },
+    };
+
+    device.enableSessionPersistence();
+    assert.equal(observer, 'unset');
+    await device.savePersistedConfig();
+    const config = await readConfig(configPath);
+    assert.equal(config.deviceId, 'device-1');
+    assert.equal(config.session, null);
+
+    await device.queuePersistedSession({ access_token: 'new-access', refresh_token: 'new-refresh' });
+    const after = await readConfig(configPath);
+    assert.equal(after.session, null, 'opt-out must ignore token rotations');
+  });
+}
+
+async function testQueuedWriteFailureIsObservable() {
+  const device = makeDevice('unused', true);
+  const synthetic = Object.assign(new Error('synthetic EPERM'), { code: 'EPERM' });
+  device.writePersistedConfigSnapshot = async () => { throw synthetic; };
+
+  await assert.rejects(
+    device.queuePersistedConfig({
+      deviceId: 'device-1',
+      session: { access_token: 'access', refresh_token: 'refresh' },
+    }),
+    /synthetic EPERM/,
+  );
+  await device.configWriteChain;
+}
+
+async function testStartupValidatesRestoredDeviceBeforeArmingPersistence() {
+  const events = [];
+  const device = makeDevice('unused', true);
+  device.baseServerUrl = 'https://example.invalid';
+  device.deviceId = 'device-1';
+  device.desktop = {
+    async initialize() { events.push('desktop-init'); },
+    onDisconnect() {},
+    async listClientTools() { return []; },
+  };
+  device.remoteChannel = {
+    user: { email: 'test@example.com' },
+    initialize() { events.push('channel-init'); },
+    async setSession() { events.push('set-session'); return { error: null }; },
+    async registerDevice() { events.push('register'); },
+    startHeartbeat() { events.push('heartbeat'); },
+  };
+  device.fetchSupabaseConfig = async () => ({ supabaseUrl: 'u', anonKey: 'k' });
+  device.loadPersistedConfig = async () => {
+    events.push('load');
+    return { access_token: 'access', refresh_token: 'refresh' };
+  };
+  device.findPersistedDeviceWithRetry = async () => {
+    events.push('validate-restored-device');
+    return { id: 'device-1' };
+  };
+  device.removeStalePersistedConfigTemps = async () => { events.push('cleanup-temps'); };
+  device.savePersistedConfig = async () => { events.push('save'); };
+  device.enableSessionPersistence = () => { events.push('arm'); };
+
+  await device.start();
+
+  assert.ok(events.indexOf('validate-restored-device') >= 0);
+  assert.ok(events.indexOf('cleanup-temps') > events.indexOf('validate-restored-device'),
+    'stale token temp cleanup must happen only after restored-device validation');
+  assert.ok(events.indexOf('save') > events.indexOf('cleanup-temps'),
+    'validated startup temp cleanup must finish before saving credentials');
+  assert.ok(events.indexOf('arm') > events.indexOf('save'),
+    'rotation persistence must arm only after the validated session is saved');
+}
+
+async function testShutdownWaitsRefreshThenDrainsBeforeDisarmingObserver() {
+  const events = [];
+  const device = makeDevice('unused', true);
+  device.isShuttingDown = false;
+  device.sessionPersistenceEnabled = true;
+  device.remoteChannel = {
+    onSessionRotated(fn) { events.push(fn === null ? 'disarm' : 'arm'); },
+    stopHeartbeat() { events.push('stop-heartbeat'); },
+    async waitForTokenRefresh() { events.push('wait-refresh'); return true; },
+    async unsubscribe() { events.push('unsubscribe'); },
+    async setOffline() { events.push('offline'); },
+  };
+  device.desktop = { async shutdown() { events.push('desktop-shutdown'); } };
+  device.flushPersistedConfigWrites = async () => { events.push('flush'); return true; };
+
+  await device.shutdown();
+
+  assert.ok(events.indexOf('stop-heartbeat') >= 0);
+  assert.ok(events.indexOf('wait-refresh') > events.indexOf('stop-heartbeat'),
+    'already-running refresh must be awaited only after future ticks are stopped');
+  assert.ok(events.indexOf('flush') > events.indexOf('wait-refresh'),
+    'persistence drain must include writes enqueued by the settled refresh');
+  assert.ok(events.indexOf('disarm') > events.indexOf('flush'),
+    'observer must remain armed until the in-flight refresh and its write are drained');
+}
+
+async function testStaleTempIsCleanedBeforePersistenceArms() {
+  await withTempDir('dc-session-temp-', async (dir) => {
+    const configPath = path.join(dir, 'device.json');
+    const stale = `${configPath}.tmp-2147483647`;
+    await fs.writeFile(stale, '{"refresh_token":"synthetic"}', 'utf8');
+    const device = makeDevice(configPath, true);
+
+    await device.removeStalePersistedConfigTemps();
+    await assert.rejects(fs.access(stale));
+  });
+}
+
+async function testShutdownDrainIsBounded() {
+  const device = makeDevice('unused', true);
+  device.configWriteChain = new Promise(() => {});
+  const start = performance.now();
+  const drained = await device.flushPersistedConfigWrites(30);
+  const elapsed = performance.now() - start;
+  assert.equal(drained, false, 'a timed-out drain must be observable by its caller');
+  assert.ok(elapsed >= 20 && elapsed < 1000,
+    `bounded drain should return near its timeout, got ${elapsed.toFixed(1)}ms`);
+}
+
+async function testDrainDeadlineIgnoresWallClockJump() {
+  const device = makeDevice('unused', true);
+  device.configWriteChain = new Promise(() => {});
+  const realDateNow = Date.now;
+  let calls = 0;
+  Date.now = () => realDateNow() + (calls++ === 0 ? 0 : 10 * 60 * 1000);
+  try {
+    const start = performance.now();
+    const drained = await device.flushPersistedConfigWrites(30);
+    const elapsed = performance.now() - start;
+    assert.equal(drained, false);
+    assert.ok(elapsed >= 20 && elapsed < 1000,
+      `wall-clock jump must not short-circuit monotonic drain deadline, got ${elapsed.toFixed(1)}ms`);
+  } finally {
+    Date.now = realDateNow;
+  }
+}
+
+const tests = [
+  testRemoteChannelObserverUsesExactRotatedSnapshot,
+  testRefreshWithoutFreshRefreshTokenDoesNotPersistFallback,
+  testRemoteChannelTracksAndWaitsForInFlightRefresh,
+  testRefreshFailureClearsInFlightTrackerAndAllowsRetry,
+  testInFlightRefreshPersistsBeforeShutdownDisarmsObserver,
+  testDeviceObserverPersistsLatestRotationAtomically,
+  testIncompleteRotationCannotOverwriteValidCredentials,
+  testMissingDeviceIdCannotPersistCompleteSession,
+  testCurrentSessionMissingPreservesExistingCredentials,
+  testIncompleteFirstSessionStillPersistsDeviceIdentity,
+  testPersistenceOptOutSavesIdentityOnlyAndIgnoresRotations,
+  testQueuedWriteFailureIsObservable,
+  testStartupValidatesRestoredDeviceBeforeArmingPersistence,
+  testShutdownWaitsRefreshThenDrainsBeforeDisarmingObserver,
+  testStaleTempIsCleanedBeforePersistenceArms,
+  testShutdownDrainIsBounded,
+  testDrainDeadlineIgnoresWallClockJump,
+];
+
+let failures = 0;
+for (const test of tests) {
+  try {
+    await test();
+    console.log(`PASS ${test.name}`);
+  } catch (error) {
+    failures++;
+    console.error(`FAIL ${test.name}`);
+    console.error(error);
+  }
+}
+
+if (failures) process.exit(1);
+console.log(`PASS ${tests.length}/${tests.length} remote session persistence tests`);


### PR DESCRIPTION
## Summary

Persist rotated Remote MCP auth sessions so a later device-process restart does not reload a refresh token that has already been consumed.

This addresses the persisted-session portion of #661. It does not claim to fix the separate `start_process` transport symptom discussed in that issue.

## What changes

- `RemoteChannel` exposes the exact fresh `TOKEN_REFRESHED` session snapshot to its device owner; events without a fresh refresh token are not persisted as a new rotation.
- `MCPDevice` serializes persisted-session writes within the device process, so older async writes cannot overtake newer rotations.
- Complete credentials are persisted only with a device ID; incomplete sessions cannot overwrite the last complete persisted credentials.
- If the first current session is incomplete, the device identity is still preserved without persisting unusable credentials.
- Config replacement uses a per-process temp file plus atomic rename, with bounded retry for transient Windows `EPERM` / `EACCES` / `EBUSY` failures.
- Persistence retry/drain deadlines use monotonic `performance.now()` so wall-clock correction cannot prematurely exhaust their budgets.
- Stale token-bearing temp files from dead processes are cleaned on successful startup.
- Graceful shutdown stops future refresh ticks, waits a bounded interval for a manual refresh already in flight, drains any rotated-session write it enqueued, and only then disarms rotation persistence.
- Manual refresh failure telemetry is explicitly best-effort, and in-flight tracker cleanup cannot create a detached rejected Promise.
- Timeout outcomes are explicit rather than being logged as successful drains.
- The graceful-shutdown force-exit guard remains 10 seconds, covering the bounded persistence phase plus the existing bounded Remote MCP offline teardown.
- The rotation observer is armed only after restored-device validation and the initial save, preserving the revoked-device behavior added in #684.

## Why

The running process already updates its realtime JWT and in-memory session when Supabase emits `TOKEN_REFRESHED`, but the rotated refresh token was not persisted back to `device.json`. A later process restart can therefore reload an older token and fail with `Invalid Refresh Token: Already Used`, forcing browser re-authorization.

A Windows 11 / Desktop Commander 0.2.48 reproduction observed two normal 45-minute rotations being persisted with this approach, followed by a real device-process restart that restored the session and reached `Device ready` without a device-authorization flow. That runtime evidence is already posted in #661.

## Validation

- `git diff --check`: PASS
- `npm run build`: PASS
- `test/test-remote-session-persistence.js`: PASS, **17/17**
  - 100 queued rotations while a concurrent reader repeatedly parses `device.json`
  - latest rotation wins; no invalid JSON or temp residue observed
  - missing device ID, incomplete sessions, opt-out behavior, startup ordering and bounded drain
  - a refresh already in flight at shutdown persists its rotated token before the observer is disarmed
  - wall-clock jumps do not short-circuit persistence deadlines
  - a thrown manual refresh clears the in-flight tracker and a later refresh can run normally
- `test-remote-channel-reconnect.js`: PASS
- `test-remote-channel-signed-out.js`: PASS
- `test-remote-transport.js`: PASS
- Windows destination-handle contention probe: PASS, including a synthetic +10 minute `Date.now()` jump while the retry is active
- Standalone patch applies cleanly with `git apply --check --whitespace=error` to exact `main` base `24337016fce3d2769866279a98d5f8c37dbfb0c9`.

### Wider Windows suite note

The same canonical set of 57 top-level test modules used for the previous revision was rerun from the expected `test/` working directory: **57/57 passed**.

Excluded from that matrix remain the same two pre-classified platform/baseline tests:
- `test-enhanced-repl.js`: explicitly Unix-specific (`command -v` and `/bin/bash`).
- `test-config-atomic-write.js`: existing Windows `EPERM` while renaming the unrelated ConfigManager file; reproduced repeatedly on an unmodified clean clone of the exact base commit.

## Scope

No OAuth/device-authorization policy is changed. No live-agent restart behavior is added. The write queue is process-local; this PR does not introduce a new cross-process locking contract. `--no-persist-session` still avoids persisting auth tokens, while preserving the device identity as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Session updates can now be securely persisted, including refreshed access and refresh credentials.
  - Session rotation notifications are supported for connected clients.

- **Bug Fixes**
  - Prevented incomplete or invalid session updates from overwriting valid credentials.
  - Improved recovery from interrupted writes by cleaning up stale temporary files.
  - Preserved identity information when complete session credentials are unavailable.

- **Reliability**
  - Improved startup validation and shutdown handling, including coordinated token refreshes and a longer window for pending changes to finish.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->