### PR TITLE
fix: decode PowerShell 5.1 UTF-16LE read_file output

### DIFF
--- a/src/utils/files/text.ts
+++ b/src/utils/files/text.ts
@@ -50,6 +50,20 @@ export class TextFileHandler implements FileHandler {
         return true;
     }
 
+    private async detectTextEncoding(filePath: string): Promise<'utf8' | 'utf16le'> {
+        const fd = await fs.open(filePath, 'r');
+        try {
+            const bom = Buffer.alloc(2);
+            const { bytesRead } = await fd.read(bom, 0, bom.length, 0);
+            if (bytesRead === 2 && bom[0] === 0xff && bom[1] === 0xfe) {
+                return 'utf16le';
+            }
+            return 'utf8';
+        } finally {
+            await fd.close();
+        }
+    }
+
     async read(filePath: string, options?: ReadOptions): Promise<FileResult> {
         const offset = options?.offset ?? 0;
         const length = options?.length ?? 1000; // Default from config
@@ -85,7 +99,11 @@ export class TextFileHandler implements FileHandler {
         // For text files that aren't too large, count lines
         if (stats.isFile() && stats.size < FILE_SIZE_LIMITS.LINE_COUNT_LIMIT) {
             try {
-                const content = await fs.readFile(path, 'utf8');
+                const encoding = await this.detectTextEncoding(path);
+                let content = await fs.readFile(path, encoding);
+                if (encoding === 'utf16le' && content.charCodeAt(0) === 0xfeff) {
+                    content = content.slice(1);
+                }
                 const lineCount = TextFileHandler.countLines(content);
                 info.metadata!.lineCount = lineCount;
             } catch (error) {
@@ -118,11 +136,18 @@ export class TextFileHandler implements FileHandler {
     /**
      * Get file line count (for files under size limit)
      */
-    private async getFileLineCount(filePath: string, signal?: AbortSignal): Promise<number | undefined> {
+    private async getFileLineCount(
+        filePath: string,
+        signal?: AbortSignal,
+        encoding: 'utf8' | 'utf16le' = 'utf8'
+    ): Promise<number | undefined> {
         try {
             const stats = await fs.stat(filePath);
             if (stats.size < FILE_SIZE_LIMITS.LINE_COUNT_LIMIT) {
-                const content = await fs.readFile(filePath, { encoding: 'utf8', signal });
+                let content = await fs.readFile(filePath, { encoding, signal });
+                if (encoding === 'utf16le' && content.charCodeAt(0) === 0xfeff) {
+                    content = content.slice(1);
+                }
                 return TextFileHandler.countLines(content);
             }
         } catch (error) {
@@ -213,8 +238,23 @@ export class TextFileHandler implements FileHandler {
     ): Promise<FileResult> {
         const stats = await fs.stat(filePath);
         const fileSize = stats.size;
+        const encoding = await this.detectTextEncoding(filePath);
+        const totalLines = await this.getFileLineCount(filePath, signal, encoding);
 
-        const totalLines = await this.getFileLineCount(filePath, signal);
+        // UTF-16LE needs character-aware streaming. Skip the two-byte BOM and keep
+        // the same line pagination/status semantics as ordinary text reads.
+        if (encoding === 'utf16le') {
+            if (offset < 0) {
+                return await this.readFromEndWithReadline(
+                    filePath, Math.abs(offset), mimeType, includeStatusMessage,
+                    totalLines, signal, 'utf16le', 2
+                );
+            }
+            return await this.readFromStartWithReadline(
+                filePath, offset, length, mimeType, includeStatusMessage,
+                totalLines, signal, 'utf16le', 2
+            );
+        }
 
         // For negative offsets (tail behavior), use reverse reading
         if (offset < 0) {
@@ -305,10 +345,12 @@ export class TextFileHandler implements FileHandler {
         mimeType: string,
         includeStatusMessage: boolean = true,
         fileTotalLines?: number,
-        signal?: AbortSignal
+        signal?: AbortSignal,
+        encoding?: BufferEncoding,
+        start?: number
     ): Promise<FileResult> {
         const rl = createInterface({
-            input: createReadStream(filePath, { signal }),
+            input: createReadStream(filePath, { signal, encoding, start }),
             crlfDelay: Infinity
         });
 
@@ -351,10 +393,12 @@ export class TextFileHandler implements FileHandler {
         mimeType: string,
         includeStatusMessage: boolean = true,
         fileTotalLines?: number,
-        signal?: AbortSignal
+        signal?: AbortSignal,
+        encoding?: BufferEncoding,
+        start?: number
     ): Promise<FileResult> {
         const rl = createInterface({
-            input: createReadStream(filePath, { signal }),
+            input: createReadStream(filePath, { signal, encoding, start }),
             crlfDelay: Infinity
         });
 

--- a/test/test-utf16-powershell-read.js
+++ b/test/test-utf16-powershell-read.js
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { readFileFromDisk } from '../dist/tools/filesystem.js';
+
+const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'dc-utf16-'));
+const file = path.join(dir, 'powershell-output.txt');
+
+try {
+    // Match Windows PowerShell 5.1 redirection: FF FE BOM + UTF-16LE text.
+    const lines = Array.from({ length: 1500 }, (_, i) =>
+        i === 0 ? 'alpha' : i === 1 ? 'Rīga' : `line ${i + 1}`
+    );
+    const source = `${lines.join('\r\n')}\r\n`;
+    const bytes = Buffer.concat([Buffer.from([0xff, 0xfe]), Buffer.from(source, 'utf16le')]);
+    await fs.writeFile(file, bytes);
+
+    const first = await readFileFromDisk(file, { offset: 0, length: 3 });
+    assert.equal(first.content.includes('\0'), false, 'read_file must not return embedded NULs');
+    assert.equal(first.content.includes('\ufeff'), false, 'read_file must not return the BOM');
+    assert.match(first.content, /^\[Reading 3 lines from start \(total: 1500 lines, 1497 remaining\)\]/);
+    assert.match(first.content, /alpha\nRīga\nline 3$/);
+
+    const middle = await readFileFromDisk(file, { offset: 500, length: 2 });
+    assert.match(middle.content, /line 501\nline 502$/);
+
+    const tail = await readFileFromDisk(file, { offset: -3 });
+    assert.match(tail.content, /^\[Reading last 3 lines \(total: 1500 lines\)\]/);
+    assert.match(tail.content, /line 1498\nline 1499\nline 1500$/);
+
+    console.log('✓ PowerShell 5.1 UTF-16LE read_file decoding and pagination work');
+} finally {
+    await fs.rm(dir, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary
Fixes `read_file` for UTF-16LE text files produced by Windows PowerShell 5.1 redirection without changing the existing UTF-8/binary/PDF/image read paths.

Fixes #610. Supersedes #621.

## Problem
Windows PowerShell 5.1 writes redirected text with a `FF FE` UTF-16LE BOM. `read_file` currently treats that text as UTF-8, which returns embedded `\u0000` characters and can break downstream persistence (`22P05`).

## Approach
- Detect the UTF-16LE BOM inside `TextFileHandler` with a 2-byte probe.
- For UTF-16LE files, stream with `utf16le` decoding and skip the BOM.
- Preserve existing positive-offset, negative-offset/tail, and `[Reading ...]` status semantics.
- Leave the normal UTF-8 and non-text handler paths unchanged.
- Keep `readFileInternal`/editing behavior out of scope so this fix does not silently transcode edited UTF-16 files to UTF-8.

## Regression test
Adds `test/test-utf16-powershell-read.js`, which writes the exact PowerShell-style bytes (`FF FE` + UTF-16LE) and verifies:
- no embedded NULs or BOM in the result
- non-ASCII text decodes correctly
- line status metadata is preserved
- positive offsets work
- negative offsets return the correct tail lines

The new test fails on current `main` with `read_file must not return embedded NULs` and passes with this change.

## Validation
- `npm test`: 59/59 tests passed on macOS
- Normal UTF-8 128 MB one-line read remains on the existing streaming path (~3 ms inside the read, ~153 MB max RSS in the local benchmark)
- Windows 11 / Windows PowerShell 5.1.26100.9168: actual `@('alpha','Rīga','gamma') *> file.txt` produced `FF FE ...`; this branch returned clean text with 0 NUL characters and the normal read-status header

Commit tested on Windows: `99f0062ba2c4f7cdeb964e3f9920153823912ad3`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for reading UTF-16LE text files, including files generated by Windows PowerShell.
  * Corrected line counts, pagination, and content when reading UTF-16LE files.
  * Prevented byte-order marks and embedded null characters from appearing in displayed text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->