### PR TITLE
docs: add tested FLUJO client setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,19 @@ Or add to `.qwen/settings.json` (project) or `~/.qwen/settings.json` (global). S
 </details>
 
 <details>
+<summary><b>FLUJO</b></summary>
+
+In [FLUJO](https://flujo.com.co/), open **Connected Apps > Connect App > I'm an expert > Configure & Test**.
+
+1. With Node.js installed, prepare a directory for Desktop Commander and run `npm install @wonderwhy-er/desktop-commander@latest` there. Installing first avoids spending the connection test's timeout downloading dependencies.
+2. Set **Server name** to `desktop-commander` and **MCP server root path** to that directory.
+3. Select **Standard IO**, set **Run command** to `npx`, and use **Add argument** to enter `-y` and `@wonderwhy-er/desktop-commander@latest` as two separate arguments.
+4. Click **3) Test run**. After the MCP handshake passes, click **Add server**.
+5. Open the saved server's **Tools** tab, select `list_directory`, enter an absolute directory path and a depth of `1`, then click **Test tool** to verify access.
+
+</details>
+
+<details>
 <summary><b>ChatGPT / Claude Web (Remote MCP)</b></summary>
 
 Use Desktop Commander from **ChatGPT**, **Claude web**, and other AI services via Remote MCP — no desktop app required.

--- a/README.md
+++ b/README.md
@@ -472,11 +472,11 @@ Or add to `.qwen/settings.json` (project) or `~/.qwen/settings.json` (global). S
 
 In [FLUJO](https://flujo.com.co/), open **Connected Apps > Connect App > I'm an expert > Configure & Test**.
 
-1. With Node.js installed, prepare a directory for Desktop Commander and run `npm install @wonderwhy-er/desktop-commander@latest` there. Installing first avoids spending the connection test's timeout downloading dependencies.
+1. With Node.js 18 or newer installed, prepare a directory for Desktop Commander and run `npm install @wonderwhy-er/desktop-commander@latest` there. Installing first avoids spending the connection test's timeout downloading dependencies.
 2. Set **Server name** to `desktop-commander` and **MCP server root path** to that directory.
 3. Select **Standard IO**, set **Run command** to `npx`, and use **Add argument** to enter `-y` and `@wonderwhy-er/desktop-commander@latest` as two separate arguments.
 4. Click **3) Test run**. After the MCP handshake passes, click **Add server**.
-5. Open the saved server's **Tools** tab, select `list_directory`, enter an absolute directory path and a depth of `1`, then click **Test tool** to verify access.
+5. Open the saved server's **Tools** tab, select `list_directory`, enter an absolute path within one of the server's configured allowed directories and a depth of `1`, then click **Test tool** to verify access.
 
 </details>
 


### PR DESCRIPTION
Adds FLUJO setup instructions to the existing "Install in Other Clients" section, using its Standard IO configuration and built-in tool tester.

Verified in a fresh Debian 12 cloud installation with FLUJO 3.45.2, Desktop Commander 0.2.48, and Node.js 22.23.2:
- Configured and saved Desktop Commander through the FLUJO UI.
- MCP handshake succeeded and discovered 26 tools.
- FLUJO's Tool Tester ran list_directory on a synthetic directory with depth=1 and returned [FILE] hello.txt.
- git diff --check passed.

The instructions explicitly install the package first and separate the executable from its arguments. A cold npx download exceeded FLUJO's 90-second connection-test limit in this environment; the preinstalled-directory route passed. This verifies the connection and one read-only tool; other tools and optional MCP Apps rendering were not tested.

[Screenshots and dated test report](https://github.com/flujo-app/flujo-mcp-client-validation/tree/main/desktop-commander).

Prepared with Codex assistance.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated FLUJO installation instructions to require Node.js 18 or newer.
  - Documented Standard IO configuration, MCP handshake testing, server registration, and verification using the `list_directory` tool with a path inside a configured allowed directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->