### PR TITLE
Recover and instrument corrupt config files

### DIFF
--- a/src/command-manager.ts
+++ b/src/command-manager.ts
@@ -231,6 +231,7 @@ class CommandManager {
             // Get blocked commands from config
             const config = await configManager.getConfig();
             const blockedCommands = config.blockedCommands || [];
+            if (blockedCommands.includes('*')) return false;
             
             // Extract all commands from the command string
             const allCommands = this.extractCommands(command);

--- a/src/config-manager.ts
+++ b/src/config-manager.ts
@@ -24,6 +24,19 @@ export interface ClientInfo {
   version: string;
 }
 
+type CorruptConfigPhase = 'startup' | 'mutation' | 'watcher';
+
+interface CorruptConfigRecoveryTelemetry {
+  phase: CorruptConfigPhase;
+  parse_error_kind: 'truncated' | 'invalid_json';
+  config_bytes: number | null;
+  config_age_bucket: '<1s' | '<1m' | '<1h' | '>=1h' | 'unknown';
+  temp_file_count: number;
+  persisted_version: string;
+  backup_created: boolean;
+  recovered_by_other_process: boolean;
+}
+
 export function normalizeTelemetryEnabledValue(value: unknown): unknown {
   if (typeof value !== 'string') {
     return value;
@@ -60,6 +73,7 @@ class ConfigManager {
   private pendingMutations: Array<(config: ServerConfig) => void> = [];
   private watcher: FSWatcher | null = null;
   private reloadTimer: NodeJS.Timeout | null = null;
+  private pendingCorruptConfigTelemetry: CorruptConfigRecoveryTelemetry[] = [];
 
   constructor() {
     // Get user's home directory
@@ -75,6 +89,7 @@ class ConfigManager {
   async init() {
     if (this.initialized) return;
 
+    let corruptConfigTelemetry: CorruptConfigRecoveryTelemetry | null = null;
     try {
       const configDir = path.dirname(this.configPath);
       if (!existsSync(configDir)) {
@@ -84,30 +99,42 @@ class ConfigManager {
       try {
         this.config = await this.readConfigFromDisk();
         this._isFirstRun = false;
-
-        if (this.config['welcomeOnboardingEligible'] === undefined) {
-          await this.performConfigMutation((latest) => {
-            if (latest['welcomeOnboardingEligible'] === undefined) {
-              latest['welcomeOnboardingEligible'] = false;
-              latest['pendingWelcomeOnboarding'] = false;
+      } catch (error: any) {
+        if (error instanceof SyntaxError) {
+          const recovery = await this.recoverCorruptConfig(error, 'startup');
+          this.config = recovery.config;
+          corruptConfigTelemetry = recovery.telemetry;
+          this._isFirstRun = false;
+        } else if (error?.code === 'ENOENT') {
+          let created = false;
+          await this.performConfigMutation((latest, existed) => {
+            if (!existed) {
+              Object.assign(latest, this.getDefaultConfig());
+              created = true;
             }
           });
+          this._isFirstRun = created;
+        } else {
+          throw error;
         }
-      } catch (error: any) {
-        if (error?.code !== 'ENOENT') throw error;
-        let created = false;
-        await this.performConfigMutation((latest, existed) => {
-          if (!existed) {
-            Object.assign(latest, this.getDefaultConfig());
-            created = true;
+      }
+
+      // Existing installs must not become welcome-page eligible merely because
+      // their config had to be recovered.
+      if (!this._isFirstRun && this.config['welcomeOnboardingEligible'] === undefined) {
+        await this.performConfigMutation((latest) => {
+          if (latest['welcomeOnboardingEligible'] === undefined) {
+            latest['welcomeOnboardingEligible'] = false;
+            latest['pendingWelcomeOnboarding'] = false;
           }
         });
-        this._isFirstRun = created;
       }
 
       this.config['version'] = VERSION;
       this.initialized = true;
       this.startConfigWatcher();
+      if (corruptConfigTelemetry) this.pendingCorruptConfigTelemetry.push(corruptConfigTelemetry);
+      this.flushCorruptConfigTelemetry();
     } catch (error) {
       console.error('Failed to initialize config:', error);
       this.config = this.getDefaultConfig();
@@ -209,6 +236,159 @@ class ConfigManager {
     throw lastError;
   }
 
+  private classifyConfigParseError(error: SyntaxError, text: string): 'truncated' | 'invalid_json' {
+    const message = error.message.toLowerCase();
+    if (message.includes('unexpected end') || message.includes('unterminated')) return 'truncated';
+
+    // Node's newer JSON parser often reports an "Expected ... at position N"
+    // error for truncation. If the failure position is at the end of the file,
+    // classify it as truncation rather than a malformed token in the middle.
+    const position = /position (\d+)/i.exec(error.message)?.[1];
+    if (position !== undefined && Number(position) >= text.length) return 'truncated';
+    return 'invalid_json';
+  }
+
+  private configAgeBucket(mtimeMs: number | null): CorruptConfigRecoveryTelemetry['config_age_bucket'] {
+    if (mtimeMs === null) return 'unknown';
+    const ageMs = Math.max(0, Date.now() - mtimeMs);
+    if (ageMs < 1_000) return '<1s';
+    if (ageMs < 60_000) return '<1m';
+    if (ageMs < 3_600_000) return '<1h';
+    return '>=1h';
+  }
+
+  private async inspectCorruptConfig(
+    error: SyntaxError,
+    phase: CorruptConfigPhase
+  ): Promise<Omit<CorruptConfigRecoveryTelemetry, 'backup_created' | 'recovered_by_other_process'>> {
+    const [stat, corruptText] = await Promise.all([
+      fs.stat(this.configPath).catch(() => null),
+      fs.readFile(this.configPath, 'utf8').catch(() => ''),
+    ]);
+    const configDir = path.dirname(this.configPath);
+    const configName = path.basename(this.configPath);
+    const entries = await fs.readdir(configDir).catch(() => [] as string[]);
+    const tempFileCount = entries.filter((name) =>
+      name.startsWith(`${configName}.`) && name.endsWith('.tmp')
+    ).length;
+    const persistedVersion = /"version"\s*:\s*"([0-9A-Za-z._+-]{1,32})"/.exec(corruptText)?.[1] ?? 'unknown';
+
+    return {
+      phase,
+      parse_error_kind: this.classifyConfigParseError(error, corruptText),
+      config_bytes: stat?.size ?? null,
+      config_age_bucket: this.configAgeBucket(stat?.mtimeMs ?? null),
+      temp_file_count: tempFileCount,
+      persisted_version: persistedVersion,
+    };
+  }
+
+  private recordCorruptConfigTelemetry(telemetry: CorruptConfigRecoveryTelemetry): void {
+    if (!this.initialized) {
+      this.pendingCorruptConfigTelemetry.push(telemetry);
+      return;
+    }
+    void this.emitCorruptConfigTelemetry(telemetry);
+  }
+
+  private flushCorruptConfigTelemetry(): void {
+    const pending = this.pendingCorruptConfigTelemetry.splice(0);
+    for (const telemetry of pending) void this.emitCorruptConfigTelemetry(telemetry);
+  }
+
+  private async emitCorruptConfigTelemetry(telemetry: CorruptConfigRecoveryTelemetry): Promise<void> {
+    try {
+      const { capture } = await import('./utils/capture.js');
+      await capture('server_config_parse_error_recovered', telemetry);
+    } catch {
+      // Recovery must never depend on telemetry delivery.
+    }
+  }
+
+  private async recoverCorruptConfigUnderLock(
+    error: SyntaxError,
+    phase: CorruptConfigPhase
+  ): Promise<{ config: ServerConfig; telemetry: CorruptConfigRecoveryTelemetry }> {
+    const forensics = await this.inspectCorruptConfig(error, phase);
+
+    // Preserve the two values that matter for privacy and analytics continuity
+    // when they are still intact before the damaged portion of the JSON. Do not
+    // attempt to salvage arbitrary settings from malformed JSON.
+    const corruptText = await fs.readFile(this.configPath, 'utf8').catch(() => '');
+    const clientIdMatch = corruptText.match(/"clientId"\s*:\s*"([0-9a-fA-F-]{36})"/);
+    const preservedClientId = clientIdMatch?.[1];
+    const telemetryWasDisabled = /"telemetryEnabled"\s*:\s*false\b/.test(corruptText);
+
+    let backupCreated = false;
+    if (existsSync(this.configPath)) {
+      const backupPath = `${this.configPath}.corrupt.${Date.now()}.${process.pid}`;
+      try {
+        await fs.rename(this.configPath, backupPath);
+        backupCreated = true;
+      } catch (backupError) {
+        console.error('Failed to preserve corrupt config before recovery:', backupError);
+      }
+    }
+
+    const defaults = this.getDefaultConfig();
+    if (preservedClientId) defaults['clientId'] = preservedClientId;
+    if (telemetryWasDisabled) defaults['telemetryEnabled'] = false;
+    // This is an existing install, not a first run. Do not replay onboarding.
+    defaults['welcomeOnboardingEligible'] = false;
+    defaults['pendingWelcomeOnboarding'] = false;
+    await this.writeConfigAtomically(defaults);
+    this.config = { ...defaults, version: VERSION };
+
+    console.error(`Recovered corrupt config during ${phase}; using defaults${backupCreated ? ' and preserved the corrupt file' : ''}.`);
+    return {
+      config: defaults,
+      telemetry: { ...forensics, backup_created: backupCreated, recovered_by_other_process: false },
+    };
+  }
+
+  private async recoverCorruptConfig(
+    error: SyntaxError,
+    phase: CorruptConfigPhase
+  ): Promise<{ config: ServerConfig; telemetry: CorruptConfigRecoveryTelemetry }> {
+    // Keep a snapshot of what this process originally observed. If another
+    // process repairs the file while we wait for the lock, this is the only
+    // evidence of the corruption this process saw.
+    const observedForensics = await this.inspectCorruptConfig(error, phase);
+    const release = await this.acquireConfigLock();
+    try {
+      try {
+        const latest = await this.readConfigFromDisk();
+        return {
+          config: latest,
+          telemetry: { ...observedForensics, backup_created: false, recovered_by_other_process: true },
+        };
+      } catch (latestError: any) {
+        if (latestError instanceof SyntaxError) {
+          // The file is still corrupt under the lock. Inspect it again so the
+          // forensic fields correspond to the exact snapshot we are replacing.
+          return await this.recoverCorruptConfigUnderLock(latestError, phase);
+        }
+        if (latestError?.code !== 'ENOENT') throw latestError;
+
+        const defaults = this.getDefaultConfig();
+        defaults['welcomeOnboardingEligible'] = false;
+        defaults['pendingWelcomeOnboarding'] = false;
+        await this.writeConfigAtomically(defaults);
+        this.config = { ...defaults, version: VERSION };
+        return {
+          config: defaults,
+          telemetry: { ...observedForensics, backup_created: false, recovered_by_other_process: false },
+        };
+      }
+    } finally {
+      try {
+        await release();
+      } catch (releaseError) {
+        console.error('Failed to release config lock after corruption recovery:', releaseError);
+      }
+    }
+  }
+
   private async writeConfigAtomically(config: ServerConfig): Promise<void> {
     const tempPath = `${this.configPath}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`;
     try {
@@ -232,20 +412,29 @@ class ConfigManager {
     mutate: (config: ServerConfig, existed: boolean) => void
   ): Promise<ServerConfig> {
     const release = await this.acquireConfigLock();
+    let result: ServerConfig | null = null;
+    let corruptConfigTelemetry: CorruptConfigRecoveryTelemetry | null = null;
     try {
       let latest: ServerConfig;
       let existed = true;
       try {
         latest = await this.readConfigFromDisk();
       } catch (error: any) {
-        if (error?.code !== 'ENOENT') throw error;
-        latest = {};
-        existed = false;
+        if (error instanceof SyntaxError) {
+          const recovery = await this.recoverCorruptConfigUnderLock(error, 'mutation');
+          latest = recovery.config;
+          corruptConfigTelemetry = recovery.telemetry;
+        } else if (error?.code === 'ENOENT') {
+          latest = {};
+          existed = false;
+        } else {
+          throw error;
+        }
       }
       mutate(latest, existed);
       await this.writeConfigAtomically(latest);
       this.config = { ...latest, version: VERSION };
-      return latest;
+      result = latest;
     } finally {
       try {
         await release();
@@ -255,6 +444,9 @@ class ConfigManager {
         console.error('Failed to release config lock:', error);
       }
     }
+    if (corruptConfigTelemetry) this.recordCorruptConfigTelemetry(corruptConfigTelemetry);
+    if (!result) throw new Error('Config mutation completed without a result');
+    return result;
   }
 
   private queueMutation(mutate: (config: ServerConfig) => void): void {
@@ -308,7 +500,19 @@ class ConfigManager {
       latest['version'] = VERSION;
       this.config = latest;
     } catch (error: any) {
-      if (error?.code !== 'ENOENT') console.error('Failed to reload config:', error);
+      if (error instanceof SyntaxError) {
+        try {
+          const recovery = await this.recoverCorruptConfig(error, 'watcher');
+          const latest = recovery.config;
+          for (const mutate of this.pendingMutations) mutate(latest);
+          this.config = { ...latest, version: VERSION };
+          this.recordCorruptConfigTelemetry(recovery.telemetry);
+        } catch (recoveryError) {
+          console.error('Failed to recover corrupt config after file change:', recoveryError);
+        }
+      } else if (error?.code !== 'ENOENT') {
+        console.error('Failed to reload config:', error);
+      }
     }
   }
 

--- a/src/config-manager.ts
+++ b/src/config-manager.ts
@@ -58,6 +58,38 @@ export function isTelemetryDisabledValue(value: unknown): boolean {
   return normalizeTelemetryEnabledValue(value) === false;
 }
 
+function extractRecoverableStringArray(text: string, key: string): string[] | null {
+  const marker = new RegExp(`(?:^|[,{])\\s*"${key}"\\s*:\\s*\\[`);
+  const match = marker.exec(text);
+  if (!match) return null;
+
+  const start = match.index + match[0].lastIndexOf('[');
+  let inString = false;
+  let escaped = false;
+  let depth = 0;
+
+  for (let i = start; i < text.length; i++) {
+    const char = text[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (char === '\\') escaped = true;
+      else if (char === '"') inString = false;
+      continue;
+    }
+    if (char === '"') { inString = true; continue; }
+    if (char === '[') depth++;
+    else if (char === ']' && --depth === 0) {
+      try {
+        const value = JSON.parse(text.slice(start, i + 1));
+        return Array.isArray(value) && value.every((item) => typeof item === 'string') ? value : null;
+      } catch {
+        return null;
+      }
+    }
+  }
+  return null;
+}
+
 /**
  * Singleton config manager for the server
  */
@@ -300,7 +332,7 @@ class ConfigManager {
   private async emitCorruptConfigTelemetry(telemetry: CorruptConfigRecoveryTelemetry): Promise<void> {
     try {
       const { capture } = await import('./utils/capture.js');
-      await capture('server_config_parse_error_recovered', telemetry);
+      await capture('config_parse_error_recovered', telemetry);
     } catch {
       // Recovery must never depend on telemetry delivery.
     }
@@ -312,13 +344,23 @@ class ConfigManager {
   ): Promise<{ config: ServerConfig; telemetry: CorruptConfigRecoveryTelemetry }> {
     const forensics = await this.inspectCorruptConfig(error, phase);
 
-    // Preserve the two values that matter for privacy and analytics continuity
-    // when they are still intact before the damaged portion of the JSON. Do not
-    // attempt to salvage arbitrary settings from malformed JSON.
+    // Prefer the last parsed in-memory policy during runtime recovery. On startup,
+    // salvage only complete string-array policy fields from the damaged JSON.
+    // This keeps recovery narrow without introducing a persistent shadow config.
     const corruptText = await fs.readFile(this.configPath, 'utf8').catch(() => '');
     const clientIdMatch = corruptText.match(/"clientId"\s*:\s*"([0-9a-fA-F-]{36})"/);
     const preservedClientId = clientIdMatch?.[1];
     const telemetryWasDisabled = /"telemetryEnabled"\s*:\s*false\b/.test(corruptText);
+    const inMemoryBlockedCommands = Array.isArray(this.config.blockedCommands)
+      && this.config.blockedCommands.every((item) => typeof item === 'string')
+      ? this.config.blockedCommands : null;
+    const inMemoryAllowedDirectories = Array.isArray(this.config.allowedDirectories)
+      && this.config.allowedDirectories.every((item) => typeof item === 'string')
+      ? this.config.allowedDirectories : null;
+    const preservedBlockedCommands = inMemoryBlockedCommands
+      ?? extractRecoverableStringArray(corruptText, 'blockedCommands');
+    const preservedAllowedDirectories = inMemoryAllowedDirectories
+      ?? extractRecoverableStringArray(corruptText, 'allowedDirectories');
 
     let backupCreated = false;
     if (existsSync(this.configPath)) {
@@ -328,12 +370,26 @@ class ConfigManager {
         backupCreated = true;
       } catch (backupError) {
         console.error('Failed to preserve corrupt config before recovery:', backupError);
+        throw backupError;
       }
     }
 
     const defaults = this.getDefaultConfig();
     if (preservedClientId) defaults['clientId'] = preservedClientId;
     if (telemetryWasDisabled) defaults['telemetryEnabled'] = false;
+    if (preservedBlockedCommands !== null) {
+      defaults['blockedCommands'] = [...preservedBlockedCommands];
+    } else {
+      // We cannot know a user's custom blocklist from an incomplete value.
+      // `*` is treated by command validation as deny-all until the user resets it.
+      defaults['blockedCommands'] = ['*'];
+    }
+    if (preservedAllowedDirectories !== null) {
+      defaults['allowedDirectories'] = [...preservedAllowedDirectories];
+    } else {
+      // Never turn an unknown prior allowlist into unrestricted filesystem access.
+      defaults['allowedDirectories'] = [path.dirname(this.configPath)];
+    }
     // This is an existing install, not a first run. Do not replay onboarding.
     defaults['welcomeOnboardingEligible'] = false;
     defaults['pendingWelcomeOnboarding'] = false;
@@ -444,8 +500,8 @@ class ConfigManager {
         // must not make callers replay a mutation that already persisted.
         console.error('Failed to release config lock:', error);
       }
+      if (corruptConfigTelemetry) this.recordCorruptConfigTelemetry(corruptConfigTelemetry);
     }
-    if (corruptConfigTelemetry) this.recordCorruptConfigTelemetry(corruptConfigTelemetry);
     if (!result) throw new Error('Config mutation completed without a result');
     return result;
   }

--- a/src/config-manager.ts
+++ b/src/config-manager.ts
@@ -134,12 +134,13 @@ class ConfigManager {
       this.initialized = true;
       this.startConfigWatcher();
       if (corruptConfigTelemetry) this.pendingCorruptConfigTelemetry.push(corruptConfigTelemetry);
-      this.flushCorruptConfigTelemetry();
     } catch (error) {
       console.error('Failed to initialize config:', error);
       this.config = this.getDefaultConfig();
       this.initialized = true;
       this.startConfigWatcher();
+    } finally {
+      this.flushCorruptConfigTelemetry();
     }
   }
 

--- a/test/test-config-corrupt-concurrency.js
+++ b/test/test-config-corrupt-concurrency.js
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import { fork } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const TEST_FILE = fileURLToPath(import.meta.url);
+const TIMEOUT_MS = 5_000;
+
+async function worker() {
+  const { configManager } = await import('../dist/config-manager.js');
+  const config = await configManager.getConfig();
+  assert.equal(configManager.isFirstRun(), false);
+  assert.deepEqual(config.blockedCommands, ['rm', 'sudo']);
+  assert.deepEqual(config.allowedDirectories, ['/safe/project']);
+  process.send?.({ type: 'done' });
+}
+
+function runWorker(home) {
+  return new Promise((resolve, reject) => {
+    const child = fork(TEST_FILE, [], {
+      env: {
+        ...process.env,
+        HOME: home,
+        USERPROFILE: home,
+        DC_CONFIG_CORRUPT_CONCURRENCY_WORKER: '1',
+        DESKTOP_COMMANDER_DISABLE_TELEMETRY: '1',
+      },
+      stdio: ['ignore', 'inherit', 'inherit', 'ipc'],
+    });
+    const timer = setTimeout(() => {
+      child.kill('SIGTERM');
+      reject(new Error('timeout waiting for concurrent corrupt-config worker'));
+    }, TIMEOUT_MS);
+
+    child.on('message', (message) => {
+      if (message.type !== 'done') return;
+      clearTimeout(timer);
+      const exited = new Promise((done) => child.once('exit', done));
+      child.kill('SIGTERM');
+      exited.then(resolve);
+    });
+    child.on('exit', (code) => {
+      if (code && code !== 0) {
+        clearTimeout(timer);
+        reject(new Error(`worker exited ${code}`));
+      }
+    });
+  });
+}
+
+async function parent() {
+  const home = mkdtempSync(path.join(os.tmpdir(), 'dc-config-corrupt-concurrency-'));
+  const dir = path.join(home, '.claude-server-commander');
+  const configPath = path.join(dir, 'config.json');
+  mkdirSync(dir, { recursive: true });
+  const corrupt = '{"blockedCommands":["rm","sudo"],"allowedDirectories":["/safe/project"],"telemetryEnabled":false,"usageStats":{';
+  writeFileSync(configPath, corrupt);
+
+  await Promise.all([runWorker(home), runWorker(home)]);
+  const base = path.basename(configPath);
+  const backups = readdirSync(dir).filter((name) => name.startsWith(`${base}.corrupt.`));
+  assert.equal(backups.length, 1, 'only one process should preserve the shared corrupt config');
+  assert.equal(readFileSync(path.join(dir, backups[0]), 'utf8'), corrupt);
+
+  const finalConfig = JSON.parse(readFileSync(configPath, 'utf8'));
+  assert.deepEqual(finalConfig.blockedCommands, ['rm', 'sudo']);
+  assert.deepEqual(finalConfig.allowedDirectories, ['/safe/project']);
+  assert.equal(finalConfig.telemetryEnabled, false);
+  console.log('✓ concurrent corrupt-config startup recovers once and both processes start');
+}
+
+if (process.env.DC_CONFIG_CORRUPT_CONCURRENCY_WORKER === '1') {
+  await worker();
+} else {
+  await parent();
+}

--- a/test/test-config-corrupt-fail-closed.js
+++ b/test/test-config-corrupt-fail-closed.js
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import { fork } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const TEST_FILE = fileURLToPath(import.meta.url);
+const TIMEOUT_MS = 5_000;
+
+async function worker() {
+  const { configManager } = await import('../dist/config-manager.js');
+  const { commandManager } = await import('../dist/command-manager.js');
+  const { CONFIG_FILE } = await import('../dist/config.js');
+
+  const config = await configManager.getConfig();
+  assert.deepEqual(config.blockedCommands, ['*']);
+  assert.deepEqual(config.allowedDirectories, [path.dirname(CONFIG_FILE)]);
+  assert.equal(await commandManager.validateCommand('echo hello'), false);
+  process.send?.({ type: 'done' });
+}
+
+async function parent() {
+  const home = mkdtempSync(path.join(os.tmpdir(), 'dc-config-corrupt-fail-closed-'));
+  const dir = path.join(home, '.claude-server-commander');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(path.join(dir, 'config.json'), '{"defaultShell":');
+
+  const child = fork(TEST_FILE, [], {    env: {
+      ...process.env,
+      HOME: home,
+      USERPROFILE: home,
+      DC_CONFIG_CORRUPT_FAIL_CLOSED_WORKER: '1',
+      DESKTOP_COMMANDER_DISABLE_TELEMETRY: '1',
+    },
+    stdio: ['ignore', 'inherit', 'inherit', 'ipc'],
+  });
+
+  await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      child.kill('SIGTERM');
+      reject(new Error('timeout waiting for fail-closed recovery worker'));
+    }, TIMEOUT_MS);
+    child.on('message', (message) => {
+      if (message.type !== 'done') return;
+      clearTimeout(timer);
+      const exited = new Promise((done) => child.once('exit', done));
+      child.kill('SIGTERM');
+      exited.then(resolve);
+    });
+    child.on('exit', (code) => {
+      if (code && code !== 0) {
+        clearTimeout(timer);
+        reject(new Error(`worker exited ${code}`));
+      }
+    });
+  });
+  console.log('✓ early corrupt config recovers with fail-closed security defaults');
+}
+
+if (process.env.DC_CONFIG_CORRUPT_FAIL_CLOSED_WORKER === '1') {
+  await worker();
+} else {
+  await parent();
+}

--- a/test/test-config-corrupt-recovery.js
+++ b/test/test-config-corrupt-recovery.js
@@ -21,6 +21,8 @@ async function worker() {
   assert.equal(config.welcomeOnboardingEligible, false);
   assert.equal(config.pendingWelcomeOnboarding, false);
   assert.equal(config.clientId, '11111111-1111-4111-8111-111111111111');
+  assert.deepEqual(config.blockedCommands, ['rm', 'sudo']);
+  assert.deepEqual(config.allowedDirectories, ['/safe/project']);
   assert.doesNotThrow(() => JSON.parse(readFileSync(CONFIG_FILE, 'utf8')));
   assert.equal(events.length, 1);
   assert.equal(events[0].phase, 'startup');
@@ -44,6 +46,8 @@ async function worker() {
   const finalConfig = JSON.parse(readFileSync(CONFIG_FILE, 'utf8'));
   assert.equal(finalConfig.__afterRecovery, 42);
   assert.equal(finalConfig.telemetryEnabled, false, 'explicit telemetry opt-out survives recoverable malformed JSON');
+  assert.deepEqual(finalConfig.blockedCommands, ['rm', 'sudo'], 'runtime recovery preserves last parsed blocklist');
+  assert.deepEqual(finalConfig.allowedDirectories, ['/safe/project'], 'runtime recovery preserves last parsed allowlist');
   const mutationEvent = events.slice(1).find((event) => event.phase === 'mutation');
   assert.ok(mutationEvent, 'mutation should recover the corrupt config');
   assert.equal(mutationEvent.parse_error_kind, 'invalid_json');
@@ -77,7 +81,7 @@ async function parent() {
   const dir = path.join(home, '.claude-server-commander');
   const configPath = path.join(dir, 'config.json');
   mkdirSync(dir, { recursive: true });
-  writeFileSync(configPath, '{"telemetryEnabled": true, "clientId": "11111111-1111-4111-8111-111111111111", "version": "0.2.48", "usageStats": {');
+  writeFileSync(configPath, '{"blockedCommands":["rm","sudo"],"allowedDirectories":["/safe/project"],"telemetryEnabled": true, "clientId": "11111111-1111-4111-8111-111111111111", "version": "0.2.48", "usageStats": {');
   writeFileSync(`${configPath}.999.123.tmp`, 'leftover temp');
 
   const child = fork(TEST_FILE, [], {

--- a/test/test-config-corrupt-recovery.js
+++ b/test/test-config-corrupt-recovery.js
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict';
+import { fork } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const TEST_FILE = fileURLToPath(import.meta.url);
+const TIMEOUT_MS = 5_000;
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function worker() {
+  const { configManager } = await import('../dist/config-manager.js');
+  const { CONFIG_FILE } = await import('../dist/config.js');
+  const events = [];
+  configManager.emitCorruptConfigTelemetry = async (telemetry) => { events.push(telemetry); };
+
+  const firstCorrupt = readFileSync(CONFIG_FILE, 'utf8');
+  const config = await configManager.getConfig();
+  assert.equal(configManager.isFirstRun(), false, 'corrupt existing config is not a first run');
+  assert.equal(config.welcomeOnboardingEligible, false);
+  assert.equal(config.pendingWelcomeOnboarding, false);
+  assert.equal(config.clientId, '11111111-1111-4111-8111-111111111111');
+  assert.doesNotThrow(() => JSON.parse(readFileSync(CONFIG_FILE, 'utf8')));
+  assert.equal(events.length, 1);
+  assert.equal(events[0].phase, 'startup');
+  assert.equal(events[0].parse_error_kind, 'truncated');
+  assert.equal(events[0].config_bytes, Buffer.byteLength(firstCorrupt));
+  assert.equal(events[0].temp_file_count, 1);
+  assert.equal(events[0].persisted_version, '0.2.48');
+  assert.equal(events[0].backup_created, true);
+  assert.equal(events[0].recovered_by_other_process, false);
+
+  const dir = path.dirname(CONFIG_FILE);
+  const base = path.basename(CONFIG_FILE);
+  const startupBackups = readdirSync(dir).filter((name) => name.startsWith(`${base}.corrupt.`));
+  assert.equal(startupBackups.length, 1);
+  assert.equal(readFileSync(path.join(dir, startupBackups[0]), 'utf8'), firstCorrupt);
+
+  // Corruption that appears after startup must also recover on the next durable mutation.
+  const secondCorrupt = '{"telemetryEnabled": false, BROKEN}';
+  writeFileSync(CONFIG_FILE, secondCorrupt);
+  await configManager.setValue('__afterRecovery', 42);
+  const finalConfig = JSON.parse(readFileSync(CONFIG_FILE, 'utf8'));
+  assert.equal(finalConfig.__afterRecovery, 42);
+  assert.equal(finalConfig.telemetryEnabled, false, 'explicit telemetry opt-out survives recoverable malformed JSON');
+  assert.equal(events.length, 2);
+  assert.equal(events[1].phase, 'mutation');
+  assert.equal(events[1].parse_error_kind, 'invalid_json');
+  assert.equal(events[1].backup_created, true);
+  assert.equal(events[1].recovered_by_other_process, false);
+
+  // A malformed external edit must be recovered by the file watcher even if no
+  // tool/config mutation happens afterward. Let watcher notifications from the
+  // previous mutation settle first; one process can legitimately observe the
+  // same corruption through both paths.
+  await sleep(200);
+  const beforeWatcherCorruption = events.length;
+  writeFileSync(CONFIG_FILE, '{"telemetryEnabled": false, "watcher": {');
+  const watcherDeadline = Date.now() + TIMEOUT_MS;
+  let watcherEvent;
+  while (!watcherEvent && Date.now() < watcherDeadline) {
+    watcherEvent = events.slice(beforeWatcherCorruption).find((event) =>
+      event.phase === 'watcher' && event.parse_error_kind === 'truncated'
+    );
+    if (!watcherEvent) await sleep(25);
+  }
+  assert.ok(watcherEvent, 'watcher should report and recover the externally corrupted config');
+  assert.equal(watcherEvent.backup_created, true);
+  assert.doesNotThrow(() => JSON.parse(readFileSync(CONFIG_FILE, 'utf8')));
+
+  process.send?.({ type: 'done' });
+}
+
+async function parent() {
+  const home = mkdtempSync(path.join(os.tmpdir(), 'dc-config-corrupt-'));
+  const dir = path.join(home, '.claude-server-commander');
+  const configPath = path.join(dir, 'config.json');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(configPath, '{"telemetryEnabled": true, "clientId": "11111111-1111-4111-8111-111111111111", "version": "0.2.48", "usageStats": {');
+  writeFileSync(`${configPath}.999.123.tmp`, 'leftover temp');
+
+  const child = fork(TEST_FILE, [], {
+    env: {
+      ...process.env,
+      HOME: home,
+      USERPROFILE: home,
+      DC_CONFIG_CORRUPT_WORKER: '1',
+      DESKTOP_COMMANDER_DISABLE_TELEMETRY: '1',
+    },
+    stdio: ['ignore', 'inherit', 'inherit', 'ipc'],
+  });
+
+  try {
+    await new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('timeout waiting for corrupt config recovery test')), TIMEOUT_MS);
+      child.on('message', (message) => {
+        if (message.type === 'done') { clearTimeout(timer); resolve(); }
+      });
+      child.on('exit', (code) => {
+        if (code && code !== 0) { clearTimeout(timer); reject(new Error(`worker exited ${code}`)); }
+      });
+    });
+    console.log('✓ corrupt config is backed up, recovered, classified, and observable at startup, mutation, and watcher time');
+  } finally {
+    const exited = child.exitCode !== null || child.signalCode !== null
+      ? Promise.resolve()
+      : new Promise((resolve) => child.once('exit', resolve));
+    child.kill('SIGTERM');
+    await exited;
+    rmSync(home, { recursive: true, force: true });
+  }
+}
+
+if (process.env.DC_CONFIG_CORRUPT_WORKER === '1') await worker(); else await parent();

--- a/test/test-config-corrupt-recovery.js
+++ b/test/test-config-corrupt-recovery.js
@@ -44,11 +44,11 @@ async function worker() {
   const finalConfig = JSON.parse(readFileSync(CONFIG_FILE, 'utf8'));
   assert.equal(finalConfig.__afterRecovery, 42);
   assert.equal(finalConfig.telemetryEnabled, false, 'explicit telemetry opt-out survives recoverable malformed JSON');
-  assert.equal(events.length, 2);
-  assert.equal(events[1].phase, 'mutation');
-  assert.equal(events[1].parse_error_kind, 'invalid_json');
-  assert.equal(events[1].backup_created, true);
-  assert.equal(events[1].recovered_by_other_process, false);
+  const mutationEvent = events.slice(1).find((event) => event.phase === 'mutation');
+  assert.ok(mutationEvent, 'mutation should recover the corrupt config');
+  assert.equal(mutationEvent.parse_error_kind, 'invalid_json');
+  assert.equal(mutationEvent.backup_created, true);
+  assert.equal(mutationEvent.recovered_by_other_process, false);
 
   // A malformed external edit must be recovered by the file watcher even if no
   // tool/config mutation happens afterward. Let watcher notifications from the

--- a/test/test-config-mutation-recovery.js
+++ b/test/test-config-mutation-recovery.js
@@ -54,6 +54,28 @@ async function worker() {
   assert.equal(JSON.parse(readFileSync(CONFIG_FILE, 'utf8')).__postCommitCounter, 1);
   configManager.acquireConfigLock = originalAcquire;
   assert.equal((await configManager.getConfig()).version, VERSION);
+
+  // Recovery telemetry must survive a later mutation write failure.
+  configManager.watcher?.close();
+  configManager.watcher = null;
+  const recoveryEvents = [];
+  configManager.emitCorruptConfigTelemetry = async (telemetry) => { recoveryEvents.push(telemetry); };
+  writeFileSync(CONFIG_FILE, '{"blockedCommands":["sudo"],"allowedDirectories":["/safe"],BROKEN}');
+  const originalWriteConfigAtomically = configManager.writeConfigAtomically.bind(configManager);
+  let recoveryWriteCount = 0;
+  configManager.writeConfigAtomically = async (...args) => {
+    recoveryWriteCount++;
+    if (recoveryWriteCount === 2) throw new Error('synthetic post-recovery mutation write failure');
+    return originalWriteConfigAtomically(...args);
+  };
+  await assert.rejects(
+    configManager.setValue('__postRecoveryFailure', 1),
+    /synthetic post-recovery mutation write failure/
+  );
+  configManager.writeConfigAtomically = originalWriteConfigAtomically;
+  assert.ok(recoveryEvents.some((event) => event.phase === 'mutation'),
+    'mutation recovery telemetry should be recorded even when the later write fails');
+
   process.send?.({ type: 'done' });
 }
 


### PR DESCRIPTION
## Summary

Fixes #692.

- recover from malformed/truncated `config.json` instead of leaving startup/config mutations broken
- preserve the corrupt file as `config.json.corrupt.<timestamp>.<pid>` before writing a replacement; if preservation fails, do not overwrite the original
- preserve an intact `clientId`, explicit `telemetryEnabled: false`, and complete `blockedCommands` / `allowedDirectories` values when recoverable
- during runtime recovery, prefer the last successfully parsed in-memory security policy
- if startup corruption happens before security policy fields can be recovered, fail closed: deny terminal commands and restrict file access to the config directory until the user resets those settings
- treat recovery as an existing install so onboarding is not replayed
- detect corruption during startup, config mutations, and file-watcher reloads
- emit `config_parse_error_recovered` with low-volume forensic metadata so we can measure how often this happens and investigate the creation path

## Telemetry

The recovery event records only structured metadata, not config contents or paths:

- phase: `startup` / `mutation` / `watcher`
- parse error kind: `truncated` / `invalid_json`
- config byte size and age bucket
- leftover atomic temp-file count
- persisted config version when recoverable
- backup-created flag
- whether another process recovered the file first

The event name includes `error`, so it remains visible to the MCP error rollup, but no longer starts with `server_`, avoiding accidental classification as a tool event. Telemetry delivery happens only after recovery and never blocks recovery.

## Concurrency

Recovery uses the existing cross-process lock and re-reads after acquiring it. If another process repaired the file first, the second process keeps the repaired config instead of replacing it.

A regression test starts two processes against the same corrupt config and verifies both start successfully while only one corrupt backup is created.

## Tests

- `test/test-config-corrupt-recovery.js`: startup, mutation, watcher, backup preservation, telemetry classification, opt-out/client-id preservation, and security-policy preservation
- `test/test-config-corrupt-concurrency.js`: two-process recovery against the same corrupt config
- `test/test-config-corrupt-fail-closed.js`: early truncation falls back to deny-all commands and config-directory-only filesystem access
- `test/test-config-mutation-recovery.js`: recovery telemetry is still recorded if the later mutation write fails
- full test suite: **62/62 passed** with isolated HOME


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrupted configuration files are now automatically recovered during startup, updates, and file changes.
  * Valid settings are preserved during recovery, and existing installations no longer unexpectedly trigger first-time onboarding.
  * Recovery now fails closed when secure settings cannot be restored: all commands are blocked and access is limited to the configuration directory.
  * A backup of the corrupted configuration is created for investigation.
  * Recovery telemetry now consistently identifies configuration parse errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->